### PR TITLE
fix issue when selecting a search result

### DIFF
--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -245,11 +245,13 @@ const OpenProjectWorkPackageBlockComponent = ({
   // Handle click outside to close dropdown
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      const path = event.composedPath();
+
       if (
         dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node) &&
+        !path.includes(dropdownRef.current) &&
         inputRef.current &&
-        !inputRef.current.contains(event.target as Node)
+        !path.includes(inputRef.current)
       ) {
         setIsDropdownOpen(false);
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-blocknote-extensions",
   "private": true,
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "module": "./dist/op-blocknote-extensions.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69924

# What are you trying to accomplish?
Allow selecting work packages even when using a shadow root

## Screenshots

https://github.com/user-attachments/assets/d69b684b-9449-4dc6-9341-3918177fd363



# What approach did you choose and why?
Rely on `composedPath` for checking if the component is in path.

