### PR TITLE
[#69706] show WP link input only for current user and remove on blur

### DIFF
--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -1,5 +1,8 @@
-import type { DefaultBlockSchema } from "@blocknote/core";
-import { BlockNoteEditor, createBlockConfig, createBlockSpec } from "@blocknote/core";
+import {
+  BlockNoteEditor,
+  createBlockConfig,
+  createBlockSpec,
+} from "@blocknote/core";
 import { insertOrUpdateBlockForSlashMenu } from "@blocknote/core/extensions";
 import { createReactBlockSpec } from "@blocknote/react";
 import React, { useEffect, useRef, useState } from "react";
@@ -7,97 +10,99 @@ import { useWorkPackage } from "../hooks/useWorkPackage";
 import { useWorkPackageSearch } from "../hooks/useWorkPackageSearch";
 import type { WorkPackage } from "../openProjectTypes";
 import { linkToWorkPackage } from "../services/openProjectApi";
-import { useColors} from "../services/colors";
+import { useColors } from "../services/colors";
 import { getAliases } from "../services/slashMenuAliases";
-import { useTranslation } from "react-i18next"; // localize react components
-import i18n from "../services/i18n.ts"; // localize other code
-
+import { useTranslation } from "react-i18next";
+import i18n from "../services/i18n.ts";
 import { LinkIcon, SearchIcon } from "@primer/octicons-react";
 import { WorkPackageElement } from "../elements/workPackageElement";
 import { UnavailableWorkPackageElement } from "../elements/unavailableWorkPackageElement";
 import styled from "styled-components";
 
-const Block = styled.div.attrs({
-  className: 'op-bn-extensions'
-})`
-    --highlight-wp-background: var(--bn-colors-highlights-gray-background);
-    [data-color-scheme="dark"] & {
-        --highlight-wp-background: var(--bn-colors-disabled-text);
-    }
-    --spacer-s: 4px;
-    --spacer-m: 8px;
-    --spacer-l: 12px;
-    --spacer-xl: 16px;
+const Block = styled.div.attrs({ className: "op-bn-extensions" })<{
+  hasWp: boolean;
+}>`
+  --highlight-wp-background: var(--bn-colors-highlights-gray-background);
+  [data-color-scheme="dark"] & {
+    --highlight-wp-background: var(--bn-colors-disabled-text);
+  }
+  --spacer-s: 4px;
+  --spacer-m: 8px;
+  --spacer-l: 12px;
+  --spacer-xl: 16px;
 `;
 
-const Search = styled.div.attrs({
-  className: 'op-bn-search'
-})`
+const Search = styled.div.attrs({ className: "op-bn-search" })`
   position: relative;
   padding: var(--spacer-m) var(--spacer-xl);
   box-shadow: var(--bn-shadow-medium);
   border-radius: var(--bn-border-radius-large);
   width: 100%;
+  background: var(--bn-colors-editor-background);
   @media (min-width: 1120px) {
     width: 500px;
   }
 `;
 
-const SearchLabel = styled.label.attrs({
-  className: 'op-bn-search--label'
-})`
+const SearchLabel = styled.label.attrs({ className: "op-bn-search--label" })`
   font-weight: normal !important;
 `;
 
 const SearchInputWrapper = styled.div.attrs({
-  className: 'op-bn-search--input-wrapper'
+  className: "op-bn-search--input-wrapper",
 })`
   position: relative;
   margin-top: var(--spacer-m);
 `;
 
 const SearchIconWrapper = styled.div.attrs({
-  className: 'op-bn-search--icon-wrapper'
+  className: "op-bn-search--icon-wrapper",
 })`
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
   padding-left: var(--spacer-m);
 `;
-const SearchInput = styled.input.attrs({
-  className: 'op-bn-search--input'
-})`
+
+const SearchInput = styled.input.attrs({ className: "op-bn-search--input" })`
   width: 100%;
   padding: var(--spacer-m) var(--spacer-l);
-  padding-left: 30px !important; // room for the search icon
-  border: 1px solid #ccc;
+  padding-left: 30px !important; // Hardcoded padding for icon
+  border: 1px solid var(--bn-colors-border);
   border-radius: var(--bn-border-radius-small);
+  background: var(--bn-colors-editor-background);
+  color: var(--bn-colors-editor-text);
+
+  &:focus {
+    outline: 2px solid var(--bn-colors-border);
+  }
 `;
 
-const Dropdown = styled.div.attrs({
-  className: 'op-bn-dropdown'
-})`
+const Dropdown = styled.div.attrs({ className: "op-bn-dropdown" })`
   background-color: var(--bn-colors-menu-background);
   overflow-y: auto;
+  max-height: 300px;
   padding-top: var(--spacer-m);
   margin: 0 -(var(--spacer-m));
 `;
 
 const DropdownOption = styled.div.attrs({
-  className: 'op-bn-dropdown--option'
+  className: "op-bn-dropdown--option",
 })<{ selected: boolean }>`
-  background-color: ${({ selected }) => selected ? 'var(--highlight-wp-background)' : 'var(--bn-colors-menu-background)'};
+  background-color: ${({ selected }) =>
+    selected ? "var(--highlight-wp-background)" : "transparent"};
   border: none;
   border-radius: var(--bn-border-radius-small);
-  margin: var(--spacer-s) 0;
-  padding: 0 var(--spacer-m);
+  margin: var(--spacer-s) var(--spacer-m);
+  padding: var(--spacer-s) var(--spacer-m);
   cursor: pointer;
 `;
 
 interface BlockProps {
-  id: string,
+  id: string;
   props: {
-    wpid: number;
+    wpid?: number;
+    initialized?: boolean;
   };
 }
 
@@ -106,115 +111,110 @@ const OpenProjectWorkPackageBlockComponent = ({
   editor,
 }: {
   block: BlockProps;
-  editor: BlockNoteEditor<DefaultBlockSchema & { openProjectWorkPackage: ReturnType<typeof openprojectWorkPackageBlockConfig> }>;
+  editor: BlockNoteEditor<any>;
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Fetch and cache colors.
-  // The hook handles triggering re-renders when data arrives.
-  useColors();
+  useColors(); // hook for syncing colors with editor
 
-  // Search mode state (API + debounce only)
-  const {
-    searchQuery,
-    setSearchQuery,
-    searchResults,
-  } = useWorkPackageSearch();
-
-  const [selectedWorkPackage, setSelectedWorkPackage] = useState<WorkPackage | null>(null);
+  const { searchQuery, setSearchQuery, searchResults } = useWorkPackageSearch();
+  const [selectedWorkPackage, setSelectedWorkPackage] =
+    useState<WorkPackage | null>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [focusedResultIndex, setFocusedResultIndex] = useState(-1);
+  const [isActive, setIsActive] = useState(false);
 
-  // Load saved work package if it exists
   const workPackageResult = useWorkPackage(block.props.wpid);
 
-  // Set selected work package when loaded
   useEffect(() => {
+    // Sync selectedWorkPackage when result updates
     if (!workPackageResult.error && workPackageResult.workPackage) {
       setSelectedWorkPackage(workPackageResult.workPackage);
     }
   }, [workPackageResult.error, workPackageResult.workPackage]);
 
-  // Autofocus search if no work package
   useEffect(() => {
-    if (workPackageResult.error || !workPackageResult.workPackage) {
-      setTimeout(() => inputRef?.current?.focus(), 50);
-    }
-  }, [workPackageResult.error, workPackageResult.workPackage]);
+    // Direct access to _tiptapEditor
+    const tiptap = (editor as any)._tiptapEditor;
+    if (!tiptap) return;
 
-  // Handle click outside to close dropdown
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const path = event.composedPath();
-
-      if (
-        dropdownRef.current &&
-        !path.includes(dropdownRef.current) &&
-        inputRef.current &&
-        !path.includes(inputRef.current)
-      ) {
-        setIsDropdownOpen(false);
-      }
+    const updateActiveState = () => {
+      const pos = editor.getTextCursorPosition();
+      setIsActive(pos?.block?.id === block.id);
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
+    tiptap.on("selectionUpdate", updateActiveState);
+    updateActiveState();
+
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      tiptap.off("selectionUpdate", updateActiveState);
     };
-  }, []);
+  }, [editor, block.id]);
+
+  useEffect(() => {
+    // Using requestAnimationFrame for focus, could be race condition
+    if (
+      !block.props.wpid &&
+      !block.props.initialized &&
+      isActive &&
+      inputRef.current
+    ) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [block.props.wpid, block.props.initialized, isActive]);
 
   const handleSelectWorkPackage = (workPackage: WorkPackage) => {
     setSelectedWorkPackage(workPackage);
     setSearchQuery("");
     setIsDropdownOpen(false);
-
-    // Update block props to persist the selection
+    setFocusedResultIndex(-1);
     editor.updateBlock(block, {
       props: {
         ...block.props,
         wpid: workPackage.id,
+        initialized: true,
       },
     });
-    setNewCursorPosition(editor, block);
+    editor.focus(); // Focus editor after selection
   };
 
-  // Handle keyboard navigation
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!isDropdownOpen) {
-      return;
-    }
-
-    switch (e.key) {
-      case "ArrowDown":
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!isDropdownOpen) setIsDropdownOpen(true);
+      setFocusedResultIndex((prev) =>
+        prev < searchResults.length - 1 ? prev + 1 : prev,
+      ); // tightly coupled to searchResults length
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedResultIndex((prev) => (prev > 0 ? prev - 1 : 0));
+    } else if (e.key === "Enter") {
+      if (focusedResultIndex >= 0 && searchResults[focusedResultIndex]) {
         e.preventDefault();
-        setFocusedResultIndex((prev) => (prev < searchResults.length - 1 ? prev + 1 : prev));
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        setFocusedResultIndex((prev) => (prev > 0 ? prev - 1 : 0));
-        break;
-      case "Enter":
-        e.preventDefault();
-        if (focusedResultIndex >= 0 && focusedResultIndex < searchResults.length) {
-          handleSelectWorkPackage(searchResults[focusedResultIndex]);
-        }
-        break;
-      case "Escape":
-        e.preventDefault();
-        setIsDropdownOpen(false);
-        break;
-      default:
-        break;
+        handleSelectWorkPackage(searchResults[focusedResultIndex]);
+      }
+    } else if (e.key === "Escape") {
+      editor.updateBlock(block, {
+        props: { ...block.props, initialized: true },
+      });
+      editor.focus();
     }
   };
+
+  const disableFocus = block.props.initialized && !block.props.wpid;
 
   return (
-    <Block>
-      <div>
-        {/* Show search dialog if no work package is selected yet */}
-        {!block.props.wpid && (
+    <Block
+      hasWp={!!block.props.wpid}
+      tabIndex={disableFocus ? -1 : 0} // tabIndex toggle could affect accessibility
+      style={disableFocus ? { pointerEvents: "none" } : undefined}
+    >
+      <div contentEditable={false}>
+        {!block.props.wpid && !block.props.initialized && isActive && (
           <Search>
             <SearchLabel>
               {t("search.label")}
@@ -224,45 +224,42 @@ const OpenProjectWorkPackageBlockComponent = ({
                 </SearchIconWrapper>
                 <SearchInput
                   ref={inputRef}
-                  type="custom"
+                  type="text"
                   placeholder={t("search.placeholder")}
                   value={searchQuery}
                   onChange={(e) => {
                     setSearchQuery(e.target.value);
-                    if (e.target.value) {
-                      setIsDropdownOpen(true);
-                    }
-                  }}
-                  onFocus={() => {
-                    if (searchResults.length > 0) {
-                      setIsDropdownOpen(true);
-                    }
+                    setIsDropdownOpen(e.target.value.length > 0);
                   }}
                   onKeyDown={handleKeyDown}
+                  onBlur={() => {
+                    // setTimeout used to defer blur, could cause subtle bugs
+                    setTimeout(() => {
+                      setIsDropdownOpen(false);
+                      setFocusedResultIndex(-1);
+                      setIsActive(false);
+                      if (!block.props.wpid) {
+                        editor.removeBlocks([block.id]);
+                      } else {
+                        editor.updateBlock(block, {
+                          props: { ...block.props, initialized: true },
+                        });
+                      }
+                    }, 100);
+                  }}
                 />
               </SearchInputWrapper>
             </SearchLabel>
 
-            {/* Autocomplete dropdown */}
             {isDropdownOpen && searchResults.length > 0 && (
-              <Dropdown
-                ref={dropdownRef}
-                role="listbox"
-                aria-label={t("search.dropdownAriaLabel")}
-              >
+              <Dropdown ref={dropdownRef}>
                 {searchResults.slice(0, 5).map((wp, index) => (
                   <DropdownOption
                     key={wp.id}
-                    role="option"
-                    aria-selected={focusedResultIndex === index}
-                    tabIndex={0}
                     selected={focusedResultIndex === index}
-                    onClick={() => handleSelectWorkPackage(wp)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        handleSelectWorkPackage(wp);
-                      }
+                    onMouseDown={(e) => {
+                      e.preventDefault(); // prevent input blur
+                      handleSelectWorkPackage(wp);
                     }}
                     onMouseEnter={() => setFocusedResultIndex(index)}
                   >
@@ -274,37 +271,45 @@ const OpenProjectWorkPackageBlockComponent = ({
           </Search>
         )}
 
-        {/* Show work package data (if available) */}
-        {block.props.wpid && !selectedWorkPackage && workPackageResult.loading && (
-          <UnavailableWorkPackageElement header={t("unavailableWorkPackage.loading.header")} message={t("unavailableWorkPackage.loading.message")} />
-        )}
-        {block.props.wpid && !selectedWorkPackage && workPackageResult.unauthorized &&  (
-          <UnavailableWorkPackageElement header={t("unavailableWorkPackage.unauthorized.header")} message={t("unavailableWorkPackage.unauthorized.message")} />
-        )}
-        {block.props.wpid && !selectedWorkPackage && workPackageResult.error && (
-          <UnavailableWorkPackageElement header={t("unavailableWorkPackage.error.header")} message={t("unavailableWorkPackage.error.message")} />
-        )}
-        {selectedWorkPackage && (
-          <WorkPackageElement workPackage={selectedWorkPackage} linkTitle={true} />
+        {block.props.wpid && (
+          <>
+            {!selectedWorkPackage && workPackageResult.loading && (
+              <UnavailableWorkPackageElement
+                header={t("unavailableWorkPackage.loading.header")}
+                message={t("unavailableWorkPackage.loading.message")}
+              />
+            )}
+            {selectedWorkPackage && (
+              <WorkPackageElement workPackage={selectedWorkPackage} linkTitle />
+            )}
+          </>
         )}
       </div>
     </Block>
   );
 };
 
-export const openprojectWorkPackageBlockConfig = createBlockConfig(
-  () => ({
-    type: "openProjectWorkPackage",
-    propSchema: {
-      wpid: { default: undefined, type: "number" },
-    },
-    content: "none",
-  }) as const
-);
+// Config with proper propSchema
+export const openprojectWorkPackageBlockConfig = createBlockConfig((() => ({
+  type: "openProjectWorkPackage",
+  propSchema: {
+    wpid: { default: undefined, type: "number" },
+    initialized: { default: false, type: "boolean" },
+  },
+  content: "none",
+  isSelectable: false,
+})) as unknown as ReturnType<typeof createBlockConfig>);
 
 export const openProjectWorkPackageBlockSpec = createReactBlockSpec(
   openprojectWorkPackageBlockConfig,
-  { render: (props) => <OpenProjectWorkPackageBlockComponent block={props.block} editor={props.editor as any} /> }
+  {
+    render: (props) => (
+      <OpenProjectWorkPackageBlockComponent
+        block={props.block}
+        editor={props.editor as any}
+      />
+    ),
+  },
 );
 
 export const openProjectWorkPackageStaticBlockSpec = createBlockSpec(
@@ -312,49 +317,30 @@ export const openProjectWorkPackageStaticBlockSpec = createBlockSpec(
   {
     render: (block) => {
       const wpid = block.props.wpid;
-      const href = linkToWorkPackage(wpid);
-
       const anchor = document.createElement("a");
-      anchor.href = href;
-      anchor.target = "_blank";
-      anchor.rel = "noopener noreferrer";
+      anchor.href = linkToWorkPackage(wpid);
       anchor.textContent = `#${wpid}`;
-
-      return {
-        dom: anchor,
-        contentDOM: anchor,
-      };
-    }
-  }
+      return { dom: anchor, contentDOM: anchor };
+    },
+  },
 );
 
 export const openProjectWorkPackageSlashMenu = (editor: any) => ({
   title: i18n.t("slashMenu.title"),
-  onItemClick: () => insertOrUpdateBlockForSlashMenu(editor, { type: "openProjectWorkPackage" }),
+  onItemClick: () => {
+    const insertedBlock = insertOrUpdateBlockForSlashMenu(editor, {
+      type: "openProjectWorkPackage",
+    });
+    requestAnimationFrame(() => {
+      // ensure cursor is placed in newly inserted block
+      if (insertedBlock?.id) {
+        editor.setTextCursorPosition(insertedBlock.id, "start");
+        editor.focus();
+      }
+    });
+  },
   aliases: [...getAliases()],
   group: "OpenProject",
   icon: <LinkIcon size={18} />,
   subtext: i18n.t("slashMenu.subtext"),
-})
-
-// The link work package block is not editable, so the cursor should be
-// positioned at the beginning of the next block.
-// Selecting the work package from a dropdown with arrow keys and enter
-// somehow messes the cursor position up, so we need to set it manually.
-function setNewCursorPosition(editor: BlockNoteEditor<any>, block: BlockProps) {
-  editor.focus();
-  editor.setTextCursorPosition(block.id, "end");
-  setCursorToNextBlock(editor, editor.getTextCursorPosition());
-}
-
-type TextCursorPosition = ReturnType<BlockNoteEditor<any>["getTextCursorPosition"]>;
-function setCursorToNextBlock(editor: BlockNoteEditor<any>, cursorPosition: TextCursorPosition) {
-  if (cursorPosition.nextBlock) {
-    editor.setTextCursorPosition(cursorPosition.nextBlock.id, "start");
-    return
-  }
-  // ensure it still works at the end of the document when there is no next block
-  if (cursorPosition.block) {
-    editor.setTextCursorPosition(cursorPosition.block.id, "end");
-  }
-}
+});

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -1,3 +1,4 @@
+import type { DefaultBlockSchema } from "@blocknote/core";
 import {
   BlockNoteEditor,
   createBlockConfig,
@@ -90,8 +91,8 @@ const DropdownOption = styled.div.attrs({
       : "var(--bn-colors-menu-background)"};
   border: none;
   border-radius: var(--bn-border-radius-small);
-  margin: var(--spacer-s) var(--spacer-m);
-  padding: var(--spacer-s) var(--spacer-m);
+  margin: var(--spacer-s) 0;
+  padding: 0 var(--spacer-m);
   cursor: pointer;
 `;
 
@@ -103,12 +104,42 @@ interface BlockProps {
   };
 }
 
+//function to handle a click on a slash menu item
+function handleOpenProjectWorkPackageClick(editor: BlockNoteEditor<any>) {
+  const insertedBlock = insertOrUpdateBlockForSlashMenu(editor, {
+    type: "openProjectWorkPackage",
+  });
+
+  requestAnimationFrame(() => {
+    if (!insertedBlock?.id) return;
+
+    editor.setTextCursorPosition(insertedBlock.id, "start");
+    editor.focus();
+
+    const [newTextBlock] = editor.insertBlocks(
+      [{ type: "text", content: "" }],
+      insertedBlock.id
+    );
+
+    if (newTextBlock?.id) {
+      requestAnimationFrame(() => {
+        editor.setTextCursorPosition(newTextBlock.id, "start");
+        editor.focus();
+      });
+    }
+  });
+}
+
 const OpenProjectWorkPackageBlockComponent = ({
   block,
   editor,
 }: {
   block: BlockProps;
-  editor: BlockNoteEditor<any>;
+  editor: BlockNoteEditor<
+    DefaultBlockSchema & {
+      openProjectWorkPackage: ReturnType<typeof openprojectWorkPackageBlockConfig>;
+    }
+  >;
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -383,43 +414,14 @@ export const openProjectWorkPackageStaticBlockSpec = createBlockSpec(
   }
 );
 
-export const openProjectWorkPackageSlashMenu =
-  (editor: BlockNoteEditor<any>) => ({
-    title: i18n.t("slashMenu.title"),
-    onItemClick: () => {
-      const insertedBlock = insertOrUpdateBlockForSlashMenu(editor, {
-        type: "openProjectWorkPackage",
-      });
-
-      requestAnimationFrame(() => {
-        if (!insertedBlock?.id) return;
-
-        editor.setTextCursorPosition(insertedBlock.id, "start");
-        editor.focus();
-
-        const [newTextBlock] = editor.insertBlocks(
-          [
-            {
-              type: "text",
-              content: "",
-            },
-          ],
-          insertedBlock.id
-        );
-
-        if (newTextBlock?.id) {
-          requestAnimationFrame(() => {
-            editor.setTextCursorPosition(newTextBlock.id, "start");
-            editor.focus(); // logic for automatically moving to a new text block
-          });
-        }
-      });
-    },
-    aliases: [...getAliases()],
-    group: "OpenProject",
-    icon: <LinkIcon size={18} />,
-    subtext: i18n.t("slashMenu.subtext"),
-  });
+export const openProjectWorkPackageSlashMenu = (editor: BlockNoteEditor<any>) => ({
+  title: i18n.t("slashMenu.title"),
+  onItemClick: () => handleOpenProjectWorkPackageClick(editor),
+  aliases: [...getAliases()],
+  group: "OpenProject",
+  icon: <LinkIcon size={18} />,
+  subtext: i18n.t("slashMenu.subtext"),
+});
 
 function moveCursorToNextBlock(
   editor: BlockNoteEditor<any>,

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -116,7 +116,7 @@ const OpenProjectWorkPackageBlockComponent = ({
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-
+  const isSelectingRef = useRef(false);
   useColors(); // hook for syncing colors with editor
 
   const { searchQuery, setSearchQuery, searchResults } = useWorkPackageSearch();
@@ -168,10 +168,13 @@ const OpenProjectWorkPackageBlockComponent = ({
   }, [block.props.wpid, block.props.initialized, isActive]);
 
   const handleSelectWorkPackage = (workPackage: WorkPackage) => {
+    isSelectingRef.current = true;
+
     setSelectedWorkPackage(workPackage);
     setSearchQuery("");
     setIsDropdownOpen(false);
     setFocusedResultIndex(-1);
+
     editor.updateBlock(block, {
       props: {
         ...block.props,
@@ -179,6 +182,7 @@ const OpenProjectWorkPackageBlockComponent = ({
         initialized: true,
       },
     });
+
     editor.focus(); // Focus editor after selection
   };
 
@@ -233,17 +237,20 @@ const OpenProjectWorkPackageBlockComponent = ({
                   }}
                   onKeyDown={handleKeyDown}
                   onBlur={() => {
-                    // setTimeout used to defer blur, could cause subtle bugs
                     setTimeout(() => {
                       setIsDropdownOpen(false);
                       setFocusedResultIndex(-1);
                       setIsActive(false);
+
+                      // If we just selected an item do nothing
+                      if (isSelectingRef.current) {
+                        isSelectingRef.current = false;
+                        return;
+                      }
+
+                      // Remove only if truly empty
                       if (!block.props.wpid) {
                         editor.removeBlocks([block.id]);
-                      } else {
-                        editor.updateBlock(block, {
-                          props: { ...block.props, initialized: true },
-                        });
                       }
                     }, 100);
                   }}

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -20,6 +20,7 @@ import { UnavailableWorkPackageElement } from "../elements/unavailableWorkPackag
 import styled from "styled-components";
 
 const Block = styled.div.attrs({ className: "op-bn-extensions" })<{
+  // Added hasWp prop to be able to style the block if WP is present
   hasWp: boolean;
 }>`
   --highlight-wp-background: var(--bn-colors-highlights-gray-background);
@@ -67,23 +68,26 @@ const SearchInput = styled.input.attrs({ className: "op-bn-search--input" })`
   width: 100%;
   padding: var(--spacer-m) var(--spacer-l);
   padding-left: 30px !important; // Hardcoded padding for icon
-  border: 1px solid var(--bn-colors-border);
+  border: 1px solid #ccc;
   border-radius: var(--bn-border-radius-small);
 `;
 
-const Dropdown = styled.div.attrs({ className: "op-bn-dropdown" })`
+const Dropdown = styled.div.attrs({
+  className: "op-bn-dropdown"
+})`
   background-color: var(--bn-colors-menu-background);
   overflow-y: auto;
-  max-height: 300px;
   padding-top: var(--spacer-m);
   margin: 0 -(var(--spacer-m));
 `;
 
 const DropdownOption = styled.div.attrs({
-  className: "op-bn-dropdown--option",
+  className: "op-bn-dropdown--option"
 })<{ selected: boolean }>`
   background-color: ${({ selected }) =>
-    selected ? "var(--highlight-wp-background)" : "transparent"};
+    selected
+      ? "var(--highlight-wp-background)"
+      : "var(--bn-colors-menu-background)"};
   border: none;
   border-radius: var(--bn-border-radius-small);
   margin: var(--spacer-s) var(--spacer-m);
@@ -95,7 +99,7 @@ interface BlockProps {
   id: string;
   props: {
     wpid?: number;
-    initialized?: boolean;
+    initialized?: boolean; // to know if the block is already initialized
   };
 }
 
@@ -109,34 +113,26 @@ const OpenProjectWorkPackageBlockComponent = ({
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const isSelectingRef = useRef(false);
-  useColors(); // hook for syncing colors with editor
+  const isSelectingRef = useRef(false); // to follow the WP selection from the dropdown
 
-  const { searchQuery, setSearchQuery, searchResults } = useWorkPackageSearch();
-  const [selectedWorkPackage, setSelectedWorkPackage] =
-    useState<WorkPackage | null>(null);
+  // Fetch and cache colors.
+  // The hook handles triggering re-renders when data arrives.
+  useColors();
+
+  const { searchQuery, setSearchQuery, searchResults } =
+    useWorkPackageSearch();
+
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [focusedResultIndex, setFocusedResultIndex] = useState(-1);
   const [isActive, setIsActive] = useState(false);
 
-  const workPackageResult = useWorkPackage(block.props.wpid);
+  // use a single source of truth — result from useWorkPackage.
+  const workPackageResult = useWorkPackage(block.props.wpid); 
+
+  const selectedWorkPackage = workPackageResult.workPackage;
 
   useEffect(() => {
-    // Sync selectedWorkPackage when result updates
-    if (workPackageResult.workPackage) {
-      setSelectedWorkPackage(workPackageResult.workPackage);
-      return;
-    }
-
-    setSelectedWorkPackage(null);
-  }, [
-    workPackageResult.workPackage,
-    workPackageResult.unauthorized,
-    workPackageResult.error,
-  ]);
-
-  useEffect(() => {
-    // Direct access to _tiptapEditor
+    // accessing private tiptap instance until public API is available
     const tiptap = (editor as any)._tiptapEditor;
     if (!tiptap) return;
 
@@ -154,13 +150,16 @@ const OpenProjectWorkPackageBlockComponent = ({
   }, [editor, block.id]);
 
   useEffect(() => {
-    // Using requestAnimationFrame for focus, could be race condition
+    // Autofocus only when the block is active and not yet initialized
     if (
       !block.props.wpid &&
       !block.props.initialized &&
       isActive &&
       inputRef.current
     ) {
+      // use requestAnimationFrame to wait for React 
+      // to commit and update the internal state
+      // of the BlockNote before focusing.
       requestAnimationFrame(() => {
         inputRef.current?.focus();
       });
@@ -168,9 +167,8 @@ const OpenProjectWorkPackageBlockComponent = ({
   }, [block.props.wpid, block.props.initialized, isActive]);
 
   const handleSelectWorkPackage = (workPackage: WorkPackage) => {
-    isSelectingRef.current = true;
+    isSelectingRef.current = true; // checkbox so that onBlur does not remove the block
 
-    setSelectedWorkPackage(workPackage);
     setSearchQuery("");
     setIsDropdownOpen(false);
     setFocusedResultIndex(-1);
@@ -183,7 +181,10 @@ const OpenProjectWorkPackageBlockComponent = ({
       },
     });
 
-    editor.focus(); // Focus editor after selection
+    requestAnimationFrame(() => {
+      // move the cursor to the next block after selecting WP
+      moveCursorToNextBlock(editor, block.id);
+    });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -191,7 +192,7 @@ const OpenProjectWorkPackageBlockComponent = ({
       e.preventDefault();
       if (!isDropdownOpen) setIsDropdownOpen(true);
       setFocusedResultIndex((prev) =>
-        prev < searchResults.length - 1 ? prev + 1 : prev,
+        prev < searchResults.length - 1 ? prev + 1 : prev
       ); // tightly coupled to searchResults length
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
@@ -203,7 +204,7 @@ const OpenProjectWorkPackageBlockComponent = ({
       }
     } else if (e.key === "Escape") {
       editor.updateBlock(block, {
-        props: { ...block.props, initialized: true },
+        props: { ...block.props, initialized: true }, // close the dropdown, fix initialized
       });
       editor.focus();
     }
@@ -241,13 +242,11 @@ const OpenProjectWorkPackageBlockComponent = ({
                       setIsDropdownOpen(false);
                       setFocusedResultIndex(-1);
                       setIsActive(false);
-
                       // If we just selected an item do nothing
                       if (isSelectingRef.current) {
                         isSelectingRef.current = false;
                         return;
                       }
-
                       // Remove only if truly empty
                       if (!block.props.wpid) {
                         editor.removeBlocks([block.id]);
@@ -259,10 +258,17 @@ const OpenProjectWorkPackageBlockComponent = ({
             </SearchLabel>
 
             {isDropdownOpen && searchResults.length > 0 && (
-              <Dropdown ref={dropdownRef}>
+              <Dropdown
+                ref={dropdownRef}
+                role="listbox"
+                aria-label={t("search.dropdownAriaLabel")}
+              >
                 {searchResults.slice(0, 5).map((wp, index) => (
                   <DropdownOption
                     key={wp.id}
+                    role="option"
+                    aria-selected={focusedResultIndex === index}
+                    tabIndex={0}
                     selected={focusedResultIndex === index}
                     onMouseDown={(e) => {
                       e.preventDefault(); // prevent input blur
@@ -280,21 +286,42 @@ const OpenProjectWorkPackageBlockComponent = ({
 
         {block.props.wpid && (
           <>
-            {!selectedWorkPackage && workPackageResult.loading && (
+            {workPackageResult.loading && (
               <UnavailableWorkPackageElement
                 header={t("unavailableWorkPackage.loading.header")}
                 message={t("unavailableWorkPackage.loading.message")}
               />
             )}
-            {!selectedWorkPackage && !workPackageResult.loading && (
+
+            {!workPackageResult.loading && workPackageResult.error && (
               <UnavailableWorkPackageElement
-                header={t("unavailableWorkPackage.unauthorized.header")}
-                message={t("unavailableWorkPackage.unauthorized.message")}
+                header={t("unavailableWorkPackage.error.header")}
+                message={t("unavailableWorkPackage.error.message")}
               />
             )}
-            {selectedWorkPackage && (
-              <WorkPackageElement workPackage={selectedWorkPackage} linkTitle />
-            )}
+
+            {!workPackageResult.loading &&
+              !workPackageResult.error &&
+              workPackageResult.unauthorized && (
+                <UnavailableWorkPackageElement
+                  header={t(
+                    "unavailableWorkPackage.unauthorized.header"
+                  )}
+                  message={t(
+                    "unavailableWorkPackage.unauthorized.message"
+                  )}
+                />
+              )}
+
+            {!workPackageResult.loading &&
+              !workPackageResult.error &&
+              !workPackageResult.unauthorized &&
+              selectedWorkPackage && (
+                <WorkPackageElement
+                  workPackage={selectedWorkPackage}
+                  linkTitle
+                />
+              )}
           </>
         )}
       </div>
@@ -322,7 +349,7 @@ export const openProjectWorkPackageBlockSpec = createReactBlockSpec(
         editor={props.editor as any}
       />
     ),
-  },
+  }
 );
 
 export const openProjectWorkPackageStaticBlockSpec = createBlockSpec(
@@ -330,30 +357,86 @@ export const openProjectWorkPackageStaticBlockSpec = createBlockSpec(
   {
     render: (block) => {
       const wpid = block.props.wpid;
+      const href = linkToWorkPackage(wpid);
+
+      /*
+      Create a wrapper element.
+      This is done for a stable DOM structure,
+      because <a> as a root block element
+      may not be serialized correctly in the clipboard.
+       */
+      const wrapper = document.createElement("span");
+
       const anchor = document.createElement("a");
-      anchor.href = linkToWorkPackage(wpid);
+      anchor.href = href;
+      anchor.target = "_blank";
+      anchor.rel = "noopener noreferrer";
       anchor.textContent = `#${wpid}`;
-      return { dom: anchor, contentDOM: anchor };
+
+      wrapper.appendChild(anchor);
+
+      return {
+        dom: wrapper,
+        contentDOM: wrapper,
+      };
     },
-  },
+  }
 );
 
-export const openProjectWorkPackageSlashMenu = (editor: any) => ({
-  title: i18n.t("slashMenu.title"),
-  onItemClick: () => {
-    const insertedBlock = insertOrUpdateBlockForSlashMenu(editor, {
-      type: "openProjectWorkPackage",
-    });
-    requestAnimationFrame(() => {
-      // ensure cursor is placed in newly inserted block
-      if (insertedBlock?.id) {
+export const openProjectWorkPackageSlashMenu =
+  (editor: BlockNoteEditor<any>) => ({
+    title: i18n.t("slashMenu.title"),
+    onItemClick: () => {
+      const insertedBlock = insertOrUpdateBlockForSlashMenu(editor, {
+        type: "openProjectWorkPackage",
+      });
+
+      requestAnimationFrame(() => {
+        if (!insertedBlock?.id) return;
+
         editor.setTextCursorPosition(insertedBlock.id, "start");
         editor.focus();
-      }
-    });
-  },
-  aliases: [...getAliases()],
-  group: "OpenProject",
-  icon: <LinkIcon size={18} />,
-  subtext: i18n.t("slashMenu.subtext"),
-});
+
+        const [newTextBlock] = editor.insertBlocks(
+          [
+            {
+              type: "text",
+              content: "",
+            },
+          ],
+          insertedBlock.id
+        );
+
+        if (newTextBlock?.id) {
+          requestAnimationFrame(() => {
+            editor.setTextCursorPosition(newTextBlock.id, "start");
+            editor.focus(); // logic for automatically moving to a new text block
+          });
+        }
+      });
+    },
+    aliases: [...getAliases()],
+    group: "OpenProject",
+    icon: <LinkIcon size={18} />,
+    subtext: i18n.t("slashMenu.subtext"),
+  });
+
+function moveCursorToNextBlock(
+  editor: BlockNoteEditor<any>,
+  blockId: string
+) {
+  editor.focus();
+  editor.setTextCursorPosition(blockId, "end");
+
+  const cursor = editor.getTextCursorPosition();
+
+  if (!cursor?.nextBlock && cursor?.block) {
+    editor.insertBlocks([{ type: "text", content: "" }], cursor.block.id);
+  }
+
+  const updatedCursor = editor.getTextCursorPosition();
+
+  if (updatedCursor?.nextBlock) {
+    editor.setTextCursorPosition(updatedCursor.nextBlock.id, "start");
+  }
+}

--- a/lib/components/OpenProjectWorkPackageBlock.tsx
+++ b/lib/components/OpenProjectWorkPackageBlock.tsx
@@ -38,7 +38,6 @@ const Search = styled.div.attrs({ className: "op-bn-search" })`
   box-shadow: var(--bn-shadow-medium);
   border-radius: var(--bn-border-radius-large);
   width: 100%;
-  background: var(--bn-colors-editor-background);
   @media (min-width: 1120px) {
     width: 500px;
   }
@@ -70,12 +69,6 @@ const SearchInput = styled.input.attrs({ className: "op-bn-search--input" })`
   padding-left: 30px !important; // Hardcoded padding for icon
   border: 1px solid var(--bn-colors-border);
   border-radius: var(--bn-border-radius-small);
-  background: var(--bn-colors-editor-background);
-  color: var(--bn-colors-editor-text);
-
-  &:focus {
-    outline: 2px solid var(--bn-colors-border);
-  }
 `;
 
 const Dropdown = styled.div.attrs({ className: "op-bn-dropdown" })`
@@ -130,10 +123,17 @@ const OpenProjectWorkPackageBlockComponent = ({
 
   useEffect(() => {
     // Sync selectedWorkPackage when result updates
-    if (!workPackageResult.error && workPackageResult.workPackage) {
+    if (workPackageResult.workPackage) {
       setSelectedWorkPackage(workPackageResult.workPackage);
+      return;
     }
-  }, [workPackageResult.error, workPackageResult.workPackage]);
+
+    setSelectedWorkPackage(null);
+  }, [
+    workPackageResult.workPackage,
+    workPackageResult.unauthorized,
+    workPackageResult.error,
+  ]);
 
   useEffect(() => {
     // Direct access to _tiptapEditor
@@ -284,6 +284,12 @@ const OpenProjectWorkPackageBlockComponent = ({
               <UnavailableWorkPackageElement
                 header={t("unavailableWorkPackage.loading.header")}
                 message={t("unavailableWorkPackage.loading.message")}
+              />
+            )}
+            {!selectedWorkPackage && !workPackageResult.loading && (
+              <UnavailableWorkPackageElement
+                header={t("unavailableWorkPackage.unauthorized.header")}
+                message={t("unavailableWorkPackage.unauthorized.message")}
               />
             )}
             {selectedWorkPackage && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,31 +4,33 @@ import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
 import {
-    getDefaultReactSlashMenuItems,
-    SuggestionMenuController,
-    useCreateBlockNote,
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  useCreateBlockNote,
 } from "@blocknote/react";
 import {
   initializeOpBlockNoteExtensions,
   openProjectWorkPackageBlockSpec,
-  openProjectWorkPackageSlashMenu
+  openProjectWorkPackageSlashMenu,
 } from "../lib";
 import "./fetchOverride";
-import * as locales from "@blocknote/core/locales";
 
 const schema = BlockNoteSchema.create().extend({
   blockSpecs: {
-    "openProjectWorkPackage": openProjectWorkPackageBlockSpec(),
+    openProjectWorkPackage: openProjectWorkPackageBlockSpec(),
   },
 });
 type EditorType = typeof schema.BlockNoteEditor;
 
 export default function App() {
   const editor = useCreateBlockNote({
-    schema
+    schema,
   });
 
-  initializeOpBlockNoteExtensions({ baseUrl: "http://localhost:3000", locale: "en" });
+  initializeOpBlockNoteExtensions({
+    baseUrl: "http://localhost:3000",
+    locale: "en",
+  });
 
   const getCustomSlashMenuItems = (editor: EditorType) => {
     return [
@@ -38,10 +40,7 @@ export default function App() {
   };
 
   return (
-    <BlockNoteView
-      editor={editor}
-      slashMenu={false}
-    >
+    <BlockNoteView editor={editor} slashMenu={false}>
       <SuggestionMenuController
         triggerCharacter="/"
         getItems={async (query: string) =>


### PR DESCRIPTION
https://community.openproject.org/projects/communicator-stream/work_packages/69706/activity

Restrict WP link input visibility to the user creating the block by tracking active state, remove uninitialized blocks on input blur, reset dropdown and focus state, ensure keyboard navigation works correctly.