### PR TITLE
Jr/bug/69478 document change default font size and font family of body text in the blocknote editor

### DIFF
--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -71,7 +71,6 @@ const SearchInput = styled.input.attrs({
   padding-left: 30px !important; // room for the search icon
   border: 1px solid #ccc;
   border-radius: var(--bn-border-radius-small);
-  font-size: 14px;
 `;
 
 const Dropdown = styled.div.attrs({

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -114,6 +114,7 @@ const WorkPackageDetails = styled.div.attrs({
   flex-wrap: wrap;
   gap: 0 10px;
   width: 100%;
+  font-size: 0.86em;
 `;
 
 const WorkPackageType = styled.div.attrs({
@@ -135,7 +136,7 @@ const WorkPackageStatus = styled.div.attrs({
   className: 'op-bn-work-package--status'
 })<{ base_color: string }>`
   ${({ base_color }) => defaultColorStyles(base_color)}
-  font-size: 0.8rem;
+  font-size: 0.95em;
   border-radius: 100px;
   border: 1px solid ${() => statusBorderColor()};
   padding: 0 7px;

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -21,7 +21,7 @@ const SPACER_L = "12px";
 const SPACER_XL = "16px";
 
 const Block = styled.div.attrs({
-  className: 'op-bn-work-package-block'
+  className: 'op-bn-extensions'
 })`
     --highlight-wp-background: var(--bn-colors-highlights-gray-background);
     [data-color-scheme="dark"] & {
@@ -29,7 +29,9 @@ const Block = styled.div.attrs({
     }
 `;
 
-const Search = styled.div`
+const Search = styled.div.attrs({
+  className: 'op-bn-search'
+})`
   position: relative;
   padding: ${SPACER_M} ${SPACER_XL};
   box-shadow: var(--bn-shadow-medium);
@@ -40,22 +42,30 @@ const Search = styled.div`
   }
 `;
 
-const SearchLabel = styled.label`
+const SearchLabel = styled.label.attrs({
+  className: 'op-bn-search--label'
+})`
   font-weight: normal !important;
 `;
 
-const SearchInputWrapper = styled.div`
+const SearchInputWrapper = styled.div.attrs({
+  className: 'op-bn-search--input-wrapper'
+})`
   position: relative;
   margin-top: ${SPACER_M};
 `;
 
-const SearchIconWrapper = styled.div`
+const SearchIconWrapper = styled.div.attrs({
+  className: 'op-bn-search--icon-wrapper'
+})`
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
   padding-left: ${SPACER_M};
 `;
-const SearchInput = styled.input`
+const SearchInput = styled.input.attrs({
+  className: 'op-bn-search--input'
+})`
   width: 100%;
   padding: ${SPACER_M} ${SPACER_L};
   padding-left: 30px !important; // room for the search icon
@@ -64,14 +74,18 @@ const SearchInput = styled.input`
   font-size: 14px;
 `;
 
-const Dropdown = styled.div`
+const Dropdown = styled.div.attrs({
+  className: 'op-bn-dropdown'
+})`
   background-color: var(--bn-colors-menu-background);
   overflow-y: auto;
   padding-top: ${SPACER_M};
   margin: 0 -${SPACER_M};
 `;
 
-const DropdownOption = styled.div<{ selected: boolean }>`
+const DropdownOption = styled.div.attrs({
+  className: 'op-bn-dropdown--option'
+})<{ selected: boolean }>`
   background-color: ${({ selected }) => selected ? 'var(--highlight-wp-background)' : 'var(--bn-colors-menu-background)'};
   border: none;
   border-radius: var(--bn-border-radius-small);
@@ -80,7 +94,9 @@ const DropdownOption = styled.div<{ selected: boolean }>`
   cursor: pointer;
 `;
 
-const WorkPackage = styled.div<{ in_dropdown?: string }>`
+const WorkPackage = styled.div.attrs({
+  className: 'op-bn-work-package'
+})<{ in_dropdown?: string }>`
   ${defaultVariables}
   padding: ${SPACER_M} ${SPACER_L};
   background-color: var(--highlight-wp-background);
@@ -92,7 +108,7 @@ const WorkPackage = styled.div<{ in_dropdown?: string }>`
 `;
 
 const WorkPackageDetails = styled.div.attrs({
-  className: 'op-bn-work-package-block__details'
+  className: 'op-bn-work-package--details'
 })`
   display: flex;
   flex-wrap: wrap;
@@ -100,18 +116,24 @@ const WorkPackageDetails = styled.div.attrs({
   width: 100%;
 `;
 
-const WorkPackageType = styled.div<{ color: string }>`
+const WorkPackageType = styled.div.attrs({
+  className: 'op-bn-work-package--type'
+})<{ color: string }>`
   ${({ color }) => defaultColorStyles(color)}
   font-weight: 500;
   text-transform: uppercase;
   color: ${() => typeTextColor} !important;
 `;
 
-const WorkPackageId = styled.div`
+const WorkPackageId = styled.div.attrs({
+  className: 'op-bn-work-package--id'
+})`
   color: var(--bn-colors-highlights-gray-text);
 `;
 
-const WorkPackageStatus = styled.div<{ base_color: string }>`
+const WorkPackageStatus = styled.div.attrs({
+  className: 'op-bn-work-package--status'
+})<{ base_color: string }>`
   ${({ base_color }) => defaultColorStyles(base_color)}
   font-size: 0.8rem;
   border-radius: 100px;
@@ -123,7 +145,7 @@ const WorkPackageStatus = styled.div<{ base_color: string }>`
 `;
 
 const WorkPackageTitle = styled.div.attrs({
-  className: 'op-bn-work-package-block__title'
+  className: 'op-bn-work-package--title'
 })`
   flex-basis: max-content;
   color: var(--bn-colors-editor-text);
@@ -140,11 +162,15 @@ const WorkPackageTitle = styled.div.attrs({
   }
 `;
 
-const UnavailableMessage = styled.div`
+const UnavailableMessage = styled.div.attrs({
+  className: 'op-bn-unavailable-message'
+})`
   color: var(--bn-colors-editor-text) !important;
 `
 
-const UnavailableMessageHeader = styled.div`
+const UnavailableMessageHeader = styled.div.attrs({
+  className: 'op-bn-unavailable-message--header'
+})`
   font-weight: 600;
   color: var(--bn-colors-editor-text) !important;
 `

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-blocknote-extensions",
-  "version": "0.0.17",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-blocknote-extensions",
-      "version": "0.0.17",
+      "version": "0.0.20",
       "dependencies": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-blocknote-extensions",
   "private": true,
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "module": "./dist/op-blocknote-extensions.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69478

# What are you trying to accomplish?
Adjust font sizes to improve the looks - but in a relative way, because we don't know the base size which is used in the editor that includes this extension.

## Screenshots
<img width="664" height="464" alt="image" src="https://github.com/user-attachments/assets/7bd9fb4e-f246-4ebb-b003-2da4607c6035" />

---

This is one half of the work package, the other one will be a PR in OpenProject.
This also includes some changes to improve readability when inspecting in the browser - so maybe its easiest to review commit by commit.