### PR TITLE
Bug/74332: Inconsistent contrast type colors when switching themes

### DIFF
--- a/lib/components/BlockWorkPackage/BlockCards.tsx
+++ b/lib/components/BlockWorkPackage/BlockCards.tsx
@@ -72,7 +72,7 @@ const CardDetailsSpaced = styled(CardDetails)`
 `;
 
 const MetaItem = styled.span`
-  color: var(--bn-colors-highlights-gray-text);
+  color: var(--op-wp-meta-color) !important;
   font-size: 0.9em;
 `;
 

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -12,12 +12,11 @@ import { UnavailableCard } from "../WorkPackage/UnavailableCard";
 import { WpOptionsPopover } from "../WorkPackage/OptionsPopover";
 import { SearchContainer, SearchLabel } from "../Search/SearchContainer";
 import { SearchDropdown } from "../Search/SearchDropdown";
+import { defaultWpVariables } from "../WorkPackage/atoms";
 
 const Block = styled.div.attrs({ className: "op-bn-extensions" })`
-  --highlight-wp-background: var(--bn-colors-highlights-gray-background);
-  [data-color-scheme="dark"] & {
-    --highlight-wp-background: var(--bn-colors-disabled-text);
-  }
+  ${defaultWpVariables}
+  background-color: var(--op-chip-bg);
 `;
 
 const BlockCardWrapper = styled.div`

--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -27,12 +27,12 @@ const Menu = styled.div.attrs({ className: "op-bn-hash-menu" })`
 const MenuItem = styled.div<{ $selected: boolean }>`
   border-radius: var(--bn-border-radius-small);
   background: ${({ $selected }) =>
-    $selected ? "var(--bn-colors-highlights-gray-background, #f0f0f0)" : "transparent"};
+    $selected ? "var(--op-item-hover-bg)" : "transparent"};
   cursor: pointer;
   padding: 0 var(--spacer-s);
 
   &:hover {
-    background: var(--bn-colors-highlights-gray-background, #f0f0f0);
+    background: var(--op-item-hover-bg);
   }
 `;
 

--- a/lib/components/InlineWorkPackage/InlineChips.tsx
+++ b/lib/components/InlineWorkPackage/InlineChips.tsx
@@ -8,7 +8,7 @@ import {
   statusTextColor,
   statusBackgroundColor,
 } from "../../services/colors";
-import { ChipBaseXXS, ChipBaseXS, ChipBaseS, StatusChevron } from "./chipLayouts";
+import { ChipBaseXXS, ChipBaseXS, ChipBaseS } from "./chipLayouts";
 import {
   WorkPackageId,
   WorkPackageType,
@@ -59,14 +59,12 @@ export const WpChipS = ({ wp }: { wp: WorkPackage }) => (
     {wp._links?.status?.title && (
       <WorkPackageStatus
         as="span"
-        $compact
         $baseColor={statusColor(wp)}
         $borderColor={statusBorderColor()}
         $textColor={statusTextColor()}
         $bgColor={statusBackgroundColor()}
       >
         {wp._links.status.title}
-        <StatusChevron />
       </WorkPackageStatus>
     )}
     <WorkPackageTitleLink {...titleLinkProps(wp)}>

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -13,6 +13,7 @@ import type { InlineWpSize } from "../WorkPackage/types";
 import { wpBridge } from "../../services/wpBridge";
 import { BlockCard } from "../BlockWorkPackage/BlockCard";
 import { useTranslation } from "react-i18next";
+import { defaultWpVariables } from "../WorkPackage/atoms";
 
 interface InlineWorkPackageChipProps {
   inlineContent: { props: { wpid: string; size: string; instanceId: string } };
@@ -23,6 +24,7 @@ const InlineChip = styled.span.attrs({
   className: "op-bn-inline-wp",
   contentEditable: false,
 })<{ selected?: boolean }>`
+ ${defaultWpVariables}
   display: inline-flex;
   align-items: center;
   vertical-align: middle;

--- a/lib/components/InlineWorkPackage/chipLayouts.tsx
+++ b/lib/components/InlineWorkPackage/chipLayouts.tsx
@@ -30,16 +30,3 @@ export const ChipBaseS = styled.span`
 `;
 
 export const ChipBase = ChipBaseS;
-
-export const StatusChevron = () => (
-  <svg
-    aria-hidden="true"
-    width={CHIP_STYLES.status.chevron.width}
-    height={CHIP_STYLES.status.chevron.height}
-    viewBox="0 0 8 5"
-    fill="none"
-    style={{ flexShrink: 0, display: "block" }}
-  >
-    <path d="M0 0L4 5L8 0H0Z" fill={CHIP_STYLES.status.chevron.color} />
-  </svg>
-);

--- a/lib/components/Search/SearchContainer.tsx
+++ b/lib/components/Search/SearchContainer.tsx
@@ -78,7 +78,10 @@ export const DropdownItem = styled.div.attrs<{
   $selected: boolean;
 }>`
   background-color: ${({ $selected }) =>
-    $selected ? "var(--bn-colors-highlights-gray-background, #f0f0f0)" : "transparent"};
+    $selected ? "var(--op-item-hover-bg)" : "transparent"};
+  &:hover {
+    background: var(--op-item-hover-bg);
+  }
   border-radius: var(--bn-border-radius-small);
   margin: var(--spacer-s) 0;
   padding: 0 var(--spacer-m);

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -15,19 +15,25 @@ export const defaultWpVariables = css`
 
   --op-chip-bg: var(--bn-colors-highlights-gray-background);
   --op-item-hover-bg: var(--bn-colors-highlights-gray-background, #f0f0f0);
+  --op-wp-meta-color: var(--bn-colors-highlights-gray-text);
 
   [data-color-scheme="dark"] & {
     --lightness-threshold: 0.6;
     --background-alpha: 0.10;
     --op-chip-bg: var(--bn-colors-disabled-text);
     --op-item-hover-bg: rgba(255, 255, 255, 0.12);
+    --op-wp-meta-color: var(--bn-colors-highlights-gray-text);
+  }
+
+  [data-color-scheme="dark"][data-high-contrast] & {
+    --op-wp-meta-color: var(--bn-colors-editor-text);
   }
 `;
 
-export const WorkPackageId = styled.div.attrs({
+export const WorkPackageId = styled.span.attrs({
   className: "op-bn-work-package--id",
 })<{ $compact?: boolean }>`
-  color: var(--bn-colors-highlights-gray-text);
+  color: var(--op-wp-meta-color) !important;
 
   ${({ $compact }) =>
     $compact &&
@@ -38,7 +44,7 @@ export const WorkPackageId = styled.div.attrs({
     `}
 `;
 
-export const WorkPackageType = styled.div.attrs({
+export const WorkPackageType = styled.span.attrs({
   className: "op-bn-work-package--type",
   "data-testid": "op-bn-work-package--type",
 })<{ $color: string; $compact?: boolean }>`
@@ -55,7 +61,7 @@ export const WorkPackageType = styled.div.attrs({
     `}
 `;
 
-export const WorkPackageStatus = styled.div.attrs({
+export const WorkPackageStatus = styled.span.attrs({
   className: "op-bn-work-package--status",
 })<{
   $baseColor: string;
@@ -85,7 +91,7 @@ export const WorkPackageStatus = styled.div.attrs({
     `}
 `;
 
-export const WorkPackageTitle = styled.div.attrs({
+export const WorkPackageTitle = styled.span.attrs({
   className: "op-bn-work-package--title",
 })<{ $compact?: boolean }>`
   flex-basis: max-content;

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -13,9 +13,14 @@ export const defaultWpVariables = css`
   --lightness-threshold: 0.453;
   --background-alpha: 0.18;
 
+  --op-chip-bg: var(--bn-colors-highlights-gray-background);
+  --op-item-hover-bg: var(--bn-colors-highlights-gray-background, #f0f0f0);
+
   [data-color-scheme="dark"] & {
     --lightness-threshold: 0.6;
     --background-alpha: 0.10;
+    --op-chip-bg: var(--bn-colors-disabled-text);
+    --op-item-hover-bg: rgba(255, 255, 255, 0.12);
   }
 `;
 

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -78,12 +78,10 @@ export const WorkPackageStatus = styled.div.attrs({
     css`
       font-size: 12px;
       font-weight: 600;
-      color: var(--bn-colors-editor-text) !important;
       flex-shrink: 0;
       display: inline-flex;
       align-items: center;
       gap: 4px;
-      border: 1px solid var(--op-status-border-color);
     `}
 `;
 

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -11,7 +11,7 @@ export const CHIP_STYLES = {
   fontSize: "12px",
 
   id: {
-    color: "var(--bn-colors-highlights-gray-text)",
+    color: "var(--op-wp-meta-color)",
     fontWeight: 400,
   },
 

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -1,5 +1,5 @@
 export const CHIP_STYLES = {
-  bg: "var(--bn-colors-highlights-gray-background)",
+  bg: "var(--op-chip-bg)",
   radius: "var(--bn-border-radius)",
   gap: "6px",
   padding: {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74332
# What are you trying to accomplish?
Fix ID and parent/meta element colors not adapting correctly across all theme modes.
In dark high contrast mode the ID and meta colors were not bright enough in inline chips,
and were only accidentally correct in block cards due to interfering OpenProject styles.
In bright high contrast and dark no-contrast modes the block cards had a brighter ID color than expected.

# What approach did you choose and why?
Introduced a semantic CSS token `--op-wp-meta-color` defined inside `defaultWpVariables`:
- Default (light, dark no-contrast, bright high-contrast): uses `--bn-colors-highlights-gray-text`
- Dark high contrast: uses `--bn-colors-editor-text` (bright/white)

Both `WorkPackageId` and `MetaItem` now reference this token with `!important` to prevent
OpenProject's global styles from accidentally overriding the correct values.

# Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)