### PR TITLE
Inconsistent inline chip heights in text flow

### DIFF
--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -33,6 +33,7 @@ const InlineChip = styled.span.attrs({
   box-shadow: ${({ selected }) => (selected ? CHIP_STYLES.focusShadow : "none")};
   position: relative;
   max-width: 100%;
+  line-height: 1;
 `;
 
 export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkPackageChipProps) => {

--- a/lib/components/Search/SearchContainer.tsx
+++ b/lib/components/Search/SearchContainer.tsx
@@ -24,6 +24,7 @@ export const SearchContainer = styled.div.attrs({
   background-color: var(--bn-colors-menu-background, #fff);
   box-shadow: var(--bn-shadow-medium);
   border-radius: var(--bn-border-radius-large);
+  line-height: 1.5;
 
   @media (min-width: 1120px) {
     width: ${({ $floating }) => ($floating ? "400px" : "500px")};

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -75,7 +75,6 @@ export const WorkPackageStatus = styled.div.attrs({
       font-weight: 600;
       color: var(--bn-colors-editor-text) !important;
       flex-shrink: 0;
-      line-height: 1.4;
       display: inline-flex;
       align-items: center;
       gap: 4px;

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -4,8 +4,8 @@ export const CHIP_STYLES = {
   gap: "6px",
   padding: {
     xxs: "2.5px 6px",
-    xs: "1px 6px",
-    s: "1px 6px",
+    xs: "1.5px 6px",
+    s: "1.5px 6px",
   },
 
   fontSize: "12px",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74341

# What are you trying to accomplish?
Fix inline work package chip causing editor rows to exceed 21px in height.

The `InlineChip` component inherited the parent editor's `line-height` (~1.5), which pushed each row to ~23.75px instead of the intended 21px. Additionally, the search dropdown popover lost its internal spacing as a side effect of the fix.

## Screenshots
<img width="808" height="274" alt="image" src="https://github.com/user-attachments/assets/afb712eb-af8a-46ec-9b4b-c6472a8557b8" />


# What approach did you choose and why?
Set `line-height: 1` on `InlineChip` to prevent it from inheriting the parent editor's line-height. This stops the chip from inflating the row height beyond what the chip's own dimensions require.

To restore spacing in the search dropdown popover (which is rendered as a child of `InlineChip` and inherits its `line-height`), added `line-height: 1.5` explicitly on `SearchContainer`.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
