### PR TITLE
Copy/paste of a single inline block(chip) does not work

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -1,5 +1,5 @@
 import { BlockNoteEditor } from "@blocknote/core";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { useWorkPackage } from "../../hooks/useWorkPackage";
@@ -87,6 +87,34 @@ export const BlockWorkPackageComponent = ({
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOptionsOpen]);
+
+  const handleCopy = useCallback(
+    (e: ClipboardEvent) => {
+      if (!isOptionsOpen || !block.props.wpid) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const wpid = block.props.wpid;
+
+      e.clipboardData?.setData("text/plain", `#${wpid}`);
+      e.clipboardData?.setData(
+        "text/html",
+        `<div data-block-content-type="openProjectWorkPackageBlock" data-wpid="${wpid}" data-size="${cardSize}" data-initialized="true">#${wpid}</div>`,
+      );
+    },
+    [isOptionsOpen, block.props.wpid, cardSize],
+  );
+
+  useEffect(() => {
+    if (!isOptionsOpen) return;
+
+    // Chrome doesn't expose clipboardData on copy events that bubble past a
+    // shadow boundary - attach to the nearest root to get a writable event.
+    const root = (cardRef.current?.getRootNode() ?? document) as Document | ShadowRoot;
+    root.addEventListener("copy", handleCopy as EventListener);
+    return () => root.removeEventListener("copy", handleCopy as EventListener);
+  }, [isOptionsOpen, handleCopy]);
 
   const handleConvertToInline = (size: InlineWpSize) => {
     if (!selectedWorkPackage) return;

--- a/lib/components/BlockWorkPackage/spec.tsx
+++ b/lib/components/BlockWorkPackage/spec.tsx
@@ -22,5 +22,33 @@ export const openProjectWorkPackageBlockSpec = createReactBlockSpec(
         editor={props.editor as any}
       />
     ),
+
+    toExternalHTML: ({ block }) => {
+      const { wpid, size, initialized } = block.props;
+      if (!wpid) return <></>;
+      return (
+        <div
+          data-block-content-type="openProjectWorkPackageBlock"
+          data-wpid={String(wpid)}
+          data-size={size ?? "m"}
+          data-initialized={String(initialized ?? true)}
+        >
+          #{wpid}
+        </div>
+      );
+    },
+
+    parse: (element) => {
+      if (element.getAttribute("data-block-content-type") !== "openProjectWorkPackageBlock") {
+        return undefined;
+      }
+      const wpid = element.getAttribute("data-wpid");
+      const size = element.getAttribute("data-size") ?? "m";
+      return {
+        wpid: wpid ? Number(wpid) : undefined,
+        size,
+        initialized: true,
+      };
+    },
   }
 );

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { useWorkPackage } from "../../hooks/useWorkPackage";
 import { useColors } from "../../services/colors";
@@ -67,6 +67,28 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, [isSelected]);
 
+  const handleCopy = useCallback(
+    (e: ClipboardEvent) => {
+      if (!isSelected || !wp || !wpid) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      e.clipboardData?.setData("text/plain", `#${wpid}`);
+      e.clipboardData?.setData(
+        "text/html",
+        `<span data-inline-content-type="openProjectWorkPackageInline" data-wpid="${wpid}" data-instance-id="${instanceId}" data-size="${size}">#${wpid}</span>`,
+      );
+    },
+    [isSelected, wp, wpid, instanceId, size],
+  );
+
+  useEffect(() => {
+    if (!isSelected) return;
+    document.addEventListener("copy", handleCopy);
+    return () => document.removeEventListener("copy", handleCopy);
+  }, [isSelected, handleCopy]);
+
   // Pending: waiting for user to pick a WP via search
   if (pendingCallbacks) {
     return (
@@ -108,19 +130,6 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-
-          // Select the chip node in the browser so Ctrl+C copies it correctly.
-          // Without this, ProseMirror has no selection and copy produces nothing.
-          if (chipRef.current) {
-            const selection = window.getSelection();
-            if (selection) {
-              const range = document.createRange();
-              range.selectNode(chipRef.current);
-              selection.removeAllRanges();
-              selection.addRange(range);
-            }
-          }
-
           setIsSelected((prev) => !prev);
         }}
       >
@@ -133,11 +142,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
             wp={wp}
             currentSize={size}
             instanceId={instanceId}
-            onClose={() => {
-              setIsSelected(false);
-              // Clear selection when closing popover
-              window.getSelection()?.removeAllRanges();
-            }}
+            onClose={() => setIsSelected(false)}
             onResize={(newSize) => {
               wpBridge.resize({ instanceId, wpid: wp.id, size: newSize });
             }}

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -108,6 +108,19 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
+
+          // Select the chip node in the browser so Ctrl+C copies it correctly.
+          // Without this, ProseMirror has no selection and copy produces nothing.
+          if (chipRef.current) {
+            const selection = window.getSelection();
+            if (selection) {
+              const range = document.createRange();
+              range.selectNode(chipRef.current);
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
+          }
+
           setIsSelected((prev) => !prev);
         }}
       >
@@ -120,7 +133,11 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
             wp={wp}
             currentSize={size}
             instanceId={instanceId}
-            onClose={() => setIsSelected(false)}
+            onClose={() => {
+              setIsSelected(false);
+              // Clear selection when closing popover
+              window.getSelection()?.removeAllRanges();
+            }}
             onResize={(newSize) => {
               wpBridge.resize({ instanceId, wpid: wp.id, size: newSize });
             }}

--- a/lib/components/InlineWorkPackage/spec.tsx
+++ b/lib/components/InlineWorkPackage/spec.tsx
@@ -30,5 +30,16 @@ export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
         </span>
       );
     },
+
+    parse: (element) => {
+      if (element.getAttribute("data-inline-content-type") !== "openProjectWorkPackageInline") {
+        return undefined;
+      }
+      return {
+        wpid: element.getAttribute("data-wpid") ?? "",
+        instanceId: element.getAttribute("data-instance-id") ?? "",
+        size: element.getAttribute("data-size") ?? "s",
+      };
+    },
   }
 );


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74538

# What are you trying to accomplish?
Fix copy/paste for inline work package chips.

Clicking a chip opened the options popover but did not create a browser selection, so ProseMirror had nothing to copy. Ctrl+C produced no output. The previous fix using document.createRange() + window.getSelection().addRange() worked in Firefox but was ignored by Chrome.

# What approach did you choose and why?
Instead of manipulating the DOM selection, we now intercept the native copy event and manually write the serialized chip data to the clipboard. This approach works across all browsers since it fires before the browser decides what to copy, giving us full control over clipboard contents.

For block work packages, the listener is attached to the nearest shadow root via getRootNode() so clipboardData is correctly exposed in shadow DOM environments.

Additionally, toExternalHTML and parse were added to both specs so BlockNote can correctly serialize and deserialize work package nodes on copy/paste.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
