### PR TITLE
define a shadow dom wrapper component

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ npm run dev
 
 Which will start a vite server with a BlockNote editor instance including the available extensions.
 
+#### Usage within a shadow dom root
+
+This project uses `styled components` to define styles. This means that styles are, by default, injected onto the page header. To be able to use styles onto a shadow dom root it is necessary to use our `ShadowDomWrapper` component targeting the root for the styles.
+
+```tsx
+  <ShadowDomWrapper target={this.targetHtmlElementOrShadowRoot}>
+    <MyBlockNoteView />
+  </ShadowDomWrapper>
+```
+
 ### To run locally with valid API requests to an OpenProject instance
 
 Step 1: Make sure that the OpenProject instance URL is correct in App.tsx

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Which will start a vite server with a BlockNote editor instance including the av
 
 #### Usage within a shadow dom root
 
-This project uses `styled components` to define styles. This means that styles are, by default, injected onto the page header. To be able to use styles onto a shadow dom root it is necessary to use our `ShadowDomWrapper` component targeting the root for the styles.
+This project uses `styledComponents` to define styles. This means that styles are, by default, injected onto the page header. To be able to use styles onto a shadow dom root it is necessary to use our `ShadowDomWrapper` component targeting the root for the styles.
 
 ```tsx
-  <ShadowDomWrapper target={this.targetHtmlElementOrShadowRoot}>
+  <ShadowDomWrapper target={targetHtmlElementOrShadowRoot}>
     <MyBlockNoteView />
   </ShadowDomWrapper>
 ```

--- a/index.html
+++ b/index.html
@@ -5,9 +5,18 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script type="module" src="/src/op-blocknote.ts"></script>
   </head>
   <body>
+    <div>-- page root --</div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+    <br />
+    <br />
+    <br />
+
+    <div>-- shadow dom --</div>
+    <op-block-note />
   </body>
 </html>

--- a/lib/components/ShadowDomWrapper.tsx
+++ b/lib/components/ShadowDomWrapper.tsx
@@ -1,0 +1,12 @@
+import type { PropsWithChildren } from "react";
+import { StyleSheetManager } from "styled-components";
+
+interface ShadowDomWrapperProps {
+  target: ShadowRoot | HTMLElement;
+}
+
+export const ShadowDomWrapper = ({ children, target }: PropsWithChildren<ShadowDomWrapperProps>) => (
+  <StyleSheetManager target={target}>
+    {children}
+  </StyleSheetManager>
+);

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./OpenProjectWorkPackageBlock";
+export * from "./ShadowDomWrapper";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-blocknote-extensions",
-  "version": "0.0.15",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-blocknote-extensions",
-      "version": "0.0.15",
+      "version": "0.0.17",
       "dependencies": {
         "@blocknote/core": "^0.44.0",
         "@blocknote/mantine": "^0.44.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,15 @@
       "name": "op-blocknote-extensions",
       "version": "0.0.17",
       "dependencies": {
-        "@blocknote/core": "^0.44.0",
-        "@blocknote/mantine": "^0.44.0",
-        "@blocknote/react": "^0.44.0",
+        "@blocknote/core": "^0.44.2",
+        "@blocknote/mantine": "^0.44.2",
+        "@blocknote/react": "^0.44.2",
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",
         "react-i18next": "^16.3.5",
         "styled-components": "^6.1.19"
       },
       "devDependencies": {
-        "@blocknote/mantine": "^0.44.0",
         "@eslint/js": "^9.38.0",
         "@mantine/core": "^8.3.6",
         "@mantine/hooks": "^8.3.5",
@@ -343,9 +342,9 @@
       }
     },
     "node_modules/@blocknote/core": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.44.0.tgz",
-      "integrity": "sha512-k7iG80o2URiW3O0KCvDM8AGr2xgsLOceJpZpDCIq5niG+SmIRfx6N8vgHHBuDNgFSvX+vEriXbTaHzHKr/mAuA==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.44.2.tgz",
+      "integrity": "sha512-PG51Ccue99x4kZtp/inkIkovr8XNviHZaOKAxuSaQowxVrLLrL599e+/GHeFar4OcJ1dcFkVBAgSwx3kYk4lJA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
@@ -399,14 +398,13 @@
       }
     },
     "node_modules/@blocknote/mantine": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.44.0.tgz",
-      "integrity": "sha512-DJSXNEcoNyDWf61zkFcf9FRwq6WShmuMpiJ5gC8BIdkSHbDz48sQnW6wHB/bQLfhWNmtPCnBkCuuRGAvXgF0ZQ==",
-      "dev": true,
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.44.2.tgz",
+      "integrity": "sha512-jH00WtAo+DNJ2YUxo9avHC9SCMq3CKHK/xWIEYpqo+LcMk1NdMfhgx08xypX7zB8GWWXoqyxFmlCEydM878Pzw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.44.0",
-        "@blocknote/react": "0.44.0",
+        "@blocknote/core": "0.44.2",
+        "@blocknote/react": "0.44.2",
         "react-icons": "^5.5.0"
       },
       "peerDependencies": {
@@ -418,12 +416,12 @@
       }
     },
     "node_modules/@blocknote/react": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.44.0.tgz",
-      "integrity": "sha512-4itxoRPqdw4oOccY31Sx6miyFWE+OVSaSWyXEMNqVyZ8USb4Gs/GhshpHfciFsN7SEqqOBUy2EYxF3sHlp9seg==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.44.2.tgz",
+      "integrity": "sha512-HRcgP1T8Mlog2IqlmbBnvPJLvrv+aGKax3y8yPLJs/4qRkP5lMpA+FkpYYHXSLy9OTcGZBC8i0xcwlJ9CUasTQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.44.0",
+        "@blocknote/core": "0.44.2",
         "@emoji-mart/data": "^1.2.1",
         "@floating-ui/react": "^0.27.16",
         "@floating-ui/utils": "0.2.10",
@@ -1257,7 +1255,6 @@
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.6.tgz",
       "integrity": "sha512-paTl+0x+O/QtgMtqVJaG8maD8sfiOdgPmLOyG485FmeGZ1L3KMdEkhxZtmdGlDFsLXhmMGQ57ducT90bvhXX5A==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1278,7 +1275,6 @@
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.6.tgz",
       "integrity": "sha512-liHfaWXHAkLjJy+Bkr29UsCwAoDQ/a64WrM67lksx8F0qqyjR5RQH8zVlhuOjdpQnwtlUkE/YiTvbJiPcoI0bw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -1289,7 +1285,6 @@
       "version": "6.0.22",
       "resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.22.tgz",
       "integrity": "sha512-RSKlNZvxhMCkOFZ6slbYvZYbWjHUM+PxDQnupIOxIdsTZQQjx/BFfrfJ7kQFOP+g7MtpOds8weAetEs5obwMOQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -1720,9 +1715,9 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.12.1.tgz",
-      "integrity": "sha512-dn5uTnsTUjMze26iRhcus8+2auW9+/vOpk6suXg/lhBp+UzOM+EALKE3S5086ANJNgBh1PDHoBX+r1T7wEmheg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-iUelgiTMgPVMpY5ZqASUpk8mC8HuR9FWKaDzK27w9oWip9tuB54Z8mePTxNcQaSPb6ErzEaC8x8egrRt7OsdGQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -1730,7 +1725,7 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.12.1"
+        "@tiptap/pm": "^3.13.0"
       }
     },
     "node_modules/@tiptap/extension-bold": {
@@ -1747,9 +1742,9 @@
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.12.1.tgz",
-      "integrity": "sha512-RMhZbI+CmcEuGrKgMmHFXyGs/UdAQPBjW8wMEiZIqa2ZxnOwhMd79jRRTzLW7uhArzXMOe6hyytOHuEMvoj+NQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.13.0.tgz",
+      "integrity": "sha512-qZ3j2DBsqP9DjG2UlExQ+tHMRhAnWlCKNreKddKocb/nAFrPdBCtvkqIEu+68zPlbLD4ukpoyjUklRJg+NipFg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1760,8 +1755,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.12.1",
-        "@tiptap/pm": "^3.12.1"
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
       }
     },
     "node_modules/@tiptap/extension-code": {
@@ -1778,9 +1773,9 @@
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.12.1.tgz",
-      "integrity": "sha512-FY0QmubovOSnH8PhHH0pnmgXUQernfLMeHq2qT1B/itCDOeDULFrBQtZ5KTMAi522czuErW6s0d2EhJQlnazdw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.13.0.tgz",
+      "integrity": "sha512-OsezV2cMofZM4c13gvgi93IEYBUzZgnu8BXTYZQiQYekz4bX4uulBmLa1KOA9EN71FzS+SoLkXHU0YzlbLjlxA==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -1789,8 +1784,8 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.12.1",
-        "@tiptap/pm": "^3.12.1"
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
@@ -1918,9 +1913,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.12.1.tgz",
-      "integrity": "sha512-YGv8uZrTraXzB3DPQYsyIB90Girx5QZdZOBSDj0R2bWSXc2Huqdb9PaulXqDQjEv/dp9x6w6+Q2VNIagCPUQwA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.13.0.tgz",
+      "integrity": "sha512-WKR4ucALq+lwx0WJZW17CspeTpXorbIOpvKv5mulZica6QxqfMhn8n1IXCkDws/mCoLRx4Drk5d377tIjFNsvQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1949,9 +1944,9 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.12.1.tgz",
-      "integrity": "sha512-P6P5soxg0TqzyO5bDXLVdfO/64k4FVk6NAU9GJrRfg/94MasoId8AM7hqklIDtXEwil5dxfnlrCb3h2N/TKToA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.13.0.tgz",
+      "integrity": "sha512-VqpqNZ9qtPr3pWK4NsZYxXgLSEiAnzl6oS7tEGmkkvJbcGSC+F7R13Xc9twv/zT5QCLxaHdEbmxHbuAIkrMgJQ==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -1963,12 +1958,12 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.12.1",
-        "@tiptap/extension-floating-menu": "^3.12.1"
+        "@tiptap/extension-bubble-menu": "^3.13.0",
+        "@tiptap/extension-floating-menu": "^3.13.0"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.12.1",
-        "@tiptap/pm": "^3.12.1",
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -2918,7 +2913,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3065,7 +3059,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -3550,7 +3543,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5781,7 +5773,6 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
       "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -5802,7 +5793,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
       "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -5828,7 +5818,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
@@ -5851,7 +5840,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
@@ -5874,7 +5862,6 @@
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
       "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -6426,7 +6413,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -6446,7 +6432,6 @@
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -6653,7 +6638,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -6675,7 +6659,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
       "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6690,7 +6673,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
       "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6705,7 +6687,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
       "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.1"
@@ -6723,7 +6704,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-blocknote-extensions",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "module": "./dist/op-blocknote-extensions.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@blocknote/mantine": "^0.44.0",
     "@eslint/js": "^9.38.0",
     "@mantine/core": "^8.3.6",
     "@mantine/hooks": "^8.3.5",
@@ -48,9 +47,9 @@
     "vitest": "^4.0.5"
   },
   "dependencies": {
-    "@blocknote/core": "^0.44.0",
-    "@blocknote/mantine": "^0.44.0",
-    "@blocknote/react": "^0.44.0",
+    "@blocknote/core": "^0.44.2",
+    "@blocknote/mantine": "^0.44.2",
+    "@blocknote/react": "^0.44.2",
     "@primer/octicons-react": "^19.20.0",
     "i18next": "^25.6.3",
     "react-i18next": "^16.3.5",

--- a/src/op-blocknote.ts
+++ b/src/op-blocknote.ts
@@ -3,9 +3,11 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 
 import mantineStyles from '@blocknote/mantine/style.css?url';
+import { ShadowDomWrapper } from '../lib';
 
 class BlockNoteElement extends HTMLElement {
   private mount: HTMLDivElement;
+  private reactRoot: ReturnType<typeof createRoot> | null = null;
 
   constructor() {
     super();
@@ -21,15 +23,26 @@ class BlockNoteElement extends HTMLElement {
   }
 
   connectedCallback() {
-    const root = createRoot(this.mount);
+    this.reactRoot = createRoot(this.mount);
 
-    root.render(this.BlockNoteReactContainer());
+    this.reactRoot.render(
+      React.createElement(
+        ShadowDomWrapper,
+        { target: this.mount },
+        React.createElement(App)
+      )
+    );
   }
 
-  BlockNoteReactContainer() {
-    return React.createElement(App);
+  disconnectedCallback() {
+    if (this.reactRoot) {
+      this.reactRoot.unmount();
+      this.reactRoot = null;
+    }
   }
 }
 
-customElements.define('op-block-note', BlockNoteElement);
+if (!customElements.get('op-block-note')) {
+  customElements.define('op-block-note', BlockNoteElement);
+}
 

--- a/src/op-blocknote.ts
+++ b/src/op-blocknote.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+import mantineStyles from '@blocknote/mantine/style.css?url';
+
+class BlockNoteElement extends HTMLElement {
+  private mount: HTMLDivElement;
+
+  constructor() {
+    super();
+
+    const shadowRoot = this.attachShadow({ mode: 'open' });
+    this.mount = document.createElement('div');
+    shadowRoot.appendChild(this.mount);
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = mantineStyles;
+    shadowRoot.appendChild(link);
+  }
+
+  connectedCallback() {
+    const root = createRoot(this.mount);
+
+    root.render(this.BlockNoteReactContainer());
+  }
+
+  BlockNoteReactContainer() {
+    return React.createElement(App);
+  }
+}
+
+customElements.define('op-block-note', BlockNoteElement);
+


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/69488/activity

Counterpart of https://github.com/opf/openproject/pull/21370

# What are you trying to accomplish?
Allow the usage of op-blocknote-extensions under a shadow dom root. Without the wrapper exposed in this PR the extension is not able to load styles on a shadow root

# What approach did you choose and why?
StyledComponents defines the StyleSheetManager precisely to manipulate how to inject styles - https://styled-components.com/docs/api#stylesheetmanager