### PR TITLE
fix(hash-menu): ensure type colors are cached before dropdown renders

### DIFF
--- a/lib/components/HashMenu/useHashWpMenu.ts
+++ b/lib/components/HashMenu/useHashWpMenu.ts
@@ -5,6 +5,7 @@ import { isHashWpQuery } from "./types";
 import type { HashMenuItem } from "./types";
 import type { AnyEditor } from "./editorUtils";
 import type { WorkPackage } from "../../openProjectTypes";
+import { cacheColors } from "../../services/colors";
 
 export function useHashWpMenu(editor: AnyEditor) {
   const { search } = useWorkPackageSearch();
@@ -13,6 +14,8 @@ export function useHashWpMenu(editor: AnyEditor) {
   const getHashItems = useCallback(
     async (query: string): Promise<HashMenuItem[]> => {
       if (!isHashWpQuery(query)) return [];
+
+      await cacheColors();
 
       const results = await search(query);
       searchResultsRef.current = results;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74330

# What are you trying to accomplish?
Fix type colors not being applied on the initial render of the `#` work package dropdown.
When the dropdown first appeared, all work package chips showed gray/default styling instead of their type colors. On subsequent opens it worked fine.

## Screenshots
<img width="413" height="308" alt="image" src="https://github.com/user-attachments/assets/f3767422-4b38-402e-8c0f-df530d064183" />


# What approach did you choose and why?
Added `await cacheColors()` at the start of `getHashItems` in `useHashWpMenu`.

`cacheColors()` is a module-level singleton promise, so it only fetches types/statuses once - repeated calls resolve immediately at near-zero cost. By awaiting it before the search results are returned, we guarantee CSS color variables are set before React renders any chip in the dropdown.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
