### PR TITLE
[#69547] Allow english and translated aliases at the same time

### DIFF
--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -428,8 +428,8 @@ export const openProjectWorkPackageSlashMenu = (editor: any) => ({
 
 function calculateAliases(): string[] {
   const namespaces = ["openproject", "op"]
-  const objectTypes = ["workpackage", "work package", "wp"]
-  const functionNames = ["link"]
+  const objectTypes = [i18n.t("slashMenu.aliases.workpackage"), i18n.t("slashMenu.aliases.work package"), i18n.t("slashMenu.aliases.wp")]
+  const functionNames = [i18n.t("slashMenu.aliases.link")]
 
   const combinations: string[] = [];
 

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -8,6 +8,7 @@ import { useWorkPackageSearch } from "../hooks/useWorkPackageSearch";
 import type { WorkPackage } from "../openProjectTypes";
 import { linkToWorkPackage } from "../services/openProjectApi";
 import { defaultVariables, defaultColorStyles, useColors, typeColor, statusColor, statusBorderColor, statusTextColor, statusBackgroundColor, typeTextColor } from "../services/colors";
+import { getAliases } from "../services/slashMenuAliases";
 import { useTranslation } from "react-i18next"; // localize react components
 import i18n from "../services/i18n.ts"; // localize other code
 
@@ -420,34 +421,11 @@ export const openProjectWorkPackageStaticBlockSpec = createBlockSpec(
 export const openProjectWorkPackageSlashMenu = (editor: any) => ({
   title: i18n.t("slashMenu.title"),
   onItemClick: () => insertOrUpdateBlockForSlashMenu(editor, { type: "openProjectWorkPackage" }),
-  aliases: [...calculateAliases()],
+  aliases: [...getAliases()],
   group: "OpenProject",
   icon: <LinkIcon size={18} />,
   subtext: i18n.t("slashMenu.subtext"),
 })
-
-function calculateAliases(): string[] {
-  const namespaces = ["openproject", "op"]
-  const objectTypes = [i18n.t("slashMenu.aliases.workpackage"), i18n.t("slashMenu.aliases.work package"), i18n.t("slashMenu.aliases.wp")]
-  const functionNames = [i18n.t("slashMenu.aliases.link")]
-
-  const combinations: string[] = [];
-
-  for (const namespace of namespaces) {
-    for (const objectType of objectTypes) {
-      for (const functionName of functionNames) {
-        combinations.push(`${namespace} ${objectType} ${functionName}`);
-        combinations.push(`${namespace} ${functionName} ${objectType}`);
-        combinations.push(`${objectType} ${namespace} ${functionName}`);
-        combinations.push(`${objectType} ${functionName} ${namespace}`);
-        combinations.push(`${functionName} ${namespace} ${objectType}`);
-        combinations.push(`${functionName} ${objectType} ${namespace}`);
-      }
-    }
-  }
-
-  return combinations;
-}
 
 // The link work package block is not editable, so the cursor should be
 // positioned at the beginning of the next block.

--- a/lib/locales/crowdin/de.ts
+++ b/lib/locales/crowdin/de.ts
@@ -6,7 +6,7 @@ export const en = {
       "aliases": {
         "workpackage": "Arbeitspaket",
         "work package": "work package",
-        "wp": "wp",
+        "wp": "ap",
         "link": "link"
       }
     },

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -3,6 +3,12 @@ export const en = {
     "slashMenu": {
       "title": "Link existing work package",
       "subtext": "Add a dynamic link to a single work package",
+      "aliases": {
+        "workpackage": "workpackage",
+        "work package": "work package",
+        "wp": "wp",
+        "link": "link"
+      }
     },
     "search": {
       "label": "Link existing work package",

--- a/lib/services/i18n.ts
+++ b/lib/services/i18n.ts
@@ -27,9 +27,6 @@ if (!i18n.isInitialized) {
       resources,
       lng: "en",
       fallbackLng: "en",
-      interpolation: {
-        escapeValue: false // React already safes from xss
-      }
     });
 }
 

--- a/lib/services/slashMenuAliases.ts
+++ b/lib/services/slashMenuAliases.ts
@@ -1,0 +1,54 @@
+import i18n from "../services/i18n.ts";
+
+let aliases: Array<string> | undefined;
+
+export function getAliases(): string[] {
+  return aliases ?? (aliases = calculateAliases());
+}
+
+i18n.on('languageChanged', () => {
+  aliases = undefined;
+});
+
+function calculateAliases(): string[] {
+  const combinations: string[] = [];
+
+  for (const namespace of namespaces()) {
+    for (const objectType of objectTypes()) {
+      for (const functionName of functionNames()) {
+        combinations.push(`${namespace} ${objectType} ${functionName}`);
+        combinations.push(`${namespace} ${functionName} ${objectType}`);
+        combinations.push(`${objectType} ${namespace} ${functionName}`);
+        combinations.push(`${objectType} ${functionName} ${namespace}`);
+        combinations.push(`${functionName} ${namespace} ${objectType}`);
+        combinations.push(`${functionName} ${objectType} ${namespace}`);
+      }
+    }
+  }
+
+  return combinations;
+}
+
+function namespaces() {
+  return ["openproject", "op"];
+}
+
+function objectTypes() {
+  const types = new Set<string>();
+  types.add("wp");
+  types.add("work package");
+  types.add("workpackage");
+  types.add(i18n.t("slashMenu.aliases.workpackage"));
+  types.add(i18n.t("slashMenu.aliases.work package"));
+  types.add(i18n.t("slashMenu.aliases.wp"));
+
+  return types;
+}
+
+function functionNames() {
+  const names = new Set<string>;
+  names.add("link");
+  names.add(i18n.t("slashMenu.aliases.link"));
+
+  return names;
+}

--- a/test/lib/components/OpenProjectWorkPackageBlock.test.ts
+++ b/test/lib/components/OpenProjectWorkPackageBlock.test.ts
@@ -1,7 +1,19 @@
 import {describe, it, expect} from "vitest";
 import {openProjectWorkPackageSlashMenu} from "../../../lib/components/OpenProjectWorkPackageBlock";
+import {initLanguage} from "../../../lib/services/i18n";
+
 
 describe("openProjectWorkPackageSlashMenu", () => {
+  it("is translated", () => {
+    initLanguage("de")
+    let slashMenu = openProjectWorkPackageSlashMenu({} as any);
+    expect(slashMenu.title).toBe("Vorhandenes Arbeitspaket verlinken");
+
+    initLanguage("en")
+    slashMenu = openProjectWorkPackageSlashMenu({} as any);
+    expect(slashMenu.title).toBe("Link existing work package");
+  });
+
   it("calculates all possible aliases for the slash menu", () => {
     const slashMenu = openProjectWorkPackageSlashMenu({} as any);
     const actual = slashMenu.aliases
@@ -23,5 +35,17 @@ describe("openProjectWorkPackageSlashMenu", () => {
       "link op work package", "link op workpackage", "link op wp"
     ]
     expect(actual.sort()).toEqual(expected.sort());
+  });
+
+  it("also keeps english object types for aliases in other languages", () => {
+    initLanguage("de");
+    const slashMenu = openProjectWorkPackageSlashMenu({} as any);
+    const actual = slashMenu.aliases
+
+    expect(actual).toContain("openproject work package link");
+    expect(actual).toContain("openproject Arbeitspaket link");
+    expect(actual).toContain("openproject wp link");
+    expect(actual).toContain("openproject ap link");
+    initLanguage("en"); // reset for next test
   });
 });


### PR DESCRIPTION
This re-introduces the translated aliases that I already had removed. It also adds having translated aliases AND english aliases at the same time when the language is not english.
Since the list of aliases is getting longer and was live calculated anew each time the slash menu was opened, I now added simple caching for it.