### PR TITLE
[#69067] Prevent typing in WorkPackageBlocks and set cursor position after insert

### DIFF
--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -76,12 +76,12 @@ const DropdownOption = styled.div<{ selected: boolean }>`
   cursor: pointer;
 `;
 
-const WorkPackage = styled.div<{ in_dropdown?: boolean }>`
+const WorkPackage = styled.div<{ in_dropdown?: string }>`
   ${defaultVariables}
   padding: ${SPACER_M} ${SPACER_L};
   background-color: var(--highlight-wp-background);
   border-radius: var(--bn-border-radius-small);
-  ${({ in_dropdown }) => in_dropdown && `
+  ${({ in_dropdown }) => in_dropdown && JSON.parse(in_dropdown) && `
     padding: ${SPACER_S} 0;
     background-color: transparent; 
   `}
@@ -148,7 +148,7 @@ interface BlockProps {
   };
 }
 
-const WorkPackageElement = ({ workPackage, inDropdown, linkTitle }: {workPackage: WorkPackage, inDropdown?: boolean, linkTitle?: boolean}) => {
+const WorkPackageElement = ({ workPackage, inDropdown, linkTitle }: {workPackage: WorkPackage, inDropdown?: string, linkTitle?: boolean}) => {
   let title = undefined
   if(linkTitle ?? false) {
     title = <a
@@ -165,7 +165,7 @@ const WorkPackageElement = ({ workPackage, inDropdown, linkTitle }: {workPackage
   }
 
   return (
-    <WorkPackage in_dropdown={inDropdown ?? false}>
+    <WorkPackage in_dropdown={inDropdown ?? "false"}>
       <WorkPackageDetails>
         <WorkPackageType color={typeColor(workPackage)}>{workPackage._links?.type?.title}</WorkPackageType>
         <WorkPackageId>#{workPackage.id}</WorkPackageId>
@@ -353,7 +353,7 @@ const OpenProjectWorkPackageBlockComponent = ({
                     }}
                     onMouseEnter={() => setFocusedResultIndex(index)}
                   >
-                    <WorkPackageElement workPackage={wp} inDropdown={true} />
+                    <WorkPackageElement workPackage={wp} inDropdown="true" />
                   </DropdownOption>
                 ))}
               </Dropdown>

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -265,6 +265,7 @@ const OpenProjectWorkPackageBlockComponent = ({
         wpid: workPackage.id,
       },
     });
+    setNewCursorPosition(editor, block);
   };
 
   // Handle keyboard navigation
@@ -445,4 +446,26 @@ function calculateAliases(): string[] {
   }
 
   return combinations;
+}
+
+// The link work package block is not editable, so the cursor should be
+// positioned at the beginning of the next block.
+// Selecting the work package from a dropdown with arrow keys and enter
+// somehow messes the cursor position up, so we need to set it manually.
+function setNewCursorPosition(editor: BlockNoteEditor<any>, block: BlockProps) {
+  editor.focus();
+  editor.setTextCursorPosition(block.id, "end");
+  setCursorToNextBlock(editor, editor.getTextCursorPosition());
+}
+
+type TextCursorPosition = ReturnType<BlockNoteEditor<any>["getTextCursorPosition"]>;
+function setCursorToNextBlock(editor: BlockNoteEditor<any>, cursorPosition: TextCursorPosition) {
+  if (cursorPosition.nextBlock) {
+    editor.setTextCursorPosition(cursorPosition.nextBlock.id, "start");
+    return
+  }
+  // ensure it still works at the end of the document when there is no next block
+  if (cursorPosition.block) {
+    editor.setTextCursorPosition(cursorPosition.block.id, "end");
+  }
 }

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -385,7 +385,7 @@ export const openprojectWorkPackageBlockConfig = createBlockConfig(
     propSchema: {
       wpid: { default: "" },
     },
-    content: "inline",
+    content: "none",
   }) as const
 );
 


### PR DESCRIPTION
https://community.openproject.org/wp/69067

Sorry, this PR somehow cares about different topics. To review this, it's probaby easiest to go commit by commit.

It makes our block non-writable and following that it needed to clean up a messed up cursor position, since the user just wants to go ahead with writing after inserting a link work package block. When debugging during development I noticed an error in the browser console, so I also fixed that one.