### PR TITLE
[#67536] blocknote openproject work packages are sorted by their id instead of the last updated by

### DIFF
--- a/lib/services/openProjectApi.ts
+++ b/lib/services/openProjectApi.ts
@@ -49,7 +49,10 @@ export function fetchTypes(): Promise<TypeCollection> {
 }
 
 export async function searchWorkPackages(query: string): Promise<WorkPackage[]> {
-  const endpoint = `/api/v3/work_packages?filters=[{"typeahead":{"operator":"**","values":["${encodeURIComponent(query)}"]}}]`;
+  const filters = encodeURIComponent(`[{"typeahead":{"operator":"**","values":["${query}"]}}]`);
+  const sortBy = encodeURIComponent(`[["updatedAt","desc"]]`);
+
+  const endpoint = `/api/v3/work_packages?filters=${filters}&sortBy=${sortBy}`;
   const data = await get<OpenProjectResponse>(endpoint);
   return data?._embedded?.elements as unknown as WorkPackage[] ?? [];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-blocknote-extensions",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-blocknote-extensions",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-blocknote-extensions",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "module": "./dist/op-blocknote-extensions.es.js",
   "types": "./dist/index.d.ts",

--- a/test/lib/services/openProjectApi.test.ts
+++ b/test/lib/services/openProjectApi.test.ts
@@ -1,5 +1,5 @@
-import {describe, it, expect} from "vitest";
-import {initOpenProjectApi, linkToWorkPackage} from "../../../lib/services/openProjectApi";
+import {describe, it, expect, vi} from "vitest";
+import {initOpenProjectApi, linkToWorkPackage, searchWorkPackages} from "../../../lib/services/openProjectApi";
 
 describe("openProjectApi", () => {
   it("works with a baseUrl with trailing slash", () => {
@@ -10,5 +10,22 @@ describe("openProjectApi", () => {
   it("works with a baseUrl without trailing slash", () => {
     initOpenProjectApi({baseUrl: "https://example.com"});
     expect(linkToWorkPackage('42')).toBe("https://example.com/wp/42");
+  });
+
+  describe("searchWorkPackages", () => {
+    it("should fetch work packages sorted by updatedAt descending", () => {
+      initOpenProjectApi({baseUrl: "http://localhost:3000"});
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ _embedded: { elements: [] } }),
+      } as Response);
+
+      searchWorkPackages("test query");
+
+      const calledUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("sortBy=%5B%5B%22updatedAt%22%2C%22desc%22%5D%5D");
+
+      fetchSpy.mockRestore();
+    })
   });
 });


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/67536

# What are you trying to accomplish?
Sort results for work packages by udpated at

