### PR TITLE
bug/74327: Сards converting to hash links on copy-paste and DnD

### DIFF
--- a/lib/components/InlineWorkPackage/spec.tsx
+++ b/lib/components/InlineWorkPackage/spec.tsx
@@ -1,6 +1,5 @@
 import { createReactInlineContentSpec } from "@blocknote/react";
 import { InlineWorkPackageChip } from "./InlineWorkPackageChip";
-import { linkToWorkPackage } from "../../services/openProjectApi";
 
 export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
   {
@@ -21,16 +20,14 @@ export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
       const { wpid, instanceId, size } = inlineContent.props;
       if (!wpid || wpid.startsWith("pending:")) return <></>;
       return (
-        <a
-          href={linkToWorkPackage(Number(wpid))}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-inline-wp={wpid}
-          data-inline-wp-instance={instanceId}
-          data-inline-wp-size={size ?? "s"}
+        <span
+          data-inline-content-type="openProjectWorkPackageInline"
+          data-wpid={wpid}
+          data-instance-id={instanceId}
+          data-size={size}
         >
           #{wpid}
-        </a>
+        </span>
       );
     },
   }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74327

# What are you trying to accomplish?
Fix inline work package chips being converted to plain hash links after copy-paste or drag-and-drop.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Replaced the `<a>` tag with a `<span>` carrying data attributes that BlockNote's parser can use to reconstruct the inline chip. This is the standard BlockNote pattern for custom inline content serialization.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
