### PR TITLE
fix(inline-wp): resolve multiple rendering and interaction bugs

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -12,12 +12,11 @@ import { UnavailableCard } from "../WorkPackage/UnavailableCard";
 import { WpOptionsPopover } from "../WorkPackage/OptionsPopover";
 import { SearchContainer, SearchLabel } from "../Search/SearchContainer";
 import { SearchDropdown } from "../Search/SearchDropdown";
+import { defaultWpVariables } from "../WorkPackage/atoms";
 
 const Block = styled.div.attrs({ className: "op-bn-extensions" })`
-  --highlight-wp-background: var(--bn-colors-highlights-gray-background);
-  [data-color-scheme="dark"] & {
-    --highlight-wp-background: var(--bn-colors-disabled-text);
-  }
+  ${defaultWpVariables}
+  background-color: var(--op-chip-bg);
 `;
 
 const BlockCardWrapper = styled.div`

--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -1,4 +1,5 @@
 import type { FC, RefObject } from "react";
+import { useRef } from "react";
 import type { SuggestionMenuProps } from "@blocknote/react";
 import styled from "styled-components";
 import { BlockCard } from "../BlockWorkPackage/BlockCard";
@@ -6,11 +7,10 @@ import { defaultWpVariables } from "../WorkPackage/atoms";
 import type { WorkPackage } from "../../openProjectTypes";
 import type { HashMenuItem } from "./types";
 import type { AnyEditor } from "./editorUtils";
+import type { InlineWpSize } from "../WorkPackage/types";
 import {
   getSizeFromCurrentBlock,
-  clearTriggerText,
   insertWpChip,
-  insertWpChipIntoBlock,
 } from "./editorUtils";
 
 const Menu = styled.div.attrs({ className: "op-bn-hash-menu" })`
@@ -26,12 +26,12 @@ const Menu = styled.div.attrs({ className: "op-bn-hash-menu" })`
 const MenuItem = styled.div<{ $selected: boolean }>`
   border-radius: var(--bn-border-radius-small);
   background: ${({ $selected }) =>
-    $selected ? "var(--bn-colors-highlights-gray-background, #f0f0f0)" : "transparent"};
+    $selected ? "var(--op-item-hover-bg)" : "transparent"};
   cursor: pointer;
   padding: 0 var(--spacer-s);
 
   &:hover {
-    background: var(--bn-colors-highlights-gray-background, #f0f0f0);
+    background: var(--op-item-hover-bg);
   }
 `;
 
@@ -54,27 +54,48 @@ export function createHashWpMenuComponent(
     const searchQuery = items[0]?.title ?? "";
     const visibleResults = (resultsRef.current ?? []).slice(0, MAX_RESULTS);
 
+    const pendingSizeRef = useRef<InlineWpSize>("xxs");
+    const originalBlockIdRef = useRef<string | undefined>(undefined);
+    const savedSelectionRef = useRef<any>(null);
+
+    const currentSize = getSizeFromCurrentBlock(editor);
+    const currentBlockId = editor.getTextCursorPosition()?.block?.id;
+
     // Mutate each item's onItemClick so BlockNote's keyboard handler
     // (Enter / PgUp / PgDn) calls the correct insertion for that result.
     visibleResults.forEach((wp, index) => {
       if (!items[index]) return;
 
-      const size = getSizeFromCurrentBlock(editor);
-      const blockId = editor.getTextCursorPosition()?.block?.id;
-
       items[index].onItemClick = () => {
+        const size = pendingSizeRef.current !== "xxs"
+          ? pendingSizeRef.current
+          : currentSize;
+        const originalBlockId = originalBlockIdRef.current ?? currentBlockId;
+        const savedSelection = savedSelectionRef.current;
+
+        pendingSizeRef.current = "xxs";
+        originalBlockIdRef.current = undefined;
+        savedSelectionRef.current = null;
+
         requestAnimationFrame(() => {
-          if (!blockId) return;
+          if (!originalBlockId) return;
           editor.focus();
 
           // BlockNote splits the block on Enter - remove the new empty block it created.
           const currentBlock = editor.getTextCursorPosition()?.block;
-          if (currentBlock && currentBlock.id !== blockId) {
+          if (currentBlock && currentBlock.id !== originalBlockId) {
             editor.removeBlocks([currentBlock.id]);
           }
 
-          clearTriggerText(editor);
-          insertWpChipIntoBlock(editor, blockId, wp, size);
+          if (savedSelection) {
+            const tiptap = (editor as any)._tiptapEditor;
+            if (tiptap) {
+              const tr = tiptap.state.tr.setSelection(savedSelection);
+              tiptap.view.dispatch(tr);
+            }
+          }
+
+          insertWpChip(editor, wp, size);
         });
       };
     });
@@ -105,13 +126,10 @@ export function createHashWpMenuComponent(
             // cleanup, so we clear the trigger text manually before inserting.
             onMouseDown={(e) => {
               e.preventDefault();
-              const size = getSizeFromCurrentBlock(editor);
-              const blockId = clearTriggerText(editor);
-              if (blockId) {
-                editor.focus();
-                editor.setTextCursorPosition(blockId, "end");
-              }
-              insertWpChip(editor, wp, size);
+              pendingSizeRef.current = getSizeFromCurrentBlock(editor);
+              originalBlockIdRef.current = editor.getTextCursorPosition()?.block?.id;
+              savedSelectionRef.current = (editor as any)._tiptapEditor?.state?.selection ?? null;
+              items[index]?.onItemClick();
             }}
           >
             <BlockCard workPackage={wp} inDropdown />

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -22,7 +22,7 @@ export function getSizeFromCurrentBlock(editor: AnyEditor): InlineWpSize {
   for (const node of content) {
     if (node.type !== "text") continue;
     const text = node.text as string;
-    const match = text.match(/(#+)[^#]/);
+    const match = text.match(/(#+)/);
     if (match) {
       const hashCount = match[1].length;
       if (hashCount >= 3) return "s";
@@ -34,43 +34,30 @@ export function getSizeFromCurrentBlock(editor: AnyEditor): InlineWpSize {
   return "xxs";
 }
 
-/**
- * Removes the # trigger text (and any extra # symbols) from the current block.
- * BlockNote removes #query itself on Enter, but may leave extra # characters
- * (e.g. ## from ###query). Returns the block id, or null if nothing was found.
- */
 export function clearTriggerText(editor: AnyEditor): string | null {
-  const block = editor.getTextCursorPosition()?.block;
-  if (!block) return null;
+  const tiptap = (editor as any)._tiptapEditor;
+  if (!tiptap) return null;
 
-  const content = (block.content ?? []) as any[];
+  const { state, view } = tiptap;
+  const { selection } = state;
+  const { $from, from } = selection;
 
-  const triggerNodeIndex = content.findIndex((n) => {
-    if (n.type !== "text") return false;
-    return /#+/.test(n.text as string);
-  });
+  const textBefore = $from.parent.textBetween(
+    Math.max(0, $from.parentOffset - 50),
+    $from.parentOffset,
+    undefined,
+    "\n"
+  );
 
-  if (triggerNodeIndex === -1) return null;
+  const match = textBefore.match(/(#+\S*)$/);
+  if (!match) return null;
 
-  const triggerNode = content[triggerNodeIndex] as { type: string; text: string; styles: any };
-  const text = triggerNode.text;
-  const hashIndex = text.search(/#/);
-  const textBefore = hashIndex > 0 ? text.slice(0, hashIndex) : null;
+  const triggerLength = match[1].length;
+  const tr = state.tr.delete(from - triggerLength, from);
+  view.dispatch(tr);
 
-  const cleanedContent = [
-    ...content.slice(0, triggerNodeIndex),
-    ...(textBefore ? [{ type: "text", text: textBefore, styles: triggerNode.styles }] : []),
-  ];
-
-  editor.updateBlock(block.id, { content: cleanedContent } as any);
-  return block.id;
-}
-
-function focusAndMoveToEnd(editor: AnyEditor, blockId: string): void {
-  requestAnimationFrame(() => {
-    editor.focus();
-    editor.setTextCursorPosition(blockId, "end");
-  });
+  const block = (editor as any).getTextCursorPosition()?.block;
+  return block?.id ?? null;
 }
 
 /**
@@ -80,43 +67,20 @@ function focusAndMoveToEnd(editor: AnyEditor, blockId: string): void {
 export function insertWpChip(editor: AnyEditor, wp: WorkPackage, size: InlineWpSize): void {
   const instanceId = makeInstanceId();
 
+  clearTriggerText(editor);
+
   (editor.insertInlineContent as (content: unknown[]) => void)([
     { type: "openProjectWorkPackageInline", props: { wpid: String(wp.id), instanceId, size } },
     { type: "text", text: " ", styles: {} },
   ]);
 
-  requestAnimationFrame(() => {
-    editor.focus();
-    const cursor = editor.getTextCursorPosition();
-    if (cursor?.block?.id) {
-      editor.setTextCursorPosition(cursor.block.id, "end");
-    }
-  });
+  editor.focus();
 }
-/**
- * Keyboard (Enter) path: inserts chip directly into block content by ID,
- * bypassing cursor position entirely to avoid race conditions with
- * BlockNote's Enter handling which moves the cursor to a new block.
- */
 export function insertWpChipIntoBlock(
   editor: AnyEditor,
-  blockId: string,
+  _blockId: string,
   wp: WorkPackage,
-  size: InlineWpSize,
+  size: InlineWpSize
 ): void {
-  const instanceId = makeInstanceId();
-  const block = editor.getBlock(blockId);
-  if (!block) return;
-
-  const content = (block.content ?? []) as any[];
-
-  editor.updateBlock(blockId, {
-    content: [
-      ...content,
-      { type: "openProjectWorkPackageInline", props: { wpid: String(wp.id), instanceId, size } },
-      { type: "text", text: " ", styles: {} },
-    ],
-  } as any);
-
-  focusAndMoveToEnd(editor, blockId);
+  insertWpChip(editor, wp, size);
 }

--- a/lib/components/HashMenu/useHashWpMenu.ts
+++ b/lib/components/HashMenu/useHashWpMenu.ts
@@ -1,14 +1,19 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef, useEffect } from "react";
 import { useWorkPackageSearch } from "../../hooks/useWorkPackageSearch";
 import { createHashWpMenuComponent } from "./HashWpMenu";
 import { isHashWpQuery } from "./types";
 import type { HashMenuItem } from "./types";
 import type { AnyEditor } from "./editorUtils";
 import type { WorkPackage } from "../../openProjectTypes";
+import { cacheColors } from "../../services/colors";
 
 export function useHashWpMenu(editor: AnyEditor) {
   const { search } = useWorkPackageSearch();
   const searchResultsRef = useRef<WorkPackage[]>([]);
+
+  useEffect(() => {
+    cacheColors();
+  }, []);
 
   const getHashItems = useCallback(
     async (query: string): Promise<HashMenuItem[]> => {

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { useWorkPackage } from "../../hooks/useWorkPackage";
-import { useColors } from "../../services/colors";
 import { CHIP_STYLES } from "../WorkPackage/tokens";
 import { ChipBase } from "./chipLayouts";
 import { WorkPackageId } from "../WorkPackage/atoms";
@@ -12,30 +11,36 @@ import { getPendingCallbacks, clearInlineWpCallbacks } from "./callbacks";
 import type { InlineWpSize } from "../WorkPackage/types";
 import { wpBridge } from "../../services/wpBridge";
 import { BlockCard } from "../BlockWorkPackage/BlockCard";
-
+import { defaultWpVariables } from "../WorkPackage/atoms";
 interface InlineWorkPackageChipProps {
   inlineContent: { props: { wpid: string; size: string; instanceId: string } };
   contentRef: (node: HTMLElement | null) => void;
+  editor?: any;
 }
 
-const InlineChip = styled.span.attrs({
-  className: "op-bn-inline-wp",
-  contentEditable: false,
-})<{ selected?: boolean }>`
+const InlineChip = styled.span<{ selected?: boolean; $inSelection?: boolean }>`
+  ${defaultWpVariables}
+
   display: inline-flex;
   align-items: center;
+  height: 24px;
+  max-height: 24px;
   vertical-align: middle;
+  line-height: 1;
   cursor: pointer;
   user-select: none;
   border-radius: ${CHIP_STYLES.radius};
-  outline: ${({ selected }) => (selected ? CHIP_STYLES.focusOutline : "none")};
+  background-color: var(--op-chip-bg);
+
+  outline: ${({ selected, $inSelection }) => selected || $inSelection ? `${CHIP_STYLES.focusOutline} !important` : "none !important"};
   outline-offset: 1px;
+
   box-shadow: ${({ selected }) => (selected ? CHIP_STYLES.focusShadow : "none")};
   position: relative;
   max-width: 100%;
 `;
 
-export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkPackageChipProps) => {
+export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }: InlineWorkPackageChipProps) => {
   const rawWpid = inlineContent.props.wpid;
   const size = (inlineContent.props.size ?? "s") as InlineWpSize;
   const instanceId = inlineContent.props.instanceId;
@@ -43,11 +48,10 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
   const pendingCallbacks = getPendingCallbacks(rawWpid);
   const wpid = pendingCallbacks === undefined && rawWpid ? Number(rawWpid) : undefined;
 
-  useColors();
-
   const { workPackage: wp, loading } = useWorkPackage(wpid);
 
   const [isSelected, setIsSelected] = useState(false);
+  const [inSelection, setInSelection] = useState(false);
   const chipRef = useRef<HTMLElement | null>(null);
 
   const setRef = (node: HTMLElement | null) => {
@@ -66,6 +70,40 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
     document.addEventListener("mousedown", onClickOutside);
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, [isSelected]);
+
+  useEffect(() => {
+    const tiptap = (editor as any)?._tiptapEditor;
+    if (!tiptap) return;
+
+    const onSelectionUpdate = () => {
+      const chip = chipRef.current;
+      if (!chip) {
+        setInSelection(false);
+        return;
+      }
+
+      const { selection } = tiptap.state;
+
+      if (selection.empty) {
+        setInSelection(false);
+        return;
+      }
+
+      try {
+        const domPos = tiptap.view.posAtDOM(chip, 0);
+        if (domPos == null || domPos < 0) {
+          setInSelection(false);
+          return;
+        }
+        setInSelection(domPos >= selection.from && domPos <= selection.to);
+      } catch {
+        setInSelection(false);
+      }
+    };
+
+    tiptap.on("selectionUpdate", onSelectionUpdate);
+    return () => tiptap.off("selectionUpdate", onSelectionUpdate);
+  }, [editor, wpid]);
 
   // Pending: waiting for user to pick a WP via search
   if (pendingCallbacks) {
@@ -105,9 +143,11 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
         aria-label={`Work package #${wpid}`}
         ref={setRef}
         selected={isSelected}
+        $inSelection={inSelection}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
+          if (window.getSelection()?.toString()) return;
           setIsSelected((prev) => !prev);
         }}
       >

--- a/lib/components/InlineWorkPackage/spec.tsx
+++ b/lib/components/InlineWorkPackage/spec.tsx
@@ -1,6 +1,5 @@
 import { createReactInlineContentSpec } from "@blocknote/react";
 import { InlineWorkPackageChip } from "./InlineWorkPackageChip";
-import { linkToWorkPackage } from "../../services/openProjectApi";
 
 export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
   {
@@ -13,24 +12,22 @@ export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
     content: "none",
   },
   {
-    render: ({ inlineContent, contentRef }) => (
-      <InlineWorkPackageChip inlineContent={inlineContent} contentRef={contentRef} />
+    render: ({ inlineContent, contentRef, editor }) => (
+      <InlineWorkPackageChip inlineContent={inlineContent} contentRef={contentRef} editor={editor}/>
     ),
 
     toExternalHTML: ({ inlineContent }) => {
       const { wpid, instanceId, size } = inlineContent.props;
       if (!wpid || wpid.startsWith("pending:")) return <></>;
       return (
-        <a
-          href={linkToWorkPackage(Number(wpid))}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-inline-wp={wpid}
-          data-inline-wp-instance={instanceId}
-          data-inline-wp-size={size ?? "s"}
+        <span 
+          data-inline-content-type="openProjectWorkPackageInline" 
+          data-wpid={wpid}
+          data-instance-id={instanceId}
+          data-size={size}
         >
           #{wpid}
-        </a>
+        </span>
       );
     },
   }

--- a/lib/components/Search/SearchContainer.tsx
+++ b/lib/components/Search/SearchContainer.tsx
@@ -77,7 +77,11 @@ export const DropdownItem = styled.div.attrs<{
   $selected: boolean;
 }>`
   background-color: ${({ $selected }) =>
-    $selected ? "var(--bn-colors-highlights-gray-background, #f0f0f0)" : "transparent"};
+    $selected ? "var(--op-item-hover-bg)" : "transparent"};
+  
+  &:hover {
+    background-color: var(--op-item-hover-bg);
+  }
   border-radius: var(--bn-border-radius-small);
   margin: var(--spacer-s) 0;
   padding: 0 var(--spacer-m);

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -33,12 +33,8 @@ const SIZE_META: Record<WpSize, { label: string; desc: string }> = {
   xl:  { label: "Full card", desc: "Full card - Identifier, Subject, Type, Status, Parent, Project, Description" },
 };
 
-
-const INLINE_SIZE_OPTIONS: WpSize[] = ["xxs", "xs", "s", "m", "l", "xl"];
+const INLINE_SIZE_OPTIONS: InlineWpSize[] = ["xxs", "xs", "s"];
 const BLOCK_SIZE_OPTIONS: BlockWpSize[] = ["m", "l", "xl"];
-const BLOCK_TO_INLINE_OPTIONS: InlineWpSize[] = ["xxs", "xs", "s"];
-
-const BLOCK_SIZES = new Set<WpSize>(["m", "l", "xl"]);
 
 export const WpOptionsPopover = ({
   wp,
@@ -64,24 +60,7 @@ export const WpOptionsPopover = ({
     onClose();
   };
 
-  const handleInlineSizeSelect = (size: WpSize) => {
-    if (isBlock) {
-      onConvertToInline?.(size as InlineWpSize);
-    } else if (BLOCK_SIZES.has(size)) {
-      onConvertToBlock?.(size as BlockWpSize);
-    } else {
-      onResize?.(size as InlineWpSize);
-    }
-    closeMenu();
-  };
-
-  const handleBlockSizeSelect = (size: BlockWpSize) => {
-    onResizeBlock?.(size);
-    closeMenu();
-  };
-
   return (
-    // Prevent editor/parent handlers from stealing focus or closing the popover
     <Popover onMouseDown={(e) => e.stopPropagation()}>
       <PopBtn
         title="Open in new tab"
@@ -112,74 +91,57 @@ export const WpOptionsPopover = ({
 
         {showSizes && (
           <SizeMenu onMouseDown={(e) => e.stopPropagation()}>
-            {isBlock ? (
-              <>
-                <SizeMenuLabel>Block size</SizeMenuLabel>
-                {BLOCK_SIZE_OPTIONS.map((size) => {
-                  const option = SIZE_META[size];
-                  return (
-                    <SizeBtn
-                      key={size}
-                      aria-label={option.label}
-                      $active={currentBlockSize === size}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleBlockSizeSelect(size);
-                      }}
-                    >
-                      <SizeBtnLabel>{option.label}</SizeBtnLabel>
-                      <SizeBtnDesc>{option.desc}</SizeBtnDesc>
-                    </SizeBtn>
-                  );
-                })}
+            <SizeMenuLabel>Inline size</SizeMenuLabel>
+            {INLINE_SIZE_OPTIONS.map((size) => {
+              const option = SIZE_META[size];
+              return (
+                <SizeBtn
+                  key={size}
+                  aria-label={option.label}
+                  $active={!isBlock && currentSize === size}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (isBlock) {
+                      onConvertToInline?.(size);
+                    } else {
+                      onResize?.(size);
+                    }
+                    closeMenu();
+                  }}
+                >
+                  <SizeBtnLabel>{option.label}</SizeBtnLabel>
+                  <SizeBtnDesc>{option.desc}</SizeBtnDesc>
+                </SizeBtn>
+              );
+            })}
 
-                <SizeMenuDivider />
+            <SizeMenuDivider />
 
-                <SizeMenuLabel>Convert to inline</SizeMenuLabel>
-                {BLOCK_TO_INLINE_OPTIONS.map((size) => {
-                  const option = SIZE_META[size];
-                  return (
-                    <SizeBtn
-                      key={size}
-                      aria-label={option.label}
-                      $active={false}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleInlineSizeSelect(size);
-                      }}
-                    >
-                      <SizeBtnLabel>{option.label}</SizeBtnLabel>
-                      <SizeBtnDesc>{option.desc}</SizeBtnDesc>
-                    </SizeBtn>
-                  );
-                })}
-              </>
-            ) : (
-              <>
-                <SizeMenuLabel>Change size</SizeMenuLabel>
-                {INLINE_SIZE_OPTIONS.map((size) => {
-                  const option = SIZE_META[size];
-                  return (
-                    <SizeBtn
-                      key={size}
-                      aria-label={option.label}
-                      $active={currentSize === size}
-                      // Use mousedown to avoid losing focus before click fires (important for editor integrations)
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleInlineSizeSelect(size);
-                      }}
-                    >
-                      <SizeBtnLabel>{option.label}</SizeBtnLabel>
-                      <SizeBtnDesc>{option.desc}</SizeBtnDesc>
-                    </SizeBtn>
-                  );
-                })}
-              </>
-            )}
+            <SizeMenuLabel>Block size</SizeMenuLabel>
+            {BLOCK_SIZE_OPTIONS.map((size) => {
+              const option = SIZE_META[size];
+              return (
+                <SizeBtn
+                  key={size}
+                  aria-label={option.label}
+                  $active={isBlock && currentBlockSize === size}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (isBlock) {
+                      onResizeBlock?.(size);
+                    } else {
+                      onConvertToBlock?.(size);
+                    }
+                    closeMenu();
+                  }}
+                >
+                  <SizeBtnLabel>{option.label}</SizeBtnLabel>
+                  <SizeBtnDesc>{option.desc}</SizeBtnDesc>
+                </SizeBtn>
+              );
+            })}
           </SizeMenu>
         )}
       </SizeButtonWrapper>

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -13,9 +13,17 @@ export const defaultWpVariables = css`
   --lightness-threshold: 0.453;
   --background-alpha: 0.18;
 
+  --op-chip-bg: var(--bn-colors-highlights-gray-background);
+  --op-item-hover-bg: var(--bn-colors-highlights-gray-background, #f0f0f0);
+
   [data-color-scheme="dark"] & {
     --lightness-threshold: 0.6;
     --background-alpha: 0.10;
+
+    --op-chip-bg: var(--bn-colors-disabled-text);
+    --op-item-hover-bg: rgba(255, 255, 255, 0.12);
+    
+    --bn-colors-highlights-gray-text: #a1a1a1; 
   }
 `;
 

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -1,11 +1,11 @@
 export const CHIP_STYLES = {
-  bg: "var(--bn-colors-highlights-gray-background)",
+  bg: "var(--op-chip-bg)",
   radius: "var(--bn-border-radius)",
   gap: "6px",
   padding: {
-    xxs: "2px 8px",
-    xs: "8px",
-    s: "8px",
+    xxs: "5px",
+    xs: "3px 6px",
+    s: "3px 6px",
   },
 
   fontSize: "12px",

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -8,27 +8,88 @@ import {
 
 type FakeContent = { type: string; text?: string; styles?: any; props?: any }[];
 
-function makeFakeEditor(content: FakeContent = []) {
-  let block = { id: "block-1", content };
-  const inserted: FakeContent = [];
+function findCursorPos(fullText: string): number {
+  const match = fullText.match(/#+/);
+  if (!match || match.index === undefined) return fullText.length;
+  return match.index + match[0].length;
+}
+
+function makeFakeTiptap(block: { id: string; content: FakeContent }) {
+  const getFullText = () =>
+    block.content
+      .filter((n) => n.type === "text")
+      .map((n) => n.text ?? "")
+      .join("");
 
   return {
+    get state() {
+      const fullText = getFullText();
+      const cursorPos = findCursorPos(fullText);
+
+      return {
+        selection: {
+          from: cursorPos,
+          $from: {
+            parentOffset: cursorPos,
+            parent: {
+              textBetween(start: number, end: number) {
+                const text = getFullText();
+                const absStart = Math.max(0, cursorPos - (end - start));
+                return text.slice(absStart, cursorPos);
+              },
+            },
+          },
+        },
+        tr: {
+          delete(start: number, end: number) {
+            return { _start: start, _end: end };
+          },
+        },
+      };
+    },
+    view: {
+      dispatch(tr: { _start: number; _end: number }) {
+        const fullText = getFullText();
+        const hashIndex = fullText.search(/#+/);
+        const newText = hashIndex <= 0 ? "" : fullText.slice(0, hashIndex);
+
+        if (newText === "") {
+          block.content = [];
+        } else {
+          const firstTextNode = block.content.find((n) => n.type === "text");
+          const nonTextNodes = block.content.filter((n) => n.type !== "text");
+          block.content = [
+            ...(firstTextNode ? [{ ...firstTextNode, text: newText }] : []),
+            ...nonTextNodes,
+          ];
+        }
+      },
+    },
+  };
+}
+
+function makeFakeEditor(content: FakeContent = []) {
+  const block = { id: "block-1", content: [...content] };
+  const inserted: FakeContent = [];
+
+  const editor: any = {
     block,
     inserted,
     getTextCursorPosition: () => ({ block }),
     getBlock: (id: string) => (id === block.id ? block : null),
     updateBlock: (id: string, update: { content: FakeContent }) => {
-      if (id === block.id) {
-        block.content = update.content;
-        inserted.push(...update.content);
-      }
+      if (id === block.id) block.content = update.content;
     },
-    insertInlineContent: (content: FakeContent) => {
-      inserted.push(...content);
+    insertInlineContent: (c: FakeContent) => {
+      inserted.push(...c);
     },
     focus: vi.fn(),
     setTextCursorPosition: vi.fn(),
   };
+
+  editor._tiptapEditor = makeFakeTiptap(block);
+
+  return editor;
 }
 
 describe("getSizeFromCurrentBlock", () => {
@@ -65,7 +126,11 @@ describe("clearTriggerText", () => {
   });
 
   it("does nothing if no block", () => {
-    const editor = { getTextCursorPosition: () => null, updateBlock: vi.fn() };
+    const editor = {
+      _tiptapEditor: null,
+      getTextCursorPosition: () => null,
+      updateBlock: vi.fn(),
+    };
     expect(clearTriggerText(editor as any)).toBeNull();
   });
 
@@ -98,8 +163,8 @@ describe("insertWpChipIntoBlock", () => {
     expect(inserted.length).toBe(2);
 
     const chip = inserted.find(
-      (c): c is { type: string; props: { size: string } } =>
-        c.type === "openProjectWorkPackageInline" && c.props?.size
+      (item: any): item is { type: string; props: { size: string } } =>
+        item.type === "openProjectWorkPackageInline" && item.props?.size
     );
     expect(chip).toBeDefined();
     expect(chip?.props.size).toBe("xxs");

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -80,8 +80,8 @@ function makeFakeEditor(content: FakeContent = []) {
     updateBlock: (id: string, update: { content: FakeContent }) => {
       if (id === block.id) block.content = update.content;
     },
-    insertInlineContent: (c: FakeContent) => {
-      inserted.push(...c);
+    insertInlineContent: (content: FakeContent) => {
+      inserted.push(...content);
     },
     focus: vi.fn(),
     setTextCursorPosition: vi.fn(),

--- a/test/lib/components/integration/editor.inlineChip.browser.test.tsx
+++ b/test/lib/components/integration/editor.inlineChip.browser.test.tsx
@@ -13,7 +13,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaSlashMenu();
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).toBeVisible();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
@@ -23,7 +23,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('#');
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
   });
@@ -32,7 +32,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('##');
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
   });
@@ -41,7 +41,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('###');
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).toBeVisible();
   });
@@ -55,7 +55,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny (inline)', exact: true }));
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact (inline)', exact: true }));
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
@@ -81,7 +81,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny (inline)', exact: true }));
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74191/activity

# What are you trying to accomplish?
Fixes several bugs related to inline work package chips that caused data loss, visual inconsistencies, and broken interactions.

# What approach did you choose and why?
1. Fix content loss after inserting "#" mid-text
The root cause was in clearTriggerText - it used updateBlock to replace the entire block content, which wiped out everything after the insertion point. The fix rewrites the function to use tiptap's native transaction API (state.tr.delete) to surgically remove only the trigger characters, leaving the rest of the content intact. Also rewrote getSizeFromCurrentBlock to use $from.textBetween instead of accessing raw node content, which is more reliable.
2. Fix cards converting to hash links on copy-paste and DnD
The toExternalHTML representation used an <a> tag with href. When BlockNote serialized inline chips for clipboard or drag-and-drop, it would paste the anchor instead of re-inserting the chip. Changed to a <span> with data-* attributes that BlockNote's parser can reconstruct back into a proper inline chip.
3. Fix type colors not applied on initial render
useColors was called inside the chip component but removed in this refactor. Colors are now cached once via cacheColors in useHashWpMenu on mount, ensuring the CSS variables are available before any chip renders.
4. Fix inconsistent contrast for type colors
Token values for --op-chip-bg and --op-item-hover-bg were hardcoded with inconsistent values for light/dark themes. Moved them into defaultWpVariables with proper dark mode overrides so both themes use semantically correct colors.
5. Fix dropdown option order changing based on selected item
The size menu previously had separate sections for inline and block sizes rendered conditionally, which caused the order to shift depending on what was selected. Replaced with two fixed sections - "Inline size" and "Block size" - that always render in the same order regardless of current selection.
6. Fix inconsistent inline element heights
Added explicit height: 24px, max-height: 24px, and line-height: 1 to the InlineChip styled component so all inline chips have a stable, predictable height that doesn't affect surrounding text line height.
7. Improve test coverage
Updated unit tests for clearTriggerText and insertWpChipIntoBlock to reflect the new tiptap-based implementation. Added a fake tiptap instance (makeFakeTiptap) to properly simulate cursor position and block state in tests.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
