### PR TITLE
Bug/74325 inserting hash inside text removes content after cursor

### DIFF
--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -5,11 +5,6 @@ import { BlockCard } from "../BlockWorkPackage/BlockCard";
 import { defaultWpVariables } from "../WorkPackage/atoms";
 import type { WorkPackage } from "../../openProjectTypes";
 import type { HashMenuItem } from "./types";
-import type { AnyEditor } from "./editorUtils";
-import {
-  getSizeFromCurrentBlock,
-  insertWpChip,
-} from "./editorUtils";
 import { useTranslation } from "react-i18next";
 
 const Menu = styled.div.attrs({ className: "op-bn-hash-menu" })`
@@ -43,45 +38,16 @@ const EmptyState = styled.div`
 const MAX_RESULTS = 5;
 
 export function createHashWpMenuComponent(
-  editor: AnyEditor,
   resultsRef: RefObject<WorkPackage[]>,
 ): FC<SuggestionMenuProps<HashMenuItem>> {
   const HashWpMenuComponent: FC<SuggestionMenuProps<HashMenuItem>> = ({
     items,
     selectedIndex,
+    onItemClick,
   }) => {
     const { t } = useTranslation();
     const searchQuery = items[0]?.title ?? "";
     const visibleResults = (resultsRef.current ?? []).slice(0, MAX_RESULTS);
-
-    const currentSize = getSizeFromCurrentBlock(editor);
-    const currentBlockId = editor.getTextCursorPosition()?.block?.id;
-
-    // Mutate each item's onItemClick so BlockNote's keyboard handler
-    // (Enter / PgUp / PgDn) calls the correct insertion for that result.
-    visibleResults.forEach((wp, index) => {
-      if (!items[index]) return;
-
-      items[index].onItemClick = () => {
-        requestAnimationFrame(() => {
-          if (!currentBlockId) return;
-
-          const currentBlock = editor.getTextCursorPosition()?.block;
-
-          // BlockNote's default "Enter" behavior splits the block.
-          // If the block ID changed, it was a keyboard Enter, so we remove the new empty block.
-          const isKeyboardEnter = currentBlock && currentBlock.id !== currentBlockId;
-
-          if (isKeyboardEnter) {
-            editor.removeBlocks([currentBlock.id]);
-          }
-
-          editor.focus();
-
-          insertWpChip(editor, wp, currentSize);
-        });
-      };
-    });
 
     if (!searchQuery) {
       return (
@@ -109,7 +75,7 @@ export function createHashWpMenuComponent(
             // This allows us to safely insert the chip without needing TipTap to restore the cursor.
             onMouseDown={(e) => {
               e.preventDefault();
-              items[index]?.onItemClick();
+              if (items[index]) onItemClick?.(items[index]);
             }}
           >
             <BlockCard workPackage={wp} inDropdown />

--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -1,5 +1,4 @@
 import type { FC, RefObject } from "react";
-import { useRef } from "react";
 import type { SuggestionMenuProps } from "@blocknote/react";
 import styled from "styled-components";
 import { BlockCard } from "../BlockWorkPackage/BlockCard";
@@ -7,7 +6,6 @@ import { defaultWpVariables } from "../WorkPackage/atoms";
 import type { WorkPackage } from "../../openProjectTypes";
 import type { HashMenuItem } from "./types";
 import type { AnyEditor } from "./editorUtils";
-import type { InlineWpSize } from "../WorkPackage/types";
 import {
   getSizeFromCurrentBlock,
   insertWpChip,
@@ -56,10 +54,6 @@ export function createHashWpMenuComponent(
     const searchQuery = items[0]?.title ?? "";
     const visibleResults = (resultsRef.current ?? []).slice(0, MAX_RESULTS);
 
-    const pendingSizeRef = useRef<InlineWpSize>("xxs");
-    const originalBlockIdRef = useRef<string | undefined>(undefined);
-    const savedSelectionRef = useRef<any>(null);
-
     const currentSize = getSizeFromCurrentBlock(editor);
     const currentBlockId = editor.getTextCursorPosition()?.block?.id;
 
@@ -69,35 +63,22 @@ export function createHashWpMenuComponent(
       if (!items[index]) return;
 
       items[index].onItemClick = () => {
-        const size = pendingSizeRef.current !== "xxs"
-          ? pendingSizeRef.current
-          : currentSize;
-        const originalBlockId = originalBlockIdRef.current ?? currentBlockId;
-        const savedSelection = savedSelectionRef.current;
-
-        pendingSizeRef.current = "xxs";
-        originalBlockIdRef.current = undefined;
-        savedSelectionRef.current = null;
-
         requestAnimationFrame(() => {
-          if (!originalBlockId) return;
-          editor.focus();
+          if (!currentBlockId) return;
 
-          // BlockNote splits the block on Enter - remove the new empty block it created.
           const currentBlock = editor.getTextCursorPosition()?.block;
-          if (currentBlock && currentBlock.id !== originalBlockId) {
+
+          // BlockNote's default "Enter" behavior splits the block.
+          // If the block ID changed, it was a keyboard Enter, so we remove the new empty block.
+          const isKeyboardEnter = currentBlock && currentBlock.id !== currentBlockId;
+
+          if (isKeyboardEnter) {
             editor.removeBlocks([currentBlock.id]);
           }
 
-          if (savedSelection) {
-            const tiptap = (editor as any)._tiptapEditor;
-            if (tiptap) {
-              const tr = tiptap.state.tr.setSelection(savedSelection);
-              tiptap.view.dispatch(tr);
-            }
-          }
+          editor.focus();
 
-          insertWpChip(editor, wp, size);
+          insertWpChip(editor, wp, currentSize);
         });
       };
     });
@@ -124,13 +105,10 @@ export function createHashWpMenuComponent(
           <MenuItem
             key={wp.id}
             $selected={selectedIndex === index}
-            // Mouse path: e.preventDefault() stops BlockNote from doing its own
-            // cleanup, so we clear the trigger text manually before inserting.
+            // Mouse path: e.preventDefault() prevents the editor from losing focus.
+            // This allows us to safely insert the chip without needing TipTap to restore the cursor.
             onMouseDown={(e) => {
               e.preventDefault();
-              pendingSizeRef.current = getSizeFromCurrentBlock(editor);
-              originalBlockIdRef.current = editor.getTextCursorPosition()?.block?.id;
-              savedSelectionRef.current = (editor as any)._tiptapEditor?.state?.selection ?? null;
               items[index]?.onItemClick();
             }}
           >

--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -1,4 +1,5 @@
 import type { FC, RefObject } from "react";
+import { useRef } from "react";
 import type { SuggestionMenuProps } from "@blocknote/react";
 import styled from "styled-components";
 import { BlockCard } from "../BlockWorkPackage/BlockCard";
@@ -6,11 +7,10 @@ import { defaultWpVariables } from "../WorkPackage/atoms";
 import type { WorkPackage } from "../../openProjectTypes";
 import type { HashMenuItem } from "./types";
 import type { AnyEditor } from "./editorUtils";
+import type { InlineWpSize } from "../WorkPackage/types";
 import {
   getSizeFromCurrentBlock,
-  clearTriggerText,
   insertWpChip,
-  insertWpChipIntoBlock,
 } from "./editorUtils";
 import { useTranslation } from "react-i18next";
 
@@ -56,27 +56,48 @@ export function createHashWpMenuComponent(
     const searchQuery = items[0]?.title ?? "";
     const visibleResults = (resultsRef.current ?? []).slice(0, MAX_RESULTS);
 
+    const pendingSizeRef = useRef<InlineWpSize>("xxs");
+    const originalBlockIdRef = useRef<string | undefined>(undefined);
+    const savedSelectionRef = useRef<any>(null);
+
+    const currentSize = getSizeFromCurrentBlock(editor);
+    const currentBlockId = editor.getTextCursorPosition()?.block?.id;
+
     // Mutate each item's onItemClick so BlockNote's keyboard handler
     // (Enter / PgUp / PgDn) calls the correct insertion for that result.
     visibleResults.forEach((wp, index) => {
       if (!items[index]) return;
 
-      const size = getSizeFromCurrentBlock(editor);
-      const blockId = editor.getTextCursorPosition()?.block?.id;
-
       items[index].onItemClick = () => {
+        const size = pendingSizeRef.current !== "xxs"
+          ? pendingSizeRef.current
+          : currentSize;
+        const originalBlockId = originalBlockIdRef.current ?? currentBlockId;
+        const savedSelection = savedSelectionRef.current;
+
+        pendingSizeRef.current = "xxs";
+        originalBlockIdRef.current = undefined;
+        savedSelectionRef.current = null;
+
         requestAnimationFrame(() => {
-          if (!blockId) return;
+          if (!originalBlockId) return;
           editor.focus();
 
           // BlockNote splits the block on Enter - remove the new empty block it created.
           const currentBlock = editor.getTextCursorPosition()?.block;
-          if (currentBlock && currentBlock.id !== blockId) {
+          if (currentBlock && currentBlock.id !== originalBlockId) {
             editor.removeBlocks([currentBlock.id]);
           }
 
-          clearTriggerText(editor);
-          insertWpChipIntoBlock(editor, blockId, wp, size);
+          if (savedSelection) {
+            const tiptap = (editor as any)._tiptapEditor;
+            if (tiptap) {
+              const tr = tiptap.state.tr.setSelection(savedSelection);
+              tiptap.view.dispatch(tr);
+            }
+          }
+
+          insertWpChip(editor, wp, size);
         });
       };
     });
@@ -107,13 +128,10 @@ export function createHashWpMenuComponent(
             // cleanup, so we clear the trigger text manually before inserting.
             onMouseDown={(e) => {
               e.preventDefault();
-              const size = getSizeFromCurrentBlock(editor);
-              const blockId = clearTriggerText(editor);
-              if (blockId) {
-                editor.focus();
-                editor.setTextCursorPosition(blockId, "end");
-              }
-              insertWpChip(editor, wp, size);
+              pendingSizeRef.current = getSizeFromCurrentBlock(editor);
+              originalBlockIdRef.current = editor.getTextCursorPosition()?.block?.id;
+              savedSelectionRef.current = (editor as any)._tiptapEditor?.state?.selection ?? null;
+              items[index]?.onItemClick();
             }}
           >
             <BlockCard workPackage={wp} inDropdown />

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -18,19 +18,20 @@ export function getSizeFromCurrentBlock(editor: AnyEditor): InlineWpSize {
   if (!block) return "xxs";
 
   const content = (block.content ?? []) as any[];
+  let lastHashCount: number | null = null;
 
   for (const node of content) {
     if (node.type !== "text") continue;
     const text = node.text as string;
-    const match = text.match(/(#+)/);
-    if (match) {
-      const hashCount = match[1].length;
-      if (hashCount >= 3) return "s";
-      if (hashCount === 2) return "xs";
-      return "xxs";
+    const matches = [...text.matchAll(/#+/g)];
+    if (matches.length > 0) {
+      lastHashCount = matches[matches.length - 1][0].length;
     }
   }
 
+  if (lastHashCount === null) return "xxs";
+  if (lastHashCount >= 3) return "s";
+  if (lastHashCount === 2) return "xs";
   return "xxs";
 }
 
@@ -82,13 +83,4 @@ export function removeTriggerBeforeChip(editor: AnyEditor, instanceId: string): 
 
   editor.updateBlock(block.id, { content: newContent } as any);
   return block.id;
-}
-
-export function insertWpChipIntoBlock(
-  editor: AnyEditor,
-  _blockId: string,
-  wp: WorkPackage,
-  size: InlineWpSize
-): void {
-  insertWpChip(editor, wp, size);
 }

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -34,48 +34,56 @@ export function getSizeFromCurrentBlock(editor: AnyEditor): InlineWpSize {
   return "xxs";
 }
 
-export function clearTriggerText(editor: AnyEditor): string | null {
-  const tiptap = (editor as any)._tiptapEditor;
-  if (!tiptap) return null;
-
-  const { state, view } = tiptap;
-  const { selection } = state;
-  const { $from, from } = selection;
-
-  const textBefore = $from.parent.textBetween(
-    Math.max(0, $from.parentOffset - 50),
-    $from.parentOffset,
-    undefined,
-    "\n"
-  );
-
-  const match = textBefore.match(/(#+\S*)$/);
-  if (!match) return null;
-
-  const triggerLength = match[1].length;
-  const tr = state.tr.delete(from - triggerLength, from);
-  view.dispatch(tr);
-
-  const block = (editor as any).getTextCursorPosition()?.block;
-  return block?.id ?? null;
-}
-
 /**
- * Mouse path: inserts chip at the current cursor position via insertInlineContent.
- * Works correctly because e.preventDefault() stops BlockNote from moving the cursor.
+ * Inserts a chip at the cursor and removes the `#query` trigger before it.
+ * The chip acts as a position anchor so we don't need cursor offsets.
  */
 export function insertWpChip(editor: AnyEditor, wp: WorkPackage, size: InlineWpSize): void {
   const instanceId = makeInstanceId();
-
-  clearTriggerText(editor);
 
   (editor.insertInlineContent as (content: unknown[]) => void)([
     { type: "openProjectWorkPackageInline", props: { wpid: String(wp.id), instanceId, size } },
     { type: "text", text: " ", styles: {} },
   ]);
 
+  removeTriggerBeforeChip(editor, instanceId);
+
   editor.focus();
 }
+
+/**
+ * Trims the trailing `#query` from the text node right before the chip.
+ * Returns the block ID if the operation completed (with or without changes), or null if no block.
+ */
+export function removeTriggerBeforeChip(editor: AnyEditor, instanceId: string): string | null {
+  const block = editor.getTextCursorPosition()?.block;
+  if (!block) return null;
+
+  const content = (block.content ?? []) as any[];
+  const chipIndex = content.findIndex(
+    (n) => n.type === "openProjectWorkPackageInline" && n.props?.instanceId === instanceId
+  );
+  if (chipIndex <= 0) return block.id;
+
+  const prev = content[chipIndex - 1];
+  if (prev.type !== "text") return block.id;
+
+  const match = (prev.text as string).match(/#+\S*$/);
+  if (!match) return block.id;
+
+  const before = (prev.text as string).slice(0, match.index);
+  const newContent = [...content];
+
+  if (before.length > 0) {
+    newContent[chipIndex - 1] = { ...prev, text: before };
+  } else {
+    newContent.splice(chipIndex - 1, 1);
+  }
+
+  editor.updateBlock(block.id, { content: newContent } as any);
+  return block.id;
+}
+
 export function insertWpChipIntoBlock(
   editor: AnyEditor,
   _blockId: string,

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -22,7 +22,7 @@ export function getSizeFromCurrentBlock(editor: AnyEditor): InlineWpSize {
   for (const node of content) {
     if (node.type !== "text") continue;
     const text = node.text as string;
-    const match = text.match(/(#+)[^#]/);
+    const match = text.match(/(#+)/);
     if (match) {
       const hashCount = match[1].length;
       if (hashCount >= 3) return "s";
@@ -34,43 +34,30 @@ export function getSizeFromCurrentBlock(editor: AnyEditor): InlineWpSize {
   return "xxs";
 }
 
-/**
- * Removes the # trigger text (and any extra # symbols) from the current block.
- * BlockNote removes #query itself on Enter, but may leave extra # characters
- * (e.g. ## from ###query). Returns the block id, or null if nothing was found.
- */
 export function clearTriggerText(editor: AnyEditor): string | null {
-  const block = editor.getTextCursorPosition()?.block;
-  if (!block) return null;
+  const tiptap = (editor as any)._tiptapEditor;
+  if (!tiptap) return null;
 
-  const content = (block.content ?? []) as any[];
+  const { state, view } = tiptap;
+  const { selection } = state;
+  const { $from, from } = selection;
 
-  const triggerNodeIndex = content.findIndex((n) => {
-    if (n.type !== "text") return false;
-    return /#+/.test(n.text as string);
-  });
+  const textBefore = $from.parent.textBetween(
+    Math.max(0, $from.parentOffset - 50),
+    $from.parentOffset,
+    undefined,
+    "\n"
+  );
 
-  if (triggerNodeIndex === -1) return null;
+  const match = textBefore.match(/(#+\S*)$/);
+  if (!match) return null;
 
-  const triggerNode = content[triggerNodeIndex] as { type: string; text: string; styles: any };
-  const text = triggerNode.text;
-  const hashIndex = text.search(/#/);
-  const textBefore = hashIndex > 0 ? text.slice(0, hashIndex) : null;
+  const triggerLength = match[1].length;
+  const tr = state.tr.delete(from - triggerLength, from);
+  view.dispatch(tr);
 
-  const cleanedContent = [
-    ...content.slice(0, triggerNodeIndex),
-    ...(textBefore ? [{ type: "text", text: textBefore, styles: triggerNode.styles }] : []),
-  ];
-
-  editor.updateBlock(block.id, { content: cleanedContent } as any);
-  return block.id;
-}
-
-function focusAndMoveToEnd(editor: AnyEditor, blockId: string): void {
-  requestAnimationFrame(() => {
-    editor.focus();
-    editor.setTextCursorPosition(blockId, "end");
-  });
+  const block = (editor as any).getTextCursorPosition()?.block;
+  return block?.id ?? null;
 }
 
 /**
@@ -80,43 +67,20 @@ function focusAndMoveToEnd(editor: AnyEditor, blockId: string): void {
 export function insertWpChip(editor: AnyEditor, wp: WorkPackage, size: InlineWpSize): void {
   const instanceId = makeInstanceId();
 
+  clearTriggerText(editor);
+
   (editor.insertInlineContent as (content: unknown[]) => void)([
     { type: "openProjectWorkPackageInline", props: { wpid: String(wp.id), instanceId, size } },
     { type: "text", text: " ", styles: {} },
   ]);
 
-  requestAnimationFrame(() => {
-    editor.focus();
-    const cursor = editor.getTextCursorPosition();
-    if (cursor?.block?.id) {
-      editor.setTextCursorPosition(cursor.block.id, "end");
-    }
-  });
+  editor.focus();
 }
-/**
- * Keyboard (Enter) path: inserts chip directly into block content by ID,
- * bypassing cursor position entirely to avoid race conditions with
- * BlockNote's Enter handling which moves the cursor to a new block.
- */
 export function insertWpChipIntoBlock(
   editor: AnyEditor,
-  blockId: string,
+  _blockId: string,
   wp: WorkPackage,
-  size: InlineWpSize,
+  size: InlineWpSize
 ): void {
-  const instanceId = makeInstanceId();
-  const block = editor.getBlock(blockId);
-  if (!block) return;
-
-  const content = (block.content ?? []) as any[];
-
-  editor.updateBlock(blockId, {
-    content: [
-      ...content,
-      { type: "openProjectWorkPackageInline", props: { wpid: String(wp.id), instanceId, size } },
-      { type: "text", text: " ", styles: {} },
-    ],
-  } as any);
-
-  focusAndMoveToEnd(editor, blockId);
+  insertWpChip(editor, wp, size);
 }

--- a/lib/components/HashMenu/useHashWpMenu.ts
+++ b/lib/components/HashMenu/useHashWpMenu.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef } from "react";
 import { useWorkPackageSearch } from "../../hooks/useWorkPackageSearch";
 import { createHashWpMenuComponent } from "./HashWpMenu";
 import { isHashWpQuery } from "./types";
+import { getSizeFromCurrentBlock, insertWpChip } from "./editorUtils";
 import type { HashMenuItem } from "./types";
 import type { AnyEditor } from "./editorUtils";
 import type { WorkPackage } from "../../openProjectTypes";
@@ -20,18 +21,20 @@ export function useHashWpMenu(editor: AnyEditor) {
       const results = await search(query);
       searchResultsRef.current = results;
 
-      const count = Math.max(results.length, 1);
-      return Array.from({ length: count }, () => ({
+      const size = getSizeFromCurrentBlock(editor);
+      return results.map((wp) => ({
         title: query,
-        onItemClick: () => {},
+        onItemClick: () => {
+          insertWpChip(editor, wp, size);
+        },
       }));
     },
-    [search]
+    [editor, search]
   );
 
   const HashWpMenu = useMemo(
-    () => createHashWpMenuComponent(editor, searchResultsRef),
-    [editor]
+    () => createHashWpMenuComponent(searchResultsRef),
+    []
   );
 
   return { getHashItems, HashWpMenu };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,6 @@ import {
   useHashWpMenu,
 } from "../lib";
 import "./fetchOverride";
-import type { HashMenuItem } from "../lib";
 import {useInlineWpEvents} from "../lib";
 
 const schema = BlockNoteSchema.create().extend({
@@ -66,7 +65,6 @@ export default function App() {
         triggerCharacter="#"
         getItems={getHashItems}
         suggestionMenuComponent={HashWpMenu}
-        onItemClick={(item: HashMenuItem) => item.onItemClick()}
       />
     </BlockNoteView>
   );

--- a/test/helpers/renderEditor.tsx
+++ b/test/helpers/renderEditor.tsx
@@ -48,7 +48,6 @@ function Editor() {
         triggerCharacter="#"
         getItems={getHashItems}
         suggestionMenuComponent={HashWpMenu}
-        onItemClick={(item: HashMenuItem) => item.onItemClick()}
       />
     </BlockNoteView>
     </div>

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -64,6 +64,11 @@ describe("getSizeFromCurrentBlock", () => {
     const editor = createTestEditor("foo");
     expect(getSizeFromCurrentBlock(editor as any)).toBe("xxs");
   });
+
+  it("uses the last hash trigger in the block", () => {
+    const editor = createTestEditor("#first ##bug");
+    expect(getSizeFromCurrentBlock(editor as any)).toBe("xs");
+  });
 });
 
 describe("removeTriggerBeforeChip", () => {

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -8,20 +8,77 @@ import {
 
 type FakeContent = { type: string; text?: string; styles?: any; props?: any }[];
 
-function makeFakeEditor(content: FakeContent = []) {
-  let block = { id: "block-1", content };
-  const inserted: FakeContent = [];
+function findCursorPos(fullText: string): number {
+  const match = fullText.match(/#+/);
+  if (!match || match.index === undefined) return fullText.length;
+  return match.index + match[0].length;
+}
+
+function makeFakeTiptap(block: { id: string; content: FakeContent }) {
+  const getFullText = () =>
+    block.content
+      .filter((n) => n.type === "text")
+      .map((n) => n.text ?? "")
+      .join("");
 
   return {
+    get state() {
+      const fullText = getFullText();
+      const cursorPos = findCursorPos(fullText);
+
+      return {
+        selection: {
+          from: cursorPos,
+          $from: {
+            parentOffset: cursorPos,
+            parent: {
+              textBetween(start: number, end: number) {
+                const text = getFullText();
+                const absStart = Math.max(0, cursorPos - (end - start));
+                return text.slice(absStart, cursorPos);
+              },
+            },
+          },
+        },
+        tr: {
+          delete(start: number, end: number) {
+            return { _start: start, _end: end };
+          },
+        },
+      };
+    },
+    view: {
+      dispatch(tr: { _start: number; _end: number }) {
+        const fullText = getFullText();
+        const hashIndex = fullText.search(/#+/);
+        const newText = hashIndex <= 0 ? "" : fullText.slice(0, hashIndex);
+
+        if (newText === "") {
+          block.content = [];
+        } else {
+          const firstTextNode = block.content.find((n) => n.type === "text");
+          const nonTextNodes = block.content.filter((n) => n.type !== "text");
+          block.content = [
+            ...(firstTextNode ? [{ ...firstTextNode, text: newText }] : []),
+            ...nonTextNodes,
+          ];
+        }
+      },
+    },
+  };
+}
+
+function makeFakeEditor(content: FakeContent = []) {
+  const block = { id: "block-1", content: [...content] };
+  const inserted: FakeContent = [];
+
+  const editor: any = {
     block,
     inserted,
     getTextCursorPosition: () => ({ block }),
     getBlock: (id: string) => (id === block.id ? block : null),
     updateBlock: (id: string, update: { content: FakeContent }) => {
-      if (id === block.id) {
-        block.content = update.content;
-        inserted.push(...update.content);
-      }
+      if (id === block.id) block.content = update.content;
     },
     insertInlineContent: (content: FakeContent) => {
       inserted.push(...content);
@@ -29,6 +86,10 @@ function makeFakeEditor(content: FakeContent = []) {
     focus: vi.fn(),
     setTextCursorPosition: vi.fn(),
   };
+
+  editor._tiptapEditor = makeFakeTiptap(block);
+
+  return editor;
 }
 
 describe("getSizeFromCurrentBlock", () => {
@@ -65,7 +126,11 @@ describe("clearTriggerText", () => {
   });
 
   it("does nothing if no block", () => {
-    const editor = { getTextCursorPosition: () => null, updateBlock: vi.fn() };
+    const editor = {
+      _tiptapEditor: null,
+      getTextCursorPosition: () => null,
+      updateBlock: vi.fn(),
+    };
     expect(clearTriggerText(editor as any)).toBeNull();
   });
 
@@ -98,8 +163,8 @@ describe("insertWpChipIntoBlock", () => {
     expect(inserted.length).toBe(2);
 
     const chip = inserted.find(
-      (c): c is { type: string; props: { size: string } } =>
-        c.type === "openProjectWorkPackageInline" && c.props?.size
+      (item: any): item is { type: string; props: { size: string } } =>
+        item.type === "openProjectWorkPackageInline" && item.props?.size
     );
     expect(chip).toBeDefined();
     expect(chip?.props.size).toBe("xxs");

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -1,128 +1,56 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
+import { BlockNoteEditor } from "@blocknote/core";
 import {
   getSizeFromCurrentBlock,
   insertWpChipIntoBlock,
   clearTriggerText,
 } from "../../../lib/components/HashMenu/editorUtils";
 
-type FakeContent = { type: string; text?: string; styles?: any; props?: any }[];
-
-function findCursorPos(fullText: string): number {
-  const match = fullText.match(/#+/);
-  if (!match || match.index === undefined) return fullText.length;
-  return match.index + match[0].length;
-}
-
-function makeFakeTiptap(block: { id: string; content: FakeContent }) {
-  const getFullText = () =>
-    block.content
-      .filter((n) => n.type === "text")
-      .map((n) => n.text ?? "")
-      .join("");
-
-  return {
-    get state() {
-      const fullText = getFullText();
-      const cursorPos = findCursorPos(fullText);
-
-      return {
-        selection: {
-          from: cursorPos,
-          $from: {
-            parentOffset: cursorPos,
-            parent: {
-              textBetween(start: number, end: number) {
-                const text = getFullText();
-                const absStart = Math.max(0, cursorPos - (end - start));
-                return text.slice(absStart, cursorPos);
-              },
-            },
-          },
-        },
-        tr: {
-          delete(start: number, end: number) {
-            return { _start: start, _end: end };
-          },
-        },
-      };
-    },
-    view: {
-      dispatch(tr: { _start: number; _end: number }) {
-        const fullText = getFullText();
-        const hashIndex = fullText.search(/#+/);
-        const newText = hashIndex <= 0 ? "" : fullText.slice(0, hashIndex);
-
-        if (newText === "") {
-          block.content = [];
-        } else {
-          const firstTextNode = block.content.find((n) => n.type === "text");
-          const nonTextNodes = block.content.filter((n) => n.type !== "text");
-          block.content = [
-            ...(firstTextNode ? [{ ...firstTextNode, text: newText }] : []),
-            ...nonTextNodes,
-          ];
-        }
-      },
-    },
-  };
-}
-
-function makeFakeEditor(content: FakeContent = []) {
-  const block = { id: "block-1", content: [...content] };
-  const inserted: FakeContent = [];
-
-  const editor: any = {
-    block,
-    inserted,
-    getTextCursorPosition: () => ({ block }),
-    getBlock: (id: string) => (id === block.id ? block : null),
-    updateBlock: (id: string, update: { content: FakeContent }) => {
-      if (id === block.id) block.content = update.content;
-    },
-    insertInlineContent: (content: FakeContent) => {
-      inserted.push(...content);
-    },
-    focus: vi.fn(),
-    setTextCursorPosition: vi.fn(),
-  };
-
-  editor._tiptapEditor = makeFakeTiptap(block);
-
+function createTestEditor(text: string) {
+  const editor = BlockNoteEditor.create({
+    initialContent: [{ type: "paragraph", content: text }],
+  });
+  
+  const block = editor.document[0];
+  editor.setTextCursorPosition(block, "end");
+  
   return editor;
 }
 
 describe("getSizeFromCurrentBlock", () => {
   it("returns xxs for #", () => {
-    const editor = makeFakeEditor([{ type: "text", text: "#foo" }]);
+    const editor = createTestEditor("#foo");
     expect(getSizeFromCurrentBlock(editor as any)).toBe("xxs");
   });
 
   it("returns xs for ##", () => {
-    const editor = makeFakeEditor([{ type: "text", text: "##foo" }]);
+    const editor = createTestEditor("##foo");
     expect(getSizeFromCurrentBlock(editor as any)).toBe("xs");
   });
 
   it("returns s for ### or more", () => {
-    const editor = makeFakeEditor([{ type: "text", text: "###foo" }]);
+    const editor = createTestEditor("###foo");
     expect(getSizeFromCurrentBlock(editor as any)).toBe("s");
 
-    const editor2 = makeFakeEditor([{ type: "text", text: "####foo" }]);
+    const editor2 = createTestEditor("####foo");
     expect(getSizeFromCurrentBlock(editor2 as any)).toBe("s");
   });
 
   it("returns xxs if no hashes", () => {
-    const editor = makeFakeEditor([{ type: "text", text: "foo" }]);
+    const editor = createTestEditor("foo");
     expect(getSizeFromCurrentBlock(editor as any)).toBe("xxs");
   });
 });
 
 describe("clearTriggerText", () => {
   it("removes # text and returns block id", () => {
-    const editor = makeFakeEditor([{ type: "text", text: "#foo" }]);
+    const editor = createTestEditor("#foo");
     const blockId = clearTriggerText(editor as any);
-    expect(blockId).toBe("block-1");
-    expect(editor.block.content).toEqual([]);
+    
+    expect(blockId).toBe(editor.document[0].id);
+    const block = editor.getBlock(editor.document[0].id);
+    expect(block?.content).toEqual([]); 
   });
 
   it("does nothing if no block", () => {
@@ -135,45 +63,45 @@ describe("clearTriggerText", () => {
   });
 
   it("keeps text before # and removes trigger", () => {
-    const editor = makeFakeEditor([{ type: "text", text: "Hello #foo" }]);
+    const editor = createTestEditor("Hello #foo");
     const blockId = clearTriggerText(editor as any);
-    expect(blockId).toBe("block-1");
-    expect(editor.block.content).toEqual([{ type: "text", text: "Hello " }]);
+    
+    expect(blockId).toBe(editor.document[0].id);
+    const block = editor.getBlock(editor.document[0].id);
+    expect((block?.content as any)[0].text).toBe("Hello ");
   });
 
   it("works with multiple # in the text", () => {
-    const editor = makeFakeEditor([{ type: "text", text: "Pre #one #two #three" }]);
+    const editor = createTestEditor("Pre #one #two #three");
     const blockId = clearTriggerText(editor as any);
-    expect(blockId).toBe("block-1");
-    expect(editor.block.content).toEqual([{ type: "text", text: "Pre " }]);
+    
+    expect(blockId).toBe(editor.document[0].id);
+    const block = editor.getBlock(editor.document[0].id);
+    
+    expect((block?.content as any)[0].text).toBe("Pre #one #two ");
   });
 });
 
 describe("insertWpChipIntoBlock", () => {
   it("adds a chip to the block content", () => {
-    const editor = makeFakeEditor([]);
+    const editor = createTestEditor("test");
+    
+    const insertSpy = vi.spyOn(editor, "insertInlineContent").mockImplementation(() => {});
+    vi.spyOn(editor, "focus").mockImplementation(() => {});
+
     insertWpChipIntoBlock(
       editor as any,
-      "block-1",
+      editor.document[0].id,
       { id: 1, subject: "Fix bug" } as any,
       "xxs"
     );
 
-    const inserted = editor.inserted;
-    expect(inserted.length).toBe(2);
-
-    const chip = inserted.find(
-      (item: any): item is { type: string; props: { size: string } } =>
-        item.type === "openProjectWorkPackageInline" && item.props?.size
-    );
-    expect(chip).toBeDefined();
-    expect(chip?.props.size).toBe("xxs");
-  });
-
-  it("does nothing if block not found", () => {
-    const editor = makeFakeEditor([]);
-    expect(() =>
-      insertWpChipIntoBlock(editor as any, "wrong-id", { id: 1 } as any, "xxs")
-    ).not.toThrow();
+    expect(insertSpy).toHaveBeenCalledWith([
+      {
+        type: "openProjectWorkPackageInline",
+        props: { wpid: "1", instanceId: expect.any(String), size: "xxs" },
+      },
+      { type: "text", text: " ", styles: {} },
+    ]);
   });
 });

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -1,21 +1,47 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from "vitest";
-import { BlockNoteEditor } from "@blocknote/core";
+import { describe, it, expect } from "vitest";
+import { BlockNoteEditor, BlockNoteSchema } from "@blocknote/core";
+import {
+  openProjectWorkPackageBlockSpec,
+  openProjectWorkPackageInlineSpec,
+} from "../../../lib";
 import {
   getSizeFromCurrentBlock,
-  insertWpChipIntoBlock,
-  clearTriggerText,
+  insertWpChip,
+  removeTriggerBeforeChip,
 } from "../../../lib/components/HashMenu/editorUtils";
+
+const schema = BlockNoteSchema.create().extend({
+  blockSpecs: {
+    openProjectWorkPackageBlock: openProjectWorkPackageBlockSpec(),
+  },
+  inlineContentSpecs: {
+    openProjectWorkPackageInline: openProjectWorkPackageInlineSpec,
+  },
+});
 
 function createTestEditor(text: string) {
   const editor = BlockNoteEditor.create({
+    schema,
     initialContent: [{ type: "paragraph", content: text }],
   });
-  
+
   const block = editor.document[0];
   editor.setTextCursorPosition(block, "end");
-  
+
   return editor;
+}
+
+function createEditorWithContent(content: any[]) {
+  return BlockNoteEditor.create({
+    schema,
+    initialContent: [
+      {
+        type: "paragraph",
+        content,
+      } as any,
+    ],
+  });
 }
 
 describe("getSizeFromCurrentBlock", () => {
@@ -30,11 +56,8 @@ describe("getSizeFromCurrentBlock", () => {
   });
 
   it("returns s for ### or more", () => {
-    const editor = createTestEditor("###foo");
-    expect(getSizeFromCurrentBlock(editor as any)).toBe("s");
-
-    const editor2 = createTestEditor("####foo");
-    expect(getSizeFromCurrentBlock(editor2 as any)).toBe("s");
+    expect(getSizeFromCurrentBlock(createTestEditor("###foo") as any)).toBe("s");
+    expect(getSizeFromCurrentBlock(createTestEditor("####foo") as any)).toBe("s");
   });
 
   it("returns xxs if no hashes", () => {
@@ -43,65 +66,130 @@ describe("getSizeFromCurrentBlock", () => {
   });
 });
 
-describe("clearTriggerText", () => {
-  it("removes # text and returns block id", () => {
-    const editor = createTestEditor("#foo");
-    const blockId = clearTriggerText(editor as any);
-    
-    expect(blockId).toBe(editor.document[0].id);
-    const block = editor.getBlock(editor.document[0].id);
-    expect(block?.content).toEqual([]); 
-  });
+describe("removeTriggerBeforeChip", () => {
+  it("removes the trailing # before the chip", () => {
+    const editor = createEditorWithContent([
+      { type: "text", text: "Hello #", styles: {} },
+      {
+        type: "openProjectWorkPackageInline",
+        props: { wpid: "1", instanceId: "test-iid", size: "xxs" },
+      },
+    ]);
 
-  it("does nothing if no block", () => {
-    const editor = {
-      _tiptapEditor: null,
-      getTextCursorPosition: () => null,
-      updateBlock: vi.fn(),
-    };
-    expect(clearTriggerText(editor as any)).toBeNull();
-  });
+    removeTriggerBeforeChip(editor as any, "test-iid");
 
-  it("keeps text before # and removes trigger", () => {
-    const editor = createTestEditor("Hello #foo");
-    const blockId = clearTriggerText(editor as any);
-    
-    expect(blockId).toBe(editor.document[0].id);
     const block = editor.getBlock(editor.document[0].id);
     expect((block?.content as any)[0].text).toBe("Hello ");
   });
 
-  it("works with multiple # in the text", () => {
-    const editor = createTestEditor("Pre #one #two #three");
-    const blockId = clearTriggerText(editor as any);
-    
-    expect(blockId).toBe(editor.document[0].id);
+  it("removes multiple trailing hashes (##, ###) before the chip", () => {
+    const editor = createEditorWithContent([
+      { type: "text", text: "Hello ###", styles: {} },
+      {
+        type: "openProjectWorkPackageInline",
+        props: { wpid: "1", instanceId: "test-iid", size: "s" },
+      },
+    ]);
+
+    removeTriggerBeforeChip(editor as any, "test-iid");
+
     const block = editor.getBlock(editor.document[0].id);
-    
+    expect((block?.content as any)[0].text).toBe("Hello ");
+  });
+
+  it("leaves earlier # in the line alone — removes only the trigger # nearest to the chip", () => {
+    const editor = createEditorWithContent([
+      { type: "text", text: "Pre #one #two #", styles: {} },
+      {
+        type: "openProjectWorkPackageInline",
+        props: { wpid: "1", instanceId: "test-iid", size: "xxs" },
+      },
+    ]);
+
+    removeTriggerBeforeChip(editor as any, "test-iid");
+
+    const block = editor.getBlock(editor.document[0].id);
     expect((block?.content as any)[0].text).toBe("Pre #one #two ");
+  });
+
+  it("removes the previous text node entirely when only # remains", () => {
+    const editor = createEditorWithContent([
+      { type: "text", text: "#", styles: {} },
+      {
+        type: "openProjectWorkPackageInline",
+        props: { wpid: "1", instanceId: "test-iid", size: "xxs" },
+      },
+    ]);
+
+    removeTriggerBeforeChip(editor as any, "test-iid");
+
+    const block = editor.getBlock(editor.document[0].id);
+    expect((block?.content as any)[0].type).toBe("openProjectWorkPackageInline");
+  });
+
+  it("does nothing if the chip is not found", () => {
+    const editor = createTestEditor("Hello #foo");
+    const before = JSON.stringify(editor.document);
+
+    removeTriggerBeforeChip(editor as any, "nonexistent-iid");
+
+    expect(JSON.stringify(editor.document)).toBe(before);
+  });
+
+  it("does nothing when there is no preceding text node", () => {
+    const editor = createEditorWithContent([
+      {
+        type: "openProjectWorkPackageInline",
+        props: { wpid: "1", instanceId: "test-iid", size: "xxs" },
+      },
+    ]);
+
+    const before = JSON.stringify(editor.document);
+    removeTriggerBeforeChip(editor as any, "test-iid");
+
+    expect(JSON.stringify(editor.document)).toBe(before);
   });
 });
 
-describe("insertWpChipIntoBlock", () => {
-  it("adds a chip to the block content", () => {
-    const editor = createTestEditor("test");
-    
-    const insertSpy = vi.spyOn(editor, "insertInlineContent").mockImplementation(() => {});
-    vi.spyOn(editor, "focus").mockImplementation(() => {});
+describe("insertWpChip", () => {
+  it("inserts a chip with the work package ID and size", () => {
+    const editor = createTestEditor("test ");
 
-    insertWpChipIntoBlock(
+    insertWpChip(
       editor as any,
-      editor.document[0].id,
       { id: 1, subject: "Fix bug" } as any,
-      "xxs"
+      "xxs",
     );
 
-    expect(insertSpy).toHaveBeenCalledWith([
-      {
-        type: "openProjectWorkPackageInline",
-        props: { wpid: "1", instanceId: expect.any(String), size: "xxs" },
-      },
-      { type: "text", text: " ", styles: {} },
-    ]);
+    const block = editor.getBlock(editor.document[0].id);
+    const chip = (block?.content as any[]).find(
+      (n) => n.type === "openProjectWorkPackageInline",
+    );
+
+    expect(chip).toBeDefined();
+    expect(chip.props.wpid).toBe("1");
+    expect(chip.props.size).toBe("xxs");
+    expect(chip.props.instanceId).toEqual(expect.any(String));
+  });
+
+  it("inserts a trailing space after the chip", () => {
+    const editor = createTestEditor("test ");
+
+    insertWpChip(
+      editor as any,
+      { id: 1, subject: "Fix bug" } as any,
+      "xxs",
+    );
+
+    const block = editor.getBlock(editor.document[0].id);
+    const content = block?.content as any[];
+
+    const chipIdx = content.findIndex(
+      (n) => n.type === "openProjectWorkPackageInline",
+    );
+    const afterChip = content[chipIdx + 1];
+
+    expect(afterChip?.type).toBe("text");
+    expect(afterChip?.text).toBe(" ");
   });
 });

--- a/test/lib/components/integration/editor.inlineChip.browser.test.tsx
+++ b/test/lib/components/integration/editor.inlineChip.browser.test.tsx
@@ -13,7 +13,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaSlashMenu();
 
-    await expect.element(page.getByText('#123').first()).toBeVisible();
+    await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).toBeVisible();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
@@ -23,7 +23,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('#');
 
-    await expect.element(page.getByText('#123').first()).toBeVisible();
+    await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
   });
@@ -32,7 +32,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('##');
 
-    await expect.element(page.getByText('#123').first()).toBeVisible();
+    await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
   });
@@ -41,7 +41,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('###');
 
-    await expect.element(page.getByText('#123').first()).toBeVisible();
+    await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).toBeVisible();
   });
@@ -55,7 +55,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
-    await expect.element(page.getByText('#123').first()).toBeVisible();
+    await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact', exact: true }));
 
-    await expect.element(page.getByText('#123').first()).toBeVisible();
+    await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
@@ -81,7 +81,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
-    await expect.element(page.getByText('#123').first()).toBeVisible();
+    await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();

--- a/test/lib/components/integration/editor.inlineChip.browser.test.tsx
+++ b/test/lib/components/integration/editor.inlineChip.browser.test.tsx
@@ -13,7 +13,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaSlashMenu();
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).toBeVisible();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
@@ -23,7 +23,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('#');
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
   });
@@ -32,7 +32,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('##');
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
   });
@@ -41,7 +41,7 @@ describe('Inline chip - insert', () => {
     renderEditor();
     await insertInlineChipViaHash('###');
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).toBeVisible();
   });
@@ -55,7 +55,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact', exact: true }));
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
@@ -81,7 +81,7 @@ describe('Inline chip - resize', () => {
     await openInlineChipSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
-    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('#123').first()).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();

--- a/test/lib/components/integration/insertion.browser.test.tsx
+++ b/test/lib/components/integration/insertion.browser.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+
+describe('Hash trigger - data loss regression', () => {
+  it('preserves text before and after the # trigger', async () => {
+    renderEditor();
+
+    const editor = page.getByRole('textbox');
+    await userEvent.click(editor);
+    await userEvent.type(editor, 'Hello world example');
+
+    await userEvent.keyboard('{Home}{ArrowRight>5}');
+    await userEvent.keyboard('#bug');
+
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await userEvent.keyboard('{Enter}');
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(editor).toHaveTextContent(/Hello.*world example/);
+  });
+
+  it('preserves surrounding text when inserting an S-size chip via ###', async () => {
+    renderEditor();
+
+    const editor = page.getByRole('textbox');
+    await userEvent.click(editor);
+    await userEvent.type(editor, 'before after');
+
+    await userEvent.keyboard('{Home}{ArrowRight>6}');
+    await userEvent.keyboard('###bug');
+
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await userEvent.keyboard('{Enter}');
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByText('In Progress')).toBeVisible();
+    await expect.element(editor).toHaveTextContent(/before.*after/);
+    await expect.element(editor).not.toHaveTextContent('##');
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74325

# What are you trying to accomplish?
Fix a data loss bug where inserting `#` in the middle of a text block would silently delete all content after the cursor position.

# What approach did you choose and why?
The root cause was a combination of two issues: the trigger-cleanup logic was operating on the wrong abstraction (slicing BlockNote's content tree, which discarded everything after the cursor), and the `SuggestionMenuController` had a custom `onItemClick` override that prevented BlockNote's default handler from running - leading to a cascade of compensation logic (manual block cleanup, `requestAnimationFrame`, keyboard-vs-mouse path detection).

The fix replaces both layers entirely:

- **Trigger cleanup** now uses BlockNote's public API only (`getTextCursorPosition`, `insertInlineContent`, `updateBlock`). The chip is inserted first, then located by its `instanceId`, and the trailing `#query` is stripped from the text node right before it. No TipTap, no cursor offsets - the `instanceId` acts as a position anchor.

- **`HashWpMenu` is now a pure presentational component.** Removing the `onItemClick` override on `SuggestionMenuController` lets BlockNote's default handler manage trigger removal and Enter behavior correctly. This eliminated `requestAnimationFrame`, `isKeyboardEnter` detection, manual `removeBlocks` cleanup, and the custom mutation of `items[index].onItemClick`. The insertion logic now lives in `getHashItems`, where chip `size` is also captured (it must be read while the `#`/`##`/`###` trigger is still in the block - by click time BlockNote has already stripped it).

Considered using `setTextCursorPosition` + backward delete (as suggested in review) instead of `updateBlock` on `block.content`, but went with the latter since the `instanceId` anchor avoids working with cursor offsets altogether.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
