### PR TITLE
[#74115] adapt work package link blocks for project based semantic work package identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ op-blocknote-extensions-*
 
 .env
 !.env.*
+
+# test screenshots
+test/lib/components/integration/__screenshots__/*

--- a/lib/components/BlockWorkPackage/BlockCards.tsx
+++ b/lib/components/BlockWorkPackage/BlockCards.tsx
@@ -16,6 +16,7 @@ import {
   statusTextColor,
   statusBackgroundColor,
 } from "../../services/colors";
+import { formatWorkPackageId } from "../../services/utils";
 
 const DESCRIPTION_MAX_CHARS = 300;
 
@@ -109,7 +110,7 @@ export const BlockCardM = ({
       <WorkPackageType $color={typeColor(workPackage)}>
         {workPackage._links?.type?.title}
       </WorkPackageType>
-      <WorkPackageId>#{workPackage.id}</WorkPackageId>
+      <WorkPackageId>{formatWorkPackageId(workPackage.displayId)}</WorkPackageId>
       <WorkPackageStatus
         $baseColor={statusColor(workPackage)}
         $borderColor={statusBorderColor()}
@@ -144,7 +145,7 @@ export const BlockCardL = ({
       <WorkPackageType $color={typeColor(workPackage)}>
         {workPackage._links?.type?.title}
       </WorkPackageType>
-      <WorkPackageId>#{workPackage.id}</WorkPackageId>
+      <WorkPackageId>{formatWorkPackageId(workPackage.displayId)}</WorkPackageId>
       <WorkPackageStatus
         $baseColor={statusColor(workPackage)}
         $borderColor={statusBorderColor()}
@@ -193,7 +194,7 @@ export const BlockCardXL = ({
         <WorkPackageType $color={typeColor(workPackage)}>
           {workPackage._links?.type?.title}
         </WorkPackageType>
-        <WorkPackageId>#{workPackage.id}</WorkPackageId>
+        <WorkPackageId>{formatWorkPackageId(workPackage.displayId)}</WorkPackageId>
         <WorkPackageStatus
           $baseColor={statusColor(workPackage)}
           $borderColor={statusBorderColor()}

--- a/lib/components/BlockWorkPackage/BlockCards.tsx
+++ b/lib/components/BlockWorkPackage/BlockCards.tsx
@@ -28,7 +28,7 @@ export interface BlockCardSharedProps {
 }
 
 function buildTitle(workPackage: WorkPackage, linkTitle: boolean) {
-  const href = linkToWorkPackage(workPackage.id);
+  const href = linkToWorkPackage(workPackage.displayId);
   if (!linkTitle) return workPackage.subject;
   return (
     <WorkPackageTitleLink

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -13,6 +13,7 @@ import { WpOptionsPopover } from "../WorkPackage/OptionsPopover";
 import { SearchContainer, SearchLabel } from "../Search/SearchContainer";
 import { SearchDropdown } from "../Search/SearchDropdown";
 import { defaultWpVariables } from "../WorkPackage/atoms";
+import { formatWorkPackageId } from "../../services/utils";
 
 const Block = styled.div.attrs({ className: "op-bn-extensions" })`
   ${defaultWpVariables}
@@ -95,14 +96,15 @@ export const BlockWorkPackageComponent = ({
       e.stopPropagation();
 
       const wpid = block.props.wpid;
+      const formattedId = formatWorkPackageId(selectedWorkPackage?.displayId ?? String(wpid));
 
-      e.clipboardData?.setData("text/plain", `#${wpid}`);
+      e.clipboardData?.setData("text/plain", formattedId);
       e.clipboardData?.setData(
         "text/html",
-        `<div data-block-content-type="openProjectWorkPackageBlock" data-wpid="${wpid}" data-size="${cardSize}" data-initialized="true">#${wpid}</div>`,
+        `<div data-block-content-type="openProjectWorkPackageBlock" data-wpid="${wpid}" data-size="${cardSize}" data-initialized="true">${formattedId}</div>`,
       );
     },
-    [isOptionsOpen, block.props.wpid, cardSize],
+    [isOptionsOpen, block.props.wpid, cardSize, selectedWorkPackage],
   );
 
   useEffect(() => {

--- a/lib/components/InlineWorkPackage/InlineChips.tsx
+++ b/lib/components/InlineWorkPackage/InlineChips.tsx
@@ -19,7 +19,7 @@ import { formatWorkPackageId } from "../../services/utils";
 
 const titleLinkProps = (wp: WorkPackage) => ({
   as: "a" as const,
-  href: linkToWorkPackage(wp.id),
+  href: linkToWorkPackage(wp.displayId),
   target: "_blank" as const,
   rel: "noopener noreferrer",
   $compact: true,

--- a/lib/components/InlineWorkPackage/InlineChips.tsx
+++ b/lib/components/InlineWorkPackage/InlineChips.tsx
@@ -15,6 +15,7 @@ import {
   WorkPackageStatus,
   WorkPackageTitleLink,
 } from "../WorkPackage/atoms";
+import { formatWorkPackageId } from "../../services/utils";
 
 const titleLinkProps = (wp: WorkPackage) => ({
   as: "a" as const,
@@ -28,14 +29,14 @@ const titleLinkProps = (wp: WorkPackage) => ({
 // XXS — "#ID"  (padding 2px 8px)
 export const WpChipXXS = ({ wp }: { wp: WorkPackage }) => (
   <ChipBaseXXS>
-    <WorkPackageId as="span" $compact>#{wp.id}</WorkPackageId>
+    <WorkPackageId as="span" $compact>{formatWorkPackageId(wp.displayId)}</WorkPackageId>
   </ChipBaseXXS>
 );
 
 // XS — "#ID  TYPE  [Title]"  (padding 8px)
 export const WpChipXS = ({ wp }: { wp: WorkPackage }) => (
   <ChipBaseXS>
-    <WorkPackageId as="span" $compact>#{wp.id}</WorkPackageId>
+    <WorkPackageId as="span" $compact>{formatWorkPackageId(wp.displayId)}</WorkPackageId>
     {wp._links?.type?.title && (
       <WorkPackageType as="span" $compact $color={typeColor(wp)}>
         {wp._links.type.title}
@@ -50,7 +51,7 @@ export const WpChipXS = ({ wp }: { wp: WorkPackage }) => (
 // S — "#ID  TYPE  [Status]  [Title]"  (padding 8px)
 export const WpChipS = ({ wp }: { wp: WorkPackage }) => (
   <ChipBaseS>
-    <WorkPackageId as="span" $compact>#{wp.id}</WorkPackageId>
+    <WorkPackageId as="span" $compact>{formatWorkPackageId(wp.displayId)}</WorkPackageId>
     {wp._links?.type?.title && (
       <WorkPackageType as="span" $compact $color={typeColor(wp)}>
         {wp._links.type.title}

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -131,7 +131,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
     return (
       <InlineChip
         role="button"
-        aria-label={t("options.chipAriaLabel", { id: wpid })}
+        aria-label={t("options.chipAriaLabel", { id: formatWorkPackageId(wp.displayId) })}
         ref={setRef}
         selected={isSelected}
         onClick={(e) => {

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -14,6 +14,7 @@ import { wpBridge } from "../../services/wpBridge";
 import { BlockCard } from "../BlockWorkPackage/BlockCard";
 import { useTranslation } from "react-i18next";
 import { defaultWpVariables } from "../WorkPackage/atoms";
+import { formatWorkPackageId } from "../../services/utils";
 
 interface InlineWorkPackageChipProps {
   inlineContent: { props: { wpid: string; size: string; instanceId: string } };
@@ -79,10 +80,11 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef }: InlineWorkP
       e.preventDefault();
       e.stopPropagation();
 
-      e.clipboardData?.setData("text/plain", `#${wpid}`);
+      const formattedId = formatWorkPackageId(wp?.displayId ?? String(wpid));
+      e.clipboardData?.setData("text/plain", formattedId);
       e.clipboardData?.setData(
         "text/html",
-        `<span data-inline-content-type="openProjectWorkPackageInline" data-wpid="${wpid}" data-instance-id="${instanceId}" data-size="${size}">#${wpid}</span>`,
+        `<span data-inline-content-type="openProjectWorkPackageInline" data-wpid="${wpid}" data-instance-id="${instanceId}" data-size="${size}">${formattedId}</span>`,
       );
     },
     [isSelected, wp, wpid, instanceId, size],

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -10,6 +10,7 @@ import {
   TrashIcon,
   ChevronDownIcon,
 } from "@primer/octicons-react";
+import {formatWorkPackageId} from "../../services/utils.ts";
 
 export interface WpOptionsProps {
   wp: WorkPackage;
@@ -57,7 +58,7 @@ export const WpOptionsPopover = ({
     <Popover onMouseDown={(e) => e.stopPropagation()}>
       <PopBtn
         title={t("options.openInNewTab")}
-        aria-label={t("options.openAriaLabel", { id: wp.id })}
+        aria-label={t("options.openAriaLabel", { id: formatWorkPackageId(wp.displayId) })}
         onClick={(e) => {
           e.stopPropagation();
           window.open(linkToWorkPackage(wp.displayId), "_blank", "noopener,noreferrer");

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -60,7 +60,7 @@ export const WpOptionsPopover = ({
         aria-label={t("options.openAriaLabel", { id: wp.id })}
         onClick={(e) => {
           e.stopPropagation();
-          window.open(linkToWorkPackage(wp.id), "_blank", "noopener,noreferrer");
+          window.open(linkToWorkPackage(wp.displayId), "_blank", "noopener,noreferrer");
         }}
       >
         <IcOpen /> {t("options.open")}

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -35,10 +35,10 @@ export const en = {
       "changeSize": "Change size",
       "remove": "Remove",
       "removeAriaLabel": "Remove work package",
-      "openAriaLabel": "Open work package #{{id}} in new tab",
+      "openAriaLabel": "Open work package {{id}} in new tab",
       "inlineSizeLabel": "Inline size",
       "blockSizeLabel": "Block size",
-      "chipAriaLabel": "Work package #{{id}}",
+      "chipAriaLabel": "Work package {{id}}",
     },
     "sizes": {
       "xxs": { "label": "Tiny", "desc": "Identifier" },

--- a/lib/openProjectTypes.ts
+++ b/lib/openProjectTypes.ts
@@ -1,5 +1,6 @@
 export interface WorkPackage {
   id: number;
+  displayId: string;
   subject: string;
   description?: { raw?: string; html?: string } | null;
   status?: string | null;

--- a/lib/services/openProjectApi.ts
+++ b/lib/services/openProjectApi.ts
@@ -32,11 +32,8 @@ async function get<T>(endpoint: string): Promise<T> {
   return response.json();
 }
 
-export function linkToWorkPackage(id: number): string {
-  if (isNaN(id) || id <= 0) {
-    throw new OpenProjectApiError(`Invalid work package ID: ${id}`);
-  }
-  return `${baseUrl}/wp/${id}`;
+export function linkToWorkPackage(displayId: string): string {
+  return `${baseUrl}/wp/${encodeURIComponent(displayId)}`;
 }
 
 export function fetchWorkPackage(id: number): Promise<WorkPackage> {

--- a/lib/services/utils.ts
+++ b/lib/services/utils.ts
@@ -6,3 +6,7 @@ export function makeInstanceId(): string {
     ? crypto.randomUUID()
     : `iid-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
+
+export function formatWorkPackageId(displayId: string): string {
+  return /^\d+$/.test(displayId) ? `#${displayId}` : displayId;
+}

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -9,20 +9,21 @@ export async function openEditorAndType(text: string) {
   await userEvent.type(editorEl, text);
 }
 
-export async function insertInlineChipViaSlashMenu() {
+export async function insertInlineChipViaSlashMenu(searchTerm:string='Fix', resultTerm:string='Fix login bug') {
   await openEditorAndType('/');
   await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
   await userEvent.click(page.getByText('Link existing work package').first());
 
   const searchInput = page.getByPlaceholder('Search by work package ID or subject');
   await expect.element(searchInput).toBeVisible();
-  await userEvent.type(searchInput, 'Fix');
+  await userEvent.type(searchInput, searchTerm);
 
-  await expect.element(page.getByText('Fix login bug')).toBeVisible();
-  await userEvent.click(page.getByText('Fix login bug'));
+  await expect.element(page.getByText(resultTerm)).toBeVisible();
+  await userEvent.click(page.getByText(resultTerm));
 
   // default S chip - status visible
-  await expect.element(page.getByText('In Progress')).toBeVisible();
+  await expect.element(searchInput).not.toBeInTheDocument();
+  await expect.element(page.getByText(resultTerm)).toBeVisible();
 }
 
 export async function insertInlineChipViaHash(hashes: string) {
@@ -35,21 +36,6 @@ export async function insertInlineChipViaHash(hashes: string) {
 export async function openInlineChipPopover(displayId: string = '#123') {
   await userEvent.click(page.getByText(displayId).first());
   await expect.element(page.getByTestId('popover-content')).toBeVisible();
-}
-
-export async function insertSemanticInlineChipViaSlashMenu() {
-  await openEditorAndType('/');
-  await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
-  await userEvent.click(page.getByText('Link existing work package').first());
-
-  const searchInput = page.getByPlaceholder('Search by work package ID or subject');
-  await expect.element(searchInput).toBeVisible();
-  await userEvent.type(searchInput, 'Semantic');
-
-  await expect.element(page.getByText('Semantic ID work package')).toBeVisible();
-  await userEvent.click(page.getByText('Semantic ID work package'));
-
-  await expect.element(page.getByText('DWPS-1')).toBeVisible();
 }
 
 export async function openInlineChipSizeMenu(displayId:string|undefined = '#123') {

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -38,7 +38,7 @@ export async function openInlineChipPopover(displayId: string = '#123') {
   await expect.element(page.getByTestId('popover-content')).toBeVisible();
 }
 
-export async function openInlineChipSizeMenu(displayId:string|undefined = '#123') {
+export async function openInlineChipSizeMenu(displayId:string = '#123') {
   await openInlineChipPopover(displayId);
   await userEvent.click(page.getByTitle('Change size'));
   await expect.element(page.getByTestId('size-menu')).toBeVisible();
@@ -56,7 +56,7 @@ export async function openBlockCardSizeMenu() {
   await expect.element(page.getByTestId('size-menu')).toBeVisible();
 }
 
-export async function convertToCompactCard(displayId:string|undefined = "#123") {
+export async function convertToCompactCard(displayId:string = "#123") {
   await openInlineChipSizeMenu(displayId);
   await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
   await expect.element(page.getByTestId('block-card')).toBeVisible();

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -32,13 +32,28 @@ export async function insertInlineChipViaHash(hashes: string) {
 }
 
 // Inline chip - popover & size menu
-export async function openInlineChipPopover() {
-  await userEvent.click(page.getByText('#123').first());
+export async function openInlineChipPopover(displayId: string = '#123') {
+  await userEvent.click(page.getByText(displayId).first());
   await expect.element(page.getByTestId('popover-content')).toBeVisible();
 }
 
-export async function openInlineChipSizeMenu() {
-  await openInlineChipPopover();
+export async function insertSemanticInlineChipViaSlashMenu() {
+  await openEditorAndType('/');
+  await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
+  await userEvent.click(page.getByText('Link existing work package').first());
+
+  const searchInput = page.getByPlaceholder('Search by work package ID or subject');
+  await expect.element(searchInput).toBeVisible();
+  await userEvent.type(searchInput, 'Semantic');
+
+  await expect.element(page.getByText('Semantic ID work package')).toBeVisible();
+  await userEvent.click(page.getByText('Semantic ID work package'));
+
+  await expect.element(page.getByText('DWPS-1')).toBeVisible();
+}
+
+export async function openInlineChipSizeMenu(displayId:string|undefined = '#123') {
+  await openInlineChipPopover(displayId);
   await userEvent.click(page.getByTitle('Change size'));
   await expect.element(page.getByTestId('size-menu')).toBeVisible();
 }
@@ -55,8 +70,8 @@ export async function openBlockCardSizeMenu() {
   await expect.element(page.getByTestId('size-menu')).toBeVisible();
 }
 
-export async function convertToCompactCard() {
-  await openInlineChipSizeMenu();
+export async function convertToCompactCard(displayId:string|undefined = "#123") {
+  await openInlineChipSizeMenu(displayId);
   await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
   await expect.element(page.getByTestId('block-card')).toBeVisible();
 }

--- a/test/lib/components/integration/editor.displayId.browser.test.tsx
+++ b/test/lib/components/integration/editor.displayId.browser.test.tsx
@@ -3,21 +3,20 @@ import { page } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
 import {
   insertInlineChipViaSlashMenu,
-  insertSemanticInlineChipViaSlashMenu,
   convertToCompactCard,
 } from '../../../helpers/editorHelpers';
 
 describe('displayId - classic (numeric)', () => {
   it('inline chip shows #123 for numeric displayId', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineChipViaSlashMenu('123');
 
     await expect.element(page.getByText('#123')).toBeVisible();
   });
 
   it('block card shows #123 for numeric displayId', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineChipViaSlashMenu('123');
     await convertToCompactCard();
 
     await expect.element(page.getByText('#123')).toBeVisible();
@@ -28,19 +27,21 @@ describe('displayId - classic (numeric)', () => {
 describe('displayId - semantic (alphanumeric)', () => {
   it('inline chip shows DWPS-1 without # for semantic displayId', async () => {
     renderEditor();
-    await insertSemanticInlineChipViaSlashMenu();
+    await insertInlineChipViaSlashMenu('DWPS-1', 'Semantic');
 
     await expect.element(page.getByText('DWPS-1')).toBeVisible();
     await expect.element(page.getByText('#DWPS-1')).not.toBeInTheDocument();
+    await expect.element(page.getByText('#789')).not.toBeInTheDocument();
   });
 
   it('block card shows DWPS-1 without # for semantic displayId', async () => {
     renderEditor();
-    await insertSemanticInlineChipViaSlashMenu();
+    await insertInlineChipViaSlashMenu('DWPS-1', 'Semantic');
     await convertToCompactCard('DWPS-1');
 
     await expect.element(page.getByText('DWPS-1')).toBeVisible();
     await expect.element(page.getByText('#DWPS-1')).not.toBeInTheDocument();
+    await expect.element(page.getByText('#789')).not.toBeInTheDocument();
     await expect.element(page.getByTestId('block-card')).toBeVisible();
   });
 });

--- a/test/lib/components/integration/editor.displayId.browser.test.tsx
+++ b/test/lib/components/integration/editor.displayId.browser.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import {
+  insertInlineChipViaSlashMenu,
+  insertSemanticInlineChipViaSlashMenu,
+  convertToCompactCard,
+} from '../../../helpers/editorHelpers';
+
+describe('displayId - classic (numeric)', () => {
+  it('inline chip shows #123 for numeric displayId', async () => {
+    renderEditor();
+    await insertInlineChipViaSlashMenu();
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+  });
+
+  it('block card shows #123 for numeric displayId', async () => {
+    renderEditor();
+    await insertInlineChipViaSlashMenu();
+    await convertToCompactCard();
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+  });
+});
+
+describe('displayId - semantic (alphanumeric)', () => {
+  it('inline chip shows DWPS-1 without # for semantic displayId', async () => {
+    renderEditor();
+    await insertSemanticInlineChipViaSlashMenu();
+
+    await expect.element(page.getByText('DWPS-1')).toBeVisible();
+    await expect.element(page.getByText('#DWPS-1')).not.toBeInTheDocument();
+  });
+
+  it('block card shows DWPS-1 without # for semantic displayId', async () => {
+    renderEditor();
+    await insertSemanticInlineChipViaSlashMenu();
+    await convertToCompactCard('DWPS-1');
+
+    await expect.element(page.getByText('DWPS-1')).toBeVisible();
+    await expect.element(page.getByText('#DWPS-1')).not.toBeInTheDocument();
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+  });
+});

--- a/test/lib/services/openProjectApi.test.ts
+++ b/test/lib/services/openProjectApi.test.ts
@@ -9,12 +9,12 @@ import {
 describe("openProjectApi", () => {
   it("works with a baseUrl with trailing slash", () => {
     initOpenProjectApi({baseUrl: "https://example.com/"});
-    expect(linkToWorkPackage(42)).toBe("https://example.com/wp/42");
+    expect(linkToWorkPackage("42")).toBe("https://example.com/wp/42");
   });
 
   it("works with a baseUrl without trailing slash", () => {
     initOpenProjectApi({baseUrl: "https://example.com"});
-    expect(linkToWorkPackage(42)).toBe("https://example.com/wp/42");
+    expect(linkToWorkPackage("42")).toBe("https://example.com/wp/42");
   });
 
   describe("searchWorkPackages", () => {
@@ -35,17 +35,23 @@ describe("openProjectApi", () => {
   });
 
   describe("linkToWorkPackage", () => {
-    it("throws an error for invalid work package ID", () => {
+    it("builds a correct URL for a numeric displayId", () => {
       initOpenProjectApi({baseUrl: "https://example.com"});
-      expect(() => linkToWorkPackage(-1)).toThrow("Invalid work package ID: -1");
-      expect(() => linkToWorkPackage(0)).toThrow("Invalid work package ID: 0");
-      expect(() => linkToWorkPackage(NaN)).toThrow("Invalid work package ID: NaN");
-      expect(() => linkToWorkPackage("abublé" as unknown as number)).toThrow("Invalid work package ID: abublé");
+      expect(linkToWorkPackage("123")).toBe("https://example.com/wp/123");
+      expect(linkToWorkPackage("42")).toBe("https://example.com/wp/42");
     });
 
-    it("builds a welformed url for valid work package ID", () => {
+    it("builds a correct URL for a semantic displayId", () => {
       initOpenProjectApi({baseUrl: "https://example.com"});
-      expect(linkToWorkPackage(123)).toBe("https://example.com/wp/123");
+      expect(linkToWorkPackage("DWPS-1")).toBe("https://example.com/wp/DWPS-1");
+      expect(linkToWorkPackage("PROJ-42")).toBe("https://example.com/wp/PROJ-42");
+    });
+
+    it("encodes path traversal attempts via encodeURIComponent", () => {
+      initOpenProjectApi({baseUrl: "https://example.com"});
+      expect(linkToWorkPackage("../secret")).toBe("https://example.com/wp/..%2Fsecret");
+      expect(linkToWorkPackage("../../etc/passwd")).toBe("https://example.com/wp/..%2F..%2Fetc%2Fpasswd");
+      expect(linkToWorkPackage("foo/bar")).toBe("https://example.com/wp/foo%2Fbar");
     });
   });
 

--- a/test/lib/services/utils.test.ts
+++ b/test/lib/services/utils.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { makeInstanceId } from "../../../lib/services/utils";
+import { makeInstanceId, formatWorkPackageId } from "../../../lib/services/utils";
+
+describe("formatWorkPackageId", () => {
+  it("prepends # to a purely numeric string", () => {
+    expect(formatWorkPackageId("123")).toBe("#123");
+    expect(formatWorkPackageId("37")).toBe("#37");
+    expect(formatWorkPackageId("1")).toBe("#1");
+  });
+
+  it("returns alphanumeric displayId as-is without # prefix", () => {
+    expect(formatWorkPackageId("DWPS-1")).toBe("DWPS-1");
+    expect(formatWorkPackageId("ABC123")).toBe("ABC123");
+    expect(formatWorkPackageId("PROJ-42")).toBe("PROJ-42");
+  });
+});
 
 describe("makeInstanceId", () => {
   it("returns a non-empty string", () => {

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 
 export const mockWorkPackage = {
   id: 123,
+  displayId: "123",
   subject: 'Fix login bug',
   _links: {
     self:   { href: '/api/v3/work_packages/123' },
@@ -12,9 +13,21 @@ export const mockWorkPackage = {
 
 export const mockWorkPackage2 = {
   id: 456,
+  displayId: "456",
   subject: 'Add dark mode',
   _links: {
     self:   { href: '/api/v3/work_packages/456' },
+    type:   { title: 'Feature', href: '/api/v3/types/2' },
+    status: { title: 'Open',    href: '/api/v3/statuses/2' },
+  },
+};
+
+export const mockWorkPackageWithSemanticId = {
+  id: 789,
+  displayId: "DWPS-1",
+  subject: 'Semantic ID work package',
+  _links: {
+    self:   { href: '/api/v3/work_packages/789' },
     type:   { title: 'Feature', href: '/api/v3/types/2' },
     status: { title: 'Open',    href: '/api/v3/statuses/2' },
   },
@@ -46,12 +59,13 @@ export const handlers = [
   http.get('http://localhost:3000/api/v3/work_packages/:id', ({ params }) => {
     const id = Number(params.id);
     if (id === 456) return HttpResponse.json(mockWorkPackage2);
-    return HttpResponse.json({ ...mockWorkPackage, id });
+    if (id === 789) return HttpResponse.json(mockWorkPackageWithSemanticId);
+    return HttpResponse.json({ ...mockWorkPackage, id, displayId: String(id) });
   }),
 
   http.get('http://localhost:3000/api/v3/work_packages', () =>
     HttpResponse.json({
-      _embedded: { elements: [mockWorkPackage, mockWorkPackage2] },
+      _embedded: { elements: [mockWorkPackage, mockWorkPackage2, mockWorkPackageWithSemanticId] },
     })
   ),
 ];


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74115

# What are you trying to accomplish?
Use either semantic or classic identifiers for work packages. The API provides these as "displayId", so we just need to use that instead of the work package ID, which we used so far.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
