### PR TITLE
bug/69478 Change default font-size and font-family of body text in the Blocknote editor

### DIFF
--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -19,11 +19,23 @@ const SPACER_M = "8px";
 const SPACER_L = "12px";
 const SPACER_XL = "16px";
 
+/**
+ * @see
+ *  - https://primer.style/foundations/typography/
+ *  - https://github.com/primer/css/blob/main/src/support/variables/typography.scss
+ *
+*/
+const PRIMER_FONT_STACK = "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'";
+const PRIMER_BODY_FONT_SIZE = "14px";
+const PRIMER_FONT_SIZE_SMALL = "12px";
+
 const Block = styled.div`
     --highlight-wp-background: var(--bn-colors-highlights-gray-background);
     [data-color-scheme="dark"] & {
         --highlight-wp-background: var(--bn-colors-disabled-text);
     }
+    font-size: ${PRIMER_BODY_FONT_SIZE};
+    font-family: ${PRIMER_FONT_STACK};
 `;
 
 const Search = styled.div`
@@ -58,7 +70,6 @@ const SearchInput = styled.input`
   padding-left: 30px !important; // room for the search icon
   border: 1px solid #ccc;
   border-radius: var(--bn-border-radius-small);
-  font-size: 14px;
 `;
 
 const Dropdown = styled.div`
@@ -84,7 +95,7 @@ const WorkPackage = styled.div<{ in_dropdown?: string }>`
   border-radius: var(--bn-border-radius-small);
   ${({ in_dropdown }) => in_dropdown && JSON.parse(in_dropdown) && `
     padding: ${SPACER_S} 0;
-    background-color: transparent; 
+    background-color: transparent;
   `}
 `;
 
@@ -93,6 +104,7 @@ const WorkPackageDetails = styled.div`
   flex-wrap: wrap;
   gap: 0 10px;
   width: 100%;
+  font-size: ${PRIMER_FONT_SIZE_SMALL};
 `;
 
 const WorkPackageType = styled.div<{ color: string }>`
@@ -108,7 +120,6 @@ const WorkPackageId = styled.div`
 
 const WorkPackageStatus = styled.div<{ base_color: string }>`
   ${({ base_color }) => defaultColorStyles(base_color)}
-  font-size: 0.8rem;
   border-radius: 100px;
   border: 1px solid ${() => statusBorderColor()};
   padding: 0 7px;
@@ -121,7 +132,7 @@ const WorkPackageTitle = styled.div`
   flex-basis: max-content;
   color: var(--bn-colors-editor-text);
   font-weight: 500;
-    
+
   a {
     cursor: pointer;
     text-decoration: none;


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/69478

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Change the default body text so that it's closer to Primer defaults
 - `font-size: 14px`
 - `font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji”` For the `WorkPackageDetail`, use 12px as the font-size (primer font-size-small)

See:
 - https://primer.style/foundations/typography/
 - https://github.com/primer/css/blob/main/src/support/variables/typography.scss

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="566" height="444" alt="Screenshot 2025-12-08 at 2 33 48 PM" src="https://github.com/user-attachments/assets/7485bdf2-6a67-4bbe-9c5a-ff34af678f0e" />
