### PR TITLE
Define a shadow dom wrapper component

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ npm run dev
 
 Which will start a vite server with a BlockNote editor instance including the available extensions.
 
+#### Usage within a shadow dom root
+
+This project uses `styled components` to define styles. This means that styles are, by default, injected onto the page header. To be able to use styles onto a shadow dom root it is necessary to use our `ShadowDomWrapper` component targeting the root for the styles.
+
+```tsx
+  <ShadowDomWrapper target={this.targetHtmlElementOrShadowRoot}>
+    <MyBlockNoteView />
+  </ShadowDomWrapper>
+```
+
 ### To run locally with valid API requests to an OpenProject instance
 
 Step 1: Make sure that the OpenProject instance URL is correct in App.tsx

--- a/lib/components/ShadowDomWrapper.tsx
+++ b/lib/components/ShadowDomWrapper.tsx
@@ -1,0 +1,12 @@
+import type { PropsWithChildren } from "react";
+import { StyleSheetManager } from "styled-components";
+
+interface ShadowDomWrapperProps {
+  target: ShadowRoot | HTMLElement;
+}
+
+export const ShadowDomWrapper = ({ children, target }: PropsWithChildren<ShadowDomWrapperProps>) => (
+  <StyleSheetManager target={target}>
+    {children}
+  </StyleSheetManager>
+);

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./OpenProjectWorkPackageBlock";
+export * from "./ShadowDomWrapper";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-blocknote-extensions",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "module": "./dist/op-blocknote-extensions.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/69488/activity

# What are you trying to accomplish?
Allow the usage of op-blocknote-extensions under a shadow dom root. Without the wrapper exposed in this PR the extension is not able to load styles on a shadow root

# What approach did you choose and why?
StyledComponents defines the StyleSheetManager precisely to manipulate how to inject styles - https://styled-components.com/docs/api#stylesheetmanager