### PR TITLE
Arrow-down selection for link work package block prevented by tooltip

### DIFF
--- a/lib/components/Search/SearchDropdown.tsx
+++ b/lib/components/Search/SearchDropdown.tsx
@@ -41,6 +41,11 @@ const SearchInputWithIcon = styled(SearchInput)`
   &:focus {
     outline: none;
   }
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-decoration {
+    -webkit-appearance: none;
+    appearance: none;
+  }
 `;
 
 export const SearchDropdown = ({ onSelect, onCancel, autoFocus, renderItem }: SearchDropdownProps) => {
@@ -84,14 +89,19 @@ export const SearchDropdown = ({ onSelect, onCancel, autoFocus, renderItem }: Se
 
         <SearchInputWithIcon
           ref={inputRef}
-          type="text"
+          type="search"
+          autoComplete="off"
+          spellCheck={false}
           placeholder={t("search.placeholder")}
           value={searchQuery}
           onChange={(e) => {
             setSearchQuery(e.target.value);
             setIsDropdownOpen(e.target.value.length > 0);
           }}
-          onKeyDown={handleKeyDown}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            handleKeyDown(e);
+          }}
           onBlur={() => {
             // Delay to allow onMouseDown on dropdown items to fire before blur.
             // Without this, clicking a result closes the dropdown before onSelect is called.

--- a/test/lib/components/integration/searchDropdown.browser.test.tsx
+++ b/test/lib/components/integration/searchDropdown.browser.test.tsx
@@ -14,7 +14,7 @@ describe('SearchDropdown', () => {
       <SearchDropdown onSelect={vi.fn()} onCancel={vi.fn()} renderItem={renderItem} />
     );
 
-    const input = page.getByRole('textbox');
+    const input = page.getByRole('searchbox');
     await userEvent.type(input, 'Fix');
 
     // Wait for debounce + MSW response
@@ -28,7 +28,7 @@ describe('SearchDropdown', () => {
       <SearchDropdown onSelect={onSelect} onCancel={vi.fn()} renderItem={renderItem} />
     );
 
-    await userEvent.type(page.getByRole('textbox'), 'bug');
+    await userEvent.type(page.getByRole('searchbox'), 'bug');
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
 
     await userEvent.click(page.getByText('Fix login bug'));
@@ -43,7 +43,7 @@ describe('SearchDropdown', () => {
       <SearchDropdown onSelect={vi.fn()} onCancel={onCancel} renderItem={renderItem} />
     );
 
-    const input = page.getByRole('textbox');
+    const input = page.getByRole('searchbox');
     await userEvent.click(input);
     await userEvent.keyboard('{Escape}');
 
@@ -56,7 +56,7 @@ describe('SearchDropdown', () => {
         <SearchDropdown onSelect={onSelect} onCancel={vi.fn()} renderItem={renderItem} />
     );
 
-    await userEvent.type(page.getByRole('textbox'), 'mode');
+    await userEvent.type(page.getByRole('searchbox'), 'mode');
     await expect.element(page.getByText('Add dark mode')).toBeVisible();
 
     await userEvent.keyboard('{ArrowDown}{Enter}');
@@ -72,7 +72,7 @@ describe('SearchDropdown', () => {
       <SearchDropdown onSelect={vi.fn()} onCancel={vi.fn()} renderItem={renderItem} />
     );
 
-    await userEvent.type(page.getByRole('textbox'), 'any');
+    await userEvent.type(page.getByRole('searchbox'), 'any');
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
 
     const items = page.getByTestId('dropdown-item');


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/blocknote-extensions/work_packages/74393

# What are you trying to accomplish?
Fix arrow-down key navigation being blocked in the work package picker dropdown.

When the user typed in the search input, a browser-native tooltip (search suggestion popup)
appeared over the dropdown list and captured keyboard events, preventing arrow key selection
from working at all.

# What approach did you choose and why?
- Changed input `type` from `"text"` to `"search"` - enables search-specific CSS resets
- Added `autoComplete="off"` - suppresses the browser's native suggestion popup that was capturing keyboard events
- Added `e.stopPropagation()` on `onKeyDown` - prevents BlockNote's outer `SuggestionMenuController` from stealing arrow key events before our handler runs
- Added CSS `::webkit-search-cancel-button` reset - hides the native clear button that `type="search"` adds in Chrome/Safari

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
