### PR TITLE
fix: work-package block exports as a real markdown link

### DIFF
--- a/lib/components/BlockWorkPackage/spec.tsx
+++ b/lib/components/BlockWorkPackage/spec.tsx
@@ -1,6 +1,7 @@
 import { createBlockConfig } from "@blocknote/core";
 import { createReactBlockSpec } from "@blocknote/react";
 import { BlockWorkPackageComponent } from "./BlockWorkPackage";
+import { linkToWorkPackage } from "../../services/openProjectApi";
 
 export const blockConfig = createBlockConfig((() => ({
   type: "openProjectWorkPackageBlock" as const,
@@ -25,16 +26,17 @@ export const openProjectWorkPackageBlockSpec = createReactBlockSpec(
 
     toExternalHTML: ({ block }) => {
       const { wpid, size, initialized } = block.props;
-      if (!wpid) return <></>;
+      if (!wpid || wpid <= 0) return <></>;
       return (
-        <div
+        <a
+          href={linkToWorkPackage(wpid)}
           data-block-content-type="openProjectWorkPackageBlock"
           data-wpid={String(wpid)}
           data-size={size ?? "m"}
           data-initialized={String(initialized ?? true)}
         >
           #{wpid}
-        </div>
+        </a>
       );
     },
 

--- a/lib/components/BlockWorkPackage/spec.tsx
+++ b/lib/components/BlockWorkPackage/spec.tsx
@@ -2,6 +2,7 @@ import { createBlockConfig } from "@blocknote/core";
 import { createReactBlockSpec } from "@blocknote/react";
 import { BlockWorkPackageComponent } from "./BlockWorkPackage";
 import { linkToWorkPackage } from "../../services/openProjectApi";
+import { hashesForSize } from "../WorkPackage/types";
 
 export const blockConfig = createBlockConfig((() => ({
   type: "openProjectWorkPackageBlock" as const,
@@ -35,7 +36,7 @@ export const openProjectWorkPackageBlockSpec = createReactBlockSpec(
           data-size={size ?? "m"}
           data-initialized={String(initialized ?? true)}
         >
-          #{wpid}
+          {hashesForSize(size)}{wpid}
         </a>
       );
     },

--- a/lib/components/InlineWorkPackage/spec.tsx
+++ b/lib/components/InlineWorkPackage/spec.tsx
@@ -1,6 +1,7 @@
 import { createReactInlineContentSpec } from "@blocknote/react";
 import { InlineWorkPackageChip } from "./InlineWorkPackageChip";
 import { linkToWorkPackage } from "../../services/openProjectApi";
+import { hashesForSize } from "../WorkPackage/types";
 
 export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
   {
@@ -30,7 +31,7 @@ export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
           data-instance-id={instanceId}
           data-size={size}
         >
-          #{wpid}
+          {hashesForSize(size)}{wpid}
         </a>
       );
     },

--- a/lib/components/InlineWorkPackage/spec.tsx
+++ b/lib/components/InlineWorkPackage/spec.tsx
@@ -1,5 +1,6 @@
 import { createReactInlineContentSpec } from "@blocknote/react";
 import { InlineWorkPackageChip } from "./InlineWorkPackageChip";
+import { linkToWorkPackage } from "../../services/openProjectApi";
 
 export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
   {
@@ -19,15 +20,18 @@ export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
     toExternalHTML: ({ inlineContent }) => {
       const { wpid, instanceId, size } = inlineContent.props;
       if (!wpid || wpid.startsWith("pending:")) return <></>;
+      const numericWpid = Number(wpid);
+      if (!Number.isFinite(numericWpid) || numericWpid <= 0) return <></>;
       return (
-        <span
+        <a
+          href={linkToWorkPackage(numericWpid)}
           data-inline-content-type="openProjectWorkPackageInline"
           data-wpid={wpid}
           data-instance-id={instanceId}
           data-size={size}
         >
           #{wpid}
-        </span>
+        </a>
       );
     },
 

--- a/lib/components/WorkPackage/types.ts
+++ b/lib/components/WorkPackage/types.ts
@@ -2,3 +2,16 @@ export type InlineWpSize = "xxs" | "xs" | "s";
 export type BlockWpSize = "m" | "l" | "xl";
 
 export type WpSize = InlineWpSize | BlockWpSize;
+
+// Visible link-text prefix for a work-package reference, sized to match the
+// chip variant. Used by both inline and block toExternalHTML so the markdown
+// export carries the size information visually:
+//   xxs (tiny inline)            → "#"
+//   xs  (compact inline)         → "##"
+//   s   (regular inline)         → "###"
+//   m / l / xl (block + preview) → "###"
+export function hashesForSize(size: string | undefined): string {
+  if (size === "xxs") return "#";
+  if (size === "xs") return "##";
+  return "###";
+}

--- a/test/lib/components/BlockWorkPackage/spec.test.tsx
+++ b/test/lib/components/BlockWorkPackage/spec.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { openProjectWorkPackageBlockSpec } from "../../../../lib/components/BlockWorkPackage/spec";
+import { initOpenProjectApi } from "../../../../lib/services/openProjectApi";
+
+type BlockArg = {
+  id: string;
+  type: string;
+  props: { wpid?: number; size?: string; initialized?: boolean };
+  content: undefined;
+  children: never[];
+};
+
+function renderExternalHTML(props: BlockArg["props"]): HTMLElement {
+  const spec = openProjectWorkPackageBlockSpec();
+  const result = spec.implementation.toExternalHTML!.call(
+    {},
+    {
+      id: "b1",
+      type: "openProjectWorkPackageBlock",
+      props,
+      content: undefined,
+      children: [],
+    } as never,
+    { headless: true } as never,
+    { nestingLevel: 0 },
+  );
+  return (result as { dom: HTMLElement }).dom;
+}
+
+describe("openProjectWorkPackageBlockSpec toExternalHTML", () => {
+  it("emits an anchor linking to the work package so blocksToMarkdownLossy produces a real link", () => {
+    initOpenProjectApi({ baseUrl: "https://example.com" });
+
+    const dom = renderExternalHTML({ wpid: 123, size: "m", initialized: true });
+    const anchor = dom.querySelector("a");
+
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute("href")).toBe("https://example.com/wp/123");
+    expect(anchor!.getAttribute("data-block-content-type")).toBe("openProjectWorkPackageBlock");
+    expect(anchor!.getAttribute("data-wpid")).toBe("123");
+    expect(anchor!.getAttribute("data-size")).toBe("m");
+    expect(anchor!.textContent).toBe("#123");
+  });
+
+  it("respects the configured baseUrl", () => {
+    initOpenProjectApi({ baseUrl: "https://op.internal/" });
+
+    const dom = renderExternalHTML({ wpid: 42, size: "s", initialized: true });
+    const anchor = dom.querySelector("a");
+
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute("href")).toBe("https://op.internal/wp/42");
+  });
+
+  it("emits no link for a missing wpid", () => {
+    initOpenProjectApi({ baseUrl: "https://example.com" });
+
+    const dom = renderExternalHTML({ wpid: undefined, size: "m", initialized: false });
+
+    expect(dom.querySelector("a")).toBeNull();
+    expect(dom.textContent).toBe("");
+  });
+
+  it("emits no link for a non-positive wpid", () => {
+    initOpenProjectApi({ baseUrl: "https://example.com" });
+
+    const dom = renderExternalHTML({ wpid: 0, size: "m", initialized: true });
+
+    expect(dom.querySelector("a")).toBeNull();
+  });
+});

--- a/test/lib/components/BlockWorkPackage/spec.test.tsx
+++ b/test/lib/components/BlockWorkPackage/spec.test.tsx
@@ -40,7 +40,16 @@ describe("openProjectWorkPackageBlockSpec toExternalHTML", () => {
     expect(anchor!.getAttribute("data-block-content-type")).toBe("openProjectWorkPackageBlock");
     expect(anchor!.getAttribute("data-wpid")).toBe("123");
     expect(anchor!.getAttribute("data-size")).toBe("m");
-    expect(anchor!.textContent).toBe("#123");
+    expect(anchor!.textContent).toBe("###123");
+  });
+
+  it("uses three hashes for any block size (m / l / xl)", () => {
+    initOpenProjectApi({ baseUrl: "https://example.com" });
+
+    for (const size of ["m", "l", "xl"]) {
+      const dom = renderExternalHTML({ wpid: 7, size, initialized: true });
+      expect(dom.querySelector("a")!.textContent).toBe("###7");
+    }
   });
 
   it("respects the configured baseUrl", () => {


### PR DESCRIPTION
## Precodition

BlockNote was bumped to >=0.0.51.

## Summary

Fixes a regression where work-package block content was effectively lost when serialized for clipboard copy or hocuspocus's server-side description (markdown) export.

`toExternalHTML` used to return a plain `<div data-...>#123</div>`. The markdown serializer dropped it. Now we emit `<a href=\"${linkToWorkPackage(wpid)}\" data-...>#123</a>`, which markdown-serializes to a proper `[#123](https://.../wp/123)`.

## Details

- `lib/components/BlockWorkPackage/spec.tsx`: replace `<div>` with `<a href>`; defensive skip for missing or non-positive wpid (avoids `linkToWorkPackage` throwing during export).
- `parse` still inspects `data-block-content-type` regardless of tag, so paste-from-HTML round-trips unchanged.
- New unit test (jsdom env) invokes `spec.implementation.toExternalHTML(...)` directly and asserts the rendered anchor's href / text / data-attrs.

## Test plan

- [x] `npm run test:unit` — 35 tests pass (4 new)
- [x] `npm run build` — clean

## Refs

- https://community.openproject.org/wp/74654