### PR TITLE
fix(wp-chip): stable dropdown option order regardless of selected size

### DIFF
--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -33,12 +33,8 @@ const SIZE_META: Record<WpSize, { label: string; desc: string }> = {
   xl:  { label: "Full card", desc: "Full card - Identifier, Subject, Type, Status, Parent, Project, Description" },
 };
 
-
-const INLINE_SIZE_OPTIONS: WpSize[] = ["xxs", "xs", "s", "m", "l", "xl"];
+const INLINE_SIZE_OPTIONS: InlineWpSize[] = ["xxs", "xs", "s"];
 const BLOCK_SIZE_OPTIONS: BlockWpSize[] = ["m", "l", "xl"];
-const BLOCK_TO_INLINE_OPTIONS: InlineWpSize[] = ["xxs", "xs", "s"];
-
-const BLOCK_SIZES = new Set<WpSize>(["m", "l", "xl"]);
 
 export const WpOptionsPopover = ({
   wp,
@@ -62,22 +58,6 @@ export const WpOptionsPopover = ({
   const closeMenu = () => {
     setShowSizes(false);
     onClose();
-  };
-
-  const handleInlineSizeSelect = (size: WpSize) => {
-    if (isBlock) {
-      onConvertToInline?.(size as InlineWpSize);
-    } else if (BLOCK_SIZES.has(size)) {
-      onConvertToBlock?.(size as BlockWpSize);
-    } else {
-      onResize?.(size as InlineWpSize);
-    }
-    closeMenu();
-  };
-
-  const handleBlockSizeSelect = (size: BlockWpSize) => {
-    onResizeBlock?.(size);
-    closeMenu();
   };
 
   return (
@@ -112,74 +92,57 @@ export const WpOptionsPopover = ({
 
         {showSizes && (
           <SizeMenu onMouseDown={(e) => e.stopPropagation()}>
-            {isBlock ? (
-              <>
-                <SizeMenuLabel>Block size</SizeMenuLabel>
-                {BLOCK_SIZE_OPTIONS.map((size) => {
-                  const option = SIZE_META[size];
-                  return (
-                    <SizeBtn
-                      key={size}
-                      aria-label={option.label}
-                      $active={currentBlockSize === size}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleBlockSizeSelect(size);
-                      }}
-                    >
-                      <SizeBtnLabel>{option.label}</SizeBtnLabel>
-                      <SizeBtnDesc>{option.desc}</SizeBtnDesc>
-                    </SizeBtn>
-                  );
-                })}
+            <SizeMenuLabel>Inline size</SizeMenuLabel>
+            {INLINE_SIZE_OPTIONS.map((size) => {
+              const option = SIZE_META[size];
+              return (
+                <SizeBtn
+                  key={size}
+                  aria-label={option.label}
+                  $active={!isBlock && currentSize === size}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (isBlock) {
+                      onConvertToInline?.(size);
+                    } else {
+                      onResize?.(size);
+                    }
+                    closeMenu();
+                  }}
+                >
+                  <SizeBtnLabel>{option.label}</SizeBtnLabel>
+                  <SizeBtnDesc>{option.desc}</SizeBtnDesc>
+                </SizeBtn>
+              );
+            })}
 
-                <SizeMenuDivider />
+            <SizeMenuDivider />
 
-                <SizeMenuLabel>Convert to inline</SizeMenuLabel>
-                {BLOCK_TO_INLINE_OPTIONS.map((size) => {
-                  const option = SIZE_META[size];
-                  return (
-                    <SizeBtn
-                      key={size}
-                      aria-label={option.label}
-                      $active={false}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleInlineSizeSelect(size);
-                      }}
-                    >
-                      <SizeBtnLabel>{option.label}</SizeBtnLabel>
-                      <SizeBtnDesc>{option.desc}</SizeBtnDesc>
-                    </SizeBtn>
-                  );
-                })}
-              </>
-            ) : (
-              <>
-                <SizeMenuLabel>Change size</SizeMenuLabel>
-                {INLINE_SIZE_OPTIONS.map((size) => {
-                  const option = SIZE_META[size];
-                  return (
-                    <SizeBtn
-                      key={size}
-                      aria-label={option.label}
-                      $active={currentSize === size}
-                      // Use mousedown to avoid losing focus before click fires (important for editor integrations)
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleInlineSizeSelect(size);
-                      }}
-                    >
-                      <SizeBtnLabel>{option.label}</SizeBtnLabel>
-                      <SizeBtnDesc>{option.desc}</SizeBtnDesc>
-                    </SizeBtn>
-                  );
-                })}
-              </>
-            )}
+            <SizeMenuLabel>Block size</SizeMenuLabel>
+            {BLOCK_SIZE_OPTIONS.map((size) => {
+              const option = SIZE_META[size];
+              return (
+                <SizeBtn
+                  key={size}
+                  aria-label={option.label}
+                  $active={isBlock && currentBlockSize === size}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (isBlock) {
+                      onResizeBlock?.(size);
+                    } else {
+                      onConvertToBlock?.(size);
+                    }
+                    closeMenu();
+                  }}
+                >
+                  <SizeBtnLabel>{option.label}</SizeBtnLabel>
+                  <SizeBtnDesc>{option.desc}</SizeBtnDesc>
+                </SizeBtn>
+              );
+            })}
           </SizeMenu>
         )}
       </SizeButtonWrapper>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74333

# What are you trying to accomplish?
Fix dropdown option order changing based on selected item in the work package chip size selector.
Previously the size menu rendered options conditionally - showing either inline or block sizes first depending on the current mode. This caused the list to visually reorder every time the user switched between inline and block, making the UI feel unpredictable.
The fix replaces the conditional rendering with two fixed sections - Inline size and Block size - that always render in the same order regardless of what is currently selected.


## Screenshots
<img width="643" height="259" alt="image" src="https://github.com/user-attachments/assets/6bbd9e61-0bb2-430c-89e0-141423b79246" />

# What approach did you choose and why?
Replaced the single conditional option list with two static arrays (INLINE_SIZE_OPTIONS and BLOCK_SIZE_OPTIONS) rendered in a fixed order, separated by a labeled divider.
The active state highlight is still applied correctly based on currentSize / currentBlockSize, and the correct callback (onResize, onConvertToBlock, onConvertToInline, onResizeBlock) is still called depending on whether the chip is currently inline or block.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
