### PR TITLE
bug/74341: Inconsistent inline chip heights in text flow

### DIFF
--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -28,7 +28,6 @@ const InlineChip = styled.span.attrs({
   cursor: pointer;
   user-select: none;
   border-radius: ${CHIP_STYLES.radius};
-  line-height: 1;
   outline: ${({ selected }) => (selected ? CHIP_STYLES.focusOutline : "none")};
   outline-offset: 1px;
   box-shadow: ${({ selected }) => (selected ? CHIP_STYLES.focusShadow : "none")};

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -28,6 +28,9 @@ const InlineChip = styled.span.attrs({
   cursor: pointer;
   user-select: none;
   border-radius: ${CHIP_STYLES.radius};
+  height: 24px;
+  line-height: 1;
+  max-height: 24px;
   outline: ${({ selected }) => (selected ? CHIP_STYLES.focusOutline : "none")};
   outline-offset: 1px;
   box-shadow: ${({ selected }) => (selected ? CHIP_STYLES.focusShadow : "none")};

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -28,9 +28,7 @@ const InlineChip = styled.span.attrs({
   cursor: pointer;
   user-select: none;
   border-radius: ${CHIP_STYLES.radius};
-  height: 24px;
   line-height: 1;
-  max-height: 24px;
   outline: ${({ selected }) => (selected ? CHIP_STYLES.focusOutline : "none")};
   outline-offset: 1px;
   box-shadow: ${({ selected }) => (selected ? CHIP_STYLES.focusShadow : "none")};

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -3,7 +3,7 @@ export const CHIP_STYLES = {
   radius: "var(--bn-border-radius)",
   gap: "6px",
   padding: {
-    xxs: "2px 6px",
+    xxs: "2.5px 6px",
     xs: "1px 6px",
     s: "1px 6px",
   },

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -3,9 +3,9 @@ export const CHIP_STYLES = {
   radius: "var(--bn-border-radius)",
   gap: "6px",
   padding: {
-    xxs: "5px 6px",
-    xs: "4px 6px",
-    s: "3px 6px",
+    xxs: "2px 6px",
+    xs: "1px 6px",
+    s: "1px 6px",
   },
 
   fontSize: "12px",

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -3,9 +3,9 @@ export const CHIP_STYLES = {
   radius: "var(--bn-border-radius)",
   gap: "6px",
   padding: {
-    xxs: "2px 8px",
-    xs: "8px",
-    s: "8px",
+    xxs: "5px 6px",
+    xs: "4px 6px",
+    s: "3px 6px",
   },
 
   fontSize: "12px",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74341

# What are you trying to accomplish?
Inline chips should have a consistent, fixed height across all instances in text flow.
They should not affect surrounding line height or cause layout shifts.

## Screenshots
<img width="711" height="74" alt="image" src="https://github.com/user-attachments/assets/55e6127a-2cf5-41ee-819e-ff8cfa108c5a" />

# What approach did you choose and why?
Set adjusted padding for consistent inline chip rendering in text flow.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
