### PR TITLE
[#71898] Don't redirect current tab to url when opening WP in new tab

### DIFF
--- a/lib/elements/workPackageElement.tsx
+++ b/lib/elements/workPackageElement.tsx
@@ -13,19 +13,22 @@ import styled from "styled-components";
 import { linkToWorkPackage } from "../services/openProjectApi";
 
 export const WorkPackageElement = ({ workPackage, inDropdown, linkTitle }: {workPackage: WorkPackage, inDropdown?: string, linkTitle?: boolean}) => {
-  let title = undefined
-  if(linkTitle ?? false) {
-    title = <a
-      href={linkToWorkPackage(workPackage.id)}
-      onClick={(event) => {
-        event.stopPropagation();
-        window.open(linkToWorkPackage(workPackage.id), '_blank', 'noopener,noreferrer');
-      }}
-    >
-      {workPackage.subject}
-    </a>
+  let title;
+  if (linkTitle ?? false) {
+    title = (
+      <a
+        href={linkToWorkPackage(workPackage.id)}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          window.open(linkToWorkPackage(workPackage.id), "_blank", "noopener,noreferrer");
+        }}
+      >
+        {workPackage.subject}
+      </a>
+    );
   } else {
-    title = workPackage.subject
+    title = workPackage.subject;
   }
 
   return (


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/71898

Fixed an issue where clicking a WP item redirected the current tab while also opening a new one. Now the link opens only in a new tab.
