### PR TITLE
Chip-to-block resize should split the surrounding sentence

### DIFF
--- a/lib/hooks/useInlineWpEvents.ts
+++ b/lib/hooks/useInlineWpEvents.ts
@@ -124,21 +124,49 @@ function handlePromoteToBlock(
   const wpid = Number(found.chip.props.wpid);
   if (Number.isNaN(wpid) || wpid <= 0) return;
 
-  updateInlineChip(editor, instanceId, () => null);
+  const chipIndex = found.content.findIndex(
+    (node) => isInlineWpNode(node) && node.props.instanceId === instanceId
+  );
+  if (chipIndex === -1) return;
 
-  const block = {
-    type:'openProjectWorkPackageBlock',
-    props:{ wpid, initialized:true, size },
+  const contentBefore = found.content.slice(0, chipIndex);
+  const contentAfter  = found.content.slice(chipIndex + 1);
+
+  const blockNode = {
+    type: 'openProjectWorkPackageBlock',
+    props: { wpid, initialized: true, size },
   } as Parameters<typeof editor.insertBlocks>[0][number];
 
-  const [insertedBlock] = editor.insertBlocks(
-    [block],
-    found.blockId,
-    'after'
-  );
+  if (contentBefore.length > 0) {
+    editor.updateBlock(found.blockId, { content: contentBefore });
+    const [insertedBlock] = editor.insertBlocks([blockNode], found.blockId, 'after');
+    if (!insertedBlock?.id) return;
+    placeAfterContent(editor, insertedBlock.id, contentAfter);
+  } else {
+    const [insertedBlock] = editor.insertBlocks([blockNode], found.blockId, 'before');
+    editor.removeBlocks([found.blockId]);
+    if (!insertedBlock?.id) return;
+    placeAfterContent(editor, insertedBlock.id, contentAfter);
+  }
+}
 
-  if (insertedBlock?.id) {
-    requestAnimationFrame(() => moveCursorAfterBlock(editor, insertedBlock.id));
+function placeAfterContent(
+  editor: AnyEditor,
+  anchorBlockId: string,
+  content: AnyInlineNode[]
+): void {
+  if (content.length > 0) {
+    const [afterParagraph] = editor.insertBlocks(
+      [{ type: 'paragraph', content }],
+      anchorBlockId,
+      'after'
+    );
+    requestAnimationFrame(() => {
+      editor.focus();
+      editor.setTextCursorPosition(afterParagraph.id, 'start');
+    });
+  } else {
+    moveCursorAfterBlock(editor, anchorBlockId);
   }
 }
 

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -9,7 +9,7 @@ export async function openEditorAndType(text: string) {
   await userEvent.type(editorEl, text);
 }
 
-export async function insertInlineChipViaSlashMenu(searchTerm:string='Fix', resultTerm:string='Fix login bug') {
+export async function insertInlineWorkPackageViaSlashMenu(searchTerm:string='Fix', resultTerm:string='Fix login bug') {
   await openEditorAndType('/');
   await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
   await userEvent.click(page.getByText('Link existing work package').first());
@@ -26,20 +26,20 @@ export async function insertInlineChipViaSlashMenu(searchTerm:string='Fix', resu
   await expect.element(page.getByText(resultTerm)).toBeVisible();
 }
 
-export async function insertInlineChipViaHash(hashes: string) {
+export async function insertInlineWorkPackageViaHash(hashes: string) {
   await openEditorAndType(`${hashes}Fix`);
   await expect.element(page.getByText('Fix login bug')).toBeVisible();
   await userEvent.click(page.getByText('Fix login bug'));
 }
 
 // Inline chip - popover & size menu
-export async function openInlineChipPopover(displayId: string = '#123') {
+export async function openInlineWorkPackagePopover(displayId: string = '#123') {
   await userEvent.click(page.getByText(displayId).first());
   await expect.element(page.getByTestId('popover-content')).toBeVisible();
 }
 
-export async function openInlineChipSizeMenu(displayId:string = '#123') {
-  await openInlineChipPopover(displayId);
+export async function openInlineWorkPackageSizeMenu(displayId:string = '#123') {
+  await openInlineWorkPackagePopover(displayId);
   await userEvent.click(page.getByTitle('Change size'));
   await expect.element(page.getByTestId('size-menu')).toBeVisible();
 }
@@ -57,12 +57,12 @@ export async function openBlockCardSizeMenu() {
 }
 
 export async function convertToCompactCard(displayId:string = "#123") {
-  await openInlineChipSizeMenu(displayId);
+  await openInlineWorkPackageSizeMenu(displayId);
   await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
   await expect.element(page.getByTestId('block-card')).toBeVisible();
 }
 
-export async function insertInlineChipViaHashWithTextBefore(before: string) {
+export async function insertInlineWorkPackageViaHashWithTextBefore(before: string) {
   const editorEl = page.getByRole('textbox');
   await expect.element(editorEl).toBeVisible();
   await userEvent.click(editorEl);

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -61,3 +61,13 @@ export async function convertToCompactCard(displayId:string = "#123") {
   await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
   await expect.element(page.getByTestId('block-card')).toBeVisible();
 }
+
+export async function insertInlineChipViaHashWithTextBefore(before: string) {
+  const editorEl = page.getByRole('textbox');
+  await expect.element(editorEl).toBeVisible();
+  await userEvent.click(editorEl);
+  await userEvent.type(editorEl, `${before}#Fix`);
+  await expect.element(page.getByText('Fix login bug')).toBeVisible();
+  await userEvent.click(page.getByText('Fix login bug'));
+  await expect.element(page.getByText('#123')).toBeVisible();
+}

--- a/test/lib/components/integration/blockWorkPackageCopyPaste.browser.test.tsx
+++ b/test/lib/components/integration/blockWorkPackageCopyPaste.browser.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
-import { insertInlineChipViaSlashMenu, convertToCompactCard } from '../../../helpers/editorHelpers';
+import { insertInlineWorkPackageViaSlashMenu, convertToCompactCard } from '../../../helpers/editorHelpers';
 import {
   computeWorkPackageBlockExternalData,
   buildWorkPackageBlockExternalDOM,
@@ -25,7 +25,7 @@ function pasteBlockCardHtml(wpid: number) {
 describe('Block card - copy/paste independence', () => {
   it('removing the pasted copy does not remove the original', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
@@ -43,7 +43,7 @@ describe('Block card - copy/paste independence', () => {
 
   it('removing the original does not remove the pasted copy', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
@@ -61,7 +61,7 @@ describe('Block card - copy/paste independence', () => {
 
   it('resizing the original does not affect the pasted copy', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
@@ -76,12 +76,13 @@ describe('Block card - copy/paste independence', () => {
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
     // The pasted copy still shows the status
+    await expect.element(page.getByText('In Progress')).toBeVisible();
     expect((await page.getByText('In Progress').all()).length).toBe(1);
   });
 
   it('resizing the pasted copy does not affect the original', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();

--- a/test/lib/components/integration/editor.blockWorkPackage.browser.test.tsx
+++ b/test/lib/components/integration/editor.blockWorkPackage.browser.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
 import {
-  insertInlineChipViaSlashMenu,
+  insertInlineWorkPackageViaSlashMenu,
   convertToCompactCard,
   openBlockCardPopover,
   openBlockCardSizeMenu,
@@ -11,7 +11,7 @@ import {
 describe('Block card - resize', () => {
   // it('Compact card -> Regular card: both show title and status', async () => {
   //   renderEditor();
-  //   await insertInlineChipViaSlashMenu();
+  //   await insertInlineWorkPackageViaSlashMenu();
   //   await convertToCompactCard();
 
   //   await openBlockCardSizeMenu();
@@ -24,7 +24,7 @@ describe('Block card - resize', () => {
 
   // it('Regular card -> Full card shows extended content', async () => {
   //   renderEditor();
-  //   await insertInlineChipViaSlashMenu();
+  //   await insertInlineWorkPackageViaSlashMenu();
 
   //   await openBlockCardSizeMenu();
   //   await userEvent.click(page.getByRole('button', { name: 'Regular card', exact: true }));
@@ -40,7 +40,7 @@ describe('Block card - resize', () => {
 
   it('size button label reflects current card size', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardPopover();
@@ -49,7 +49,7 @@ describe('Block card - resize', () => {
 
   it('size menu shows all 4 options for a block card', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardSizeMenu();
@@ -66,7 +66,7 @@ describe('Block card - resize', () => {
 
   it('size menu closes after selecting a size', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardSizeMenu();
@@ -79,7 +79,7 @@ describe('Block card - resize', () => {
 describe('Block card - popover UX', () => {
   it('popover is not visible before clicking the card', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await expect.element(page.getByTestId('popover-content')).not.toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('Block card - popover UX', () => {
 
   it('clicking the card opens the popover', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardPopover();
@@ -97,7 +97,7 @@ describe('Block card - popover UX', () => {
   it('"Open" button opens the work package in a new tab', async () => {
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardPopover();
@@ -115,7 +115,7 @@ describe('Block card - popover UX', () => {
 describe('Block card - remove', () => {
   it('removing a block card removes it from the editor', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardPopover();

--- a/test/lib/components/integration/editor.conversion.browser.test.tsx
+++ b/test/lib/components/integration/editor.conversion.browser.test.tsx
@@ -141,6 +141,54 @@ describe('Inline chip -> block: surrounding text is split at chip position', () 
     expect(helloEl.compareDocumentPosition(blockCardEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(blockCardEl.contains(helloEl)).toBe(false);
   });
+
+  it('text - WP1 WP2 WP3 - text: converting the middle chip splits correctly, leaving adjacent chips intact', async () => {
+    renderEditor();
+    const editorEl = page.getByRole('textbox');
+    await expect.element(editorEl).toBeVisible();
+    await userEvent.click(editorEl);
+
+    // "Hello <#123><#456><#123> World"
+    await userEvent.type(editorEl, 'Hello #Fix');
+    await expect.element(page.getByText('Fix login bug').first()).toBeVisible();
+    await userEvent.click(page.getByText('Fix login bug').first()); // WP1: #123
+
+    await userEvent.type(editorEl, '#dark');
+    await expect.element(page.getByText('Add dark mode')).toBeVisible();
+    await userEvent.click(page.getByText('Add dark mode')); // WP2: #456
+
+    await userEvent.type(editorEl, '#Fix');
+    await expect.element(page.getByText('Fix login bug').first()).toBeVisible();
+    await userEvent.click(page.getByText('Fix login bug').first()); // WP3: #123
+
+    await userEvent.keyboard(' World');
+
+    // Convert middle chip (#456) to block card
+    await openInlineWorkPackageSizeMenu('#456');
+    await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+    await expect.element(page.getByText('Add dark mode')).toBeVisible();
+    await expect.element(page.getByText('Hello')).toBeVisible();
+    await expect.element(page.getByText('World')).toBeVisible();
+
+    expect(page.getByText('#123').all().length).toBe(2);
+
+    // DOM order: Hello+WP1 -> block wp -> WP3+World
+    const helloEl = page.getByText('Hello').element();
+    const blockCardEl = page.getByTestId('block-card').element();
+    const worldEl = page.getByText('World').element();
+    expect(helloEl.compareDocumentPosition(blockCardEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(blockCardEl.compareDocumentPosition(worldEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(blockCardEl.contains(helloEl)).toBe(false);
+    expect(blockCardEl.contains(worldEl)).toBe(false);
+
+    // WP1 (#123) precedes the block wp; WP3 (#123) follows it
+    const wp1El = page.getByText('#123').nth(0).element();
+    const wp3El = page.getByText('#123').nth(1).element();
+    expect(wp1El.compareDocumentPosition(blockCardEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(blockCardEl.compareDocumentPosition(wp3El) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });
 
 describe('Round-trip conversion', () => {

--- a/test/lib/components/integration/editor.conversion.browser.test.tsx
+++ b/test/lib/components/integration/editor.conversion.browser.test.tsx
@@ -2,18 +2,18 @@ import { describe, it, expect } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
 import {
-  insertInlineChipViaSlashMenu,
-  insertInlineChipViaHash,
-  insertInlineChipViaHashWithTextBefore,
+  insertInlineWorkPackageViaSlashMenu,
+  insertInlineWorkPackageViaHash,
+  insertInlineWorkPackageViaHashWithTextBefore,
   convertToCompactCard,
-  openInlineChipSizeMenu,
+  openInlineWorkPackageSizeMenu,
   openBlockCardSizeMenu,
 } from '../../../helpers/editorHelpers';
 
 describe('Inline chip - convert to block card', () => {
   it('inline -> Compact card replaces chip with block card', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await convertToCompactCard();
 
@@ -25,9 +25,9 @@ describe('Inline chip - convert to block card', () => {
 
   // it('inline → Regular card replaces chip with block card', async () => {
   //   renderEditor();
-  //   await insertInlineChipViaSlashMenu();
+  //   await insertInlineWorkPackageViaSlashMenu();
 
-  //   await openInlineChipSizeMenu();
+  //   await openInlineWorkPackageSizeMenu();
   //   await userEvent.click(page.getByRole('button', { name: 'Regular card', exact: true }));
 
   //   await expect.element(page.getByTestId('block-card')).toBeVisible();
@@ -39,7 +39,7 @@ describe('Inline chip - convert to block card', () => {
 describe('Block card - convert to inline chip', () => {
   it('block -> Tiny replaces card with XXS chip', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardSizeMenu();
@@ -53,7 +53,7 @@ describe('Block card - convert to inline chip', () => {
 
   it('block -> Compact (inline) replaces card with XS chip', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardSizeMenu();
@@ -68,7 +68,7 @@ describe('Block card - convert to inline chip', () => {
 
   it('block -> Regular (inline) replaces card with S chip', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardSizeMenu();
@@ -83,10 +83,10 @@ describe('Block card - convert to inline chip', () => {
 describe('Inline chip -> block: surrounding text is split at chip position', () => {
   it('WP - text: text after chip moves to new paragraph below block', async () => {
     renderEditor();
-    await insertInlineChipViaHash('#');
+    await insertInlineWorkPackageViaHash('#');
     await userEvent.keyboard(' World');
 
-    await openInlineChipSizeMenu();
+    await openInlineWorkPackageSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
@@ -102,10 +102,10 @@ describe('Inline chip -> block: surrounding text is split at chip position', () 
 
   it('text - WP - text: surrounding sentence is split into two paragraphs around the block', async () => {
     renderEditor();
-    await insertInlineChipViaHashWithTextBefore('Hello ');
+    await insertInlineWorkPackageViaHashWithTextBefore('Hello ');
     await userEvent.keyboard(' World');
 
-    await openInlineChipSizeMenu();
+    await openInlineWorkPackageSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
@@ -126,9 +126,9 @@ describe('Inline chip -> block: surrounding text is split at chip position', () 
 
   it('text - WP: text before chip stays in paragraph above block', async () => {
     renderEditor();
-    await insertInlineChipViaHashWithTextBefore('Hello ');
+    await insertInlineWorkPackageViaHashWithTextBefore('Hello ');
 
-    await openInlineChipSizeMenu();
+    await openInlineWorkPackageSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
@@ -146,7 +146,7 @@ describe('Inline chip -> block: surrounding text is split at chip position', () 
 describe('Round-trip conversion', () => {
   it('inline chip survives block card round-trip and retains WP data', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     // block
     await convertToCompactCard();
@@ -164,10 +164,10 @@ describe('Round-trip conversion', () => {
 
   it('XXS chip inserted via # survives block card round-trip', async () => {
     renderEditor();
-    await insertInlineChipViaHash('#');
+    await insertInlineWorkPackageViaHash('#');
 
     // block
-    await openInlineChipSizeMenu();
+    await openInlineWorkPackageSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
     await expect.element(page.getByTestId('block-card')).toBeVisible();
 

--- a/test/lib/components/integration/editor.conversion.browser.test.tsx
+++ b/test/lib/components/integration/editor.conversion.browser.test.tsx
@@ -4,6 +4,7 @@ import { renderEditor } from '../../../helpers/renderEditor';
 import {
   insertInlineChipViaSlashMenu,
   insertInlineChipViaHash,
+  insertInlineChipViaHashWithTextBefore,
   convertToCompactCard,
   openInlineChipSizeMenu,
   openBlockCardSizeMenu,
@@ -76,6 +77,48 @@ describe('Block card - convert to inline chip', () => {
     await expect.element(page.getByTestId('block-card')).not.toBeInTheDocument();
     await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByText('In Progress')).toBeVisible();
+  });
+});
+
+describe('Inline chip -> block: surrounding text is split at chip position', () => {
+  it('WP - text: text after chip moves to new paragraph below block', async () => {
+    renderEditor();
+    await insertInlineChipViaHash('#');
+    await userEvent.keyboard(' World');
+
+    await openInlineChipSizeMenu();
+    await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await expect.element(page.getByText('World')).toBeVisible();
+  });
+
+  it('text - WP - text: surrounding sentence is split into two paragraphs around the block', async () => {
+    renderEditor();
+    await insertInlineChipViaHashWithTextBefore('Hello ');
+    await userEvent.keyboard(' World');
+
+    await openInlineChipSizeMenu();
+    await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await expect.element(page.getByText('Hello')).toBeVisible();
+    await expect.element(page.getByText('World')).toBeVisible();
+    await expect.element(page.getByText('Hello World')).not.toBeInTheDocument();
+  });
+
+  it('text - WP: text before chip stays in paragraph above block', async () => {
+    renderEditor();
+    await insertInlineChipViaHashWithTextBefore('Hello ');
+
+    await openInlineChipSizeMenu();
+    await userEvent.click(page.getByRole('button', { name: 'Compact card', exact: true }));
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await expect.element(page.getByText('Hello')).toBeVisible();
   });
 });
 

--- a/test/lib/components/integration/editor.conversion.browser.test.tsx
+++ b/test/lib/components/integration/editor.conversion.browser.test.tsx
@@ -92,6 +92,12 @@ describe('Inline chip -> block: surrounding text is split at chip position', () 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
     await expect.element(page.getByText('World')).toBeVisible();
+
+    const blockCardEl = page.getByTestId('block-card').element();
+    const worldEl = page.getByText('World').element();
+    // World must follow the block card in the DOM and not be inside it
+    expect(blockCardEl.compareDocumentPosition(worldEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(blockCardEl.contains(worldEl)).toBe(false);
   });
 
   it('text - WP - text: surrounding sentence is split into two paragraphs around the block', async () => {
@@ -107,6 +113,15 @@ describe('Inline chip -> block: surrounding text is split at chip position', () 
     await expect.element(page.getByText('Hello')).toBeVisible();
     await expect.element(page.getByText('World')).toBeVisible();
     await expect.element(page.getByText('Hello World')).not.toBeInTheDocument();
+
+    const helloEl = page.getByText('Hello').element();
+    const blockCardEl = page.getByTestId('block-card').element();
+    const worldEl = page.getByText('World').element();
+    // DOM order must be: Hello paragraph -> block card -> World paragraph
+    expect(helloEl.compareDocumentPosition(blockCardEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(blockCardEl.compareDocumentPosition(worldEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(blockCardEl.contains(helloEl)).toBe(false);
+    expect(blockCardEl.contains(worldEl)).toBe(false);
   });
 
   it('text - WP: text before chip stays in paragraph above block', async () => {
@@ -119,6 +134,12 @@ describe('Inline chip -> block: surrounding text is split at chip position', () 
     await expect.element(page.getByTestId('block-card')).toBeVisible();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
     await expect.element(page.getByText('Hello')).toBeVisible();
+
+    const helloEl = page.getByText('Hello').element();
+    const blockCardEl = page.getByTestId('block-card').element();
+    // Hello must precede the block card in the DOM and not be inside it
+    expect(helloEl.compareDocumentPosition(blockCardEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(blockCardEl.contains(helloEl)).toBe(false);
   });
 });
 

--- a/test/lib/components/integration/editor.displayId.browser.test.tsx
+++ b/test/lib/components/integration/editor.displayId.browser.test.tsx
@@ -2,21 +2,21 @@ import { describe, it, expect } from 'vitest';
 import { page } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
 import {
-  insertInlineChipViaSlashMenu,
+  insertInlineWorkPackageViaSlashMenu,
   convertToCompactCard,
 } from '../../../helpers/editorHelpers';
 
 describe('displayId - classic (numeric)', () => {
   it('inline chip shows #123 for numeric displayId', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu('123');
+    await insertInlineWorkPackageViaSlashMenu('123');
 
     await expect.element(page.getByText('#123')).toBeVisible();
   });
 
   it('block card shows #123 for numeric displayId', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu('123');
+    await insertInlineWorkPackageViaSlashMenu('123');
     await convertToCompactCard();
 
     await expect.element(page.getByText('#123')).toBeVisible();
@@ -27,7 +27,7 @@ describe('displayId - classic (numeric)', () => {
 describe('displayId - semantic (alphanumeric)', () => {
   it('inline chip shows DWPS-1 without # for semantic displayId', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu('DWPS-1', 'Semantic');
+    await insertInlineWorkPackageViaSlashMenu('DWPS-1', 'Semantic');
 
     await expect.element(page.getByText('DWPS-1')).toBeVisible();
     await expect.element(page.getByText('#DWPS-1')).not.toBeInTheDocument();
@@ -36,7 +36,7 @@ describe('displayId - semantic (alphanumeric)', () => {
 
   it('block card shows DWPS-1 without # for semantic displayId', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu('DWPS-1', 'Semantic');
+    await insertInlineWorkPackageViaSlashMenu('DWPS-1', 'Semantic');
     await convertToCompactCard('DWPS-1');
 
     await expect.element(page.getByText('DWPS-1')).toBeVisible();

--- a/test/lib/components/integration/editor.drag.browser.test.tsx
+++ b/test/lib/components/integration/editor.drag.browser.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
-import { insertInlineChipViaSlashMenu, convertToCompactCard } from '../../../helpers/editorHelpers';
+import { insertInlineWorkPackageViaSlashMenu, convertToCompactCard } from '../../../helpers/editorHelpers';
 
 describe('Drag and drop - inline chip', () => {
   it('chip has data-drag-handle and is not independently draggable', async () => {
@@ -10,7 +10,7 @@ describe('Drag and drop - inline chip', () => {
     const editor = page.getByRole('textbox');
     await userEvent.click(editor);
     await userEvent.type(editor, 'Before ');
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await expect.element(page.getByText('#123')).toBeVisible();
 
@@ -27,7 +27,7 @@ describe('Drag and drop - inline chip', () => {
     await userEvent.click(editor);
     await userEvent.type(editor, 'First line');
     await userEvent.keyboard('{Enter}');
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await userEvent.keyboard('{Enter}');
     await userEvent.type(editor, 'Last line');
 
@@ -56,7 +56,7 @@ describe('Drag and drop - block card', () => {
 
     const editor = page.getByRole('textbox');
     await userEvent.click(editor);
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await expect.element(page.getByTestId('block-card')).toBeVisible();

--- a/test/lib/components/integration/editor.inlineWorkPackage.browser.test.tsx
+++ b/test/lib/components/integration/editor.inlineWorkPackage.browser.test.tsx
@@ -2,16 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
 import {
-  insertInlineChipViaSlashMenu,
-  insertInlineChipViaHash,
-  openInlineChipPopover,
-  openInlineChipSizeMenu,
+  insertInlineWorkPackageViaSlashMenu,
+  insertInlineWorkPackageViaHash,
+  openInlineWorkPackagePopover,
+  openInlineWorkPackageSizeMenu,
 } from '../../../helpers/editorHelpers';
 
 describe('Inline chip - insert', () => {
   it('inserts S chip via slash menu - shows ID, type, status, subject', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
@@ -21,7 +21,7 @@ describe('Inline chip - insert', () => {
 
   it('inserts XXS chip via # - shows only ID', async () => {
     renderEditor();
-    await insertInlineChipViaHash('#');
+    await insertInlineWorkPackageViaHash('#');
 
     await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).not.toBeInTheDocument();
@@ -30,7 +30,7 @@ describe('Inline chip - insert', () => {
 
   it('inserts XS chip via ## - shows ID, type, subject but no status', async () => {
     renderEditor();
-    await insertInlineChipViaHash('##');
+    await insertInlineWorkPackageViaHash('##');
 
     await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
@@ -39,7 +39,7 @@ describe('Inline chip - insert', () => {
 
   it('inserts S chip via ### — shows ID, type, status, subject', async () => {
     renderEditor();
-    await insertInlineChipViaHash('###');
+    await insertInlineWorkPackageViaHash('###');
 
     await expect.element(page.getByText('#123')).toBeVisible();
     await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
@@ -50,9 +50,9 @@ describe('Inline chip - insert', () => {
 describe('Inline chip - resize', () => {
   it('S -> XXS: hides type, status, subject - shows only ID', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
-    await openInlineChipSizeMenu();
+    await openInlineWorkPackageSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
     await expect.element(page.getByText('#123')).toBeVisible();
@@ -63,9 +63,9 @@ describe('Inline chip - resize', () => {
 
   it('S -> XS: hides status - shows ID, type, subject', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
-    await openInlineChipSizeMenu();
+    await openInlineWorkPackageSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Compact', exact: true }));
 
     await expect.element(page.getByText('#123')).toBeVisible();
@@ -76,9 +76,9 @@ describe('Inline chip - resize', () => {
 
   it('XS -> XXS: hides type, subject and status - shows only ID', async () => {
     renderEditor();
-    await insertInlineChipViaHash('##');
+    await insertInlineWorkPackageViaHash('##');
 
-    await openInlineChipSizeMenu();
+    await openInlineWorkPackageSizeMenu();
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
     await expect.element(page.getByText('#123')).toBeVisible();
@@ -91,25 +91,25 @@ describe('Inline chip - resize', () => {
 describe('Inline chip - popover UX', () => {
   it('popover is not visible before clicking the chip', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await expect.element(page.getByTestId('popover-content')).not.toBeInTheDocument();
   });
 
   it('clicking the chip opens the popover', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
-    await openInlineChipPopover();
+    await openInlineWorkPackagePopover();
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
   });
 
   it('"Open" button opens the work package in a new tab', async () => {
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
-    await openInlineChipPopover();
+    await openInlineWorkPackagePopover();
     await userEvent.click(page.getByTitle('Open in new tab'));
 
     expect(openSpy).toHaveBeenCalledWith(
@@ -124,9 +124,9 @@ describe('Inline chip - popover UX', () => {
 describe('Inline chip - remove', () => {
   it('removing an inline chip removes it from the editor', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
-    await openInlineChipPopover();
+    await openInlineWorkPackagePopover();
     await userEvent.click(page.getByTestId('remove-btn'));
 
     await expect.element(page.getByText('#123')).not.toBeInTheDocument();

--- a/test/lib/components/integration/inlineWorkPackageCopyPaste.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageCopyPaste.browser.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
-import { insertInlineChipViaSlashMenu } from '../../../helpers/editorHelpers';
+import { insertInlineWorkPackageViaSlashMenu } from '../../../helpers/editorHelpers';
 
 describe('Inline chip - copy/paste independence', () => {
   it('resizing the original does not affect the copy', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await userEvent.keyboard('{Control>}a{/Control}');
     await userEvent.keyboard('{Control>}c{/Control}');
@@ -27,7 +27,7 @@ describe('Inline chip - copy/paste independence', () => {
 
   it('resizing the copy does not affect the original', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await userEvent.keyboard('{Control>}a{/Control}');
     await userEvent.keyboard('{Control>}c{/Control}');
@@ -48,7 +48,7 @@ describe('Inline chip - copy/paste independence', () => {
 
   it('removing the copy does not remove the original', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await userEvent.keyboard('{Control>}a{/Control}');
     await userEvent.keyboard('{Control>}c{/Control}');
@@ -67,7 +67,7 @@ describe('Inline chip - copy/paste independence', () => {
 
   it('removing the original does not remove the copy', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
 
     await userEvent.keyboard('{Control>}a{/Control}');
     await userEvent.keyboard('{Control>}c{/Control}');

--- a/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
+++ b/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
@@ -6,7 +6,7 @@ import { InlineWorkPackageChip } from '../../../../lib/components/InlineWorkPack
 import { wpBridge } from '../../../../lib/services/wpBridge';
 import { renderEditor } from '../../../helpers/renderEditor';
 import {
-  insertInlineChipViaSlashMenu,
+  insertInlineWorkPackageViaSlashMenu,
   convertToCompactCard,
   openBlockCardPopover,
 } from '../../../helpers/editorHelpers';
@@ -139,7 +139,7 @@ describe('Options popover portal', () => {
 
   it('block card: popover is rendered outside the block DOM so it is not clipped by overflow', async () => {
     renderEditor();
-    await insertInlineChipViaSlashMenu();
+    await insertInlineWorkPackageViaSlashMenu();
     await convertToCompactCard();
 
     await openBlockCardPopover();


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74978

# What are you trying to accomplish?
When resizing an inline work package chip to block size, the surrounding text was not split at the chip's position. The entire paragraph remained intact with only the chip removed, leaving text before and after merged on one line.

After this fix, promoting a chip to block correctly splits the sentence: text before the chip stays in the original paragraph, the block chip is inserted on its own line, and text after the chip continues in a new paragraph below.

# What approach did you choose and why?
`handlePromoteToBlock` now finds the chip's index in the inline content array and slices it into `contentBefore` and `contentAfter`. Depending on whether there is content before the chip, it either updates the original block or
replaces it entirely to avoid leaving an empty paragraph. A small `placeAfterContent` helper handles cursor placement and conditionally inserts the trailing paragraph only when there is content to place, preventing a spurious empty block when the chip was at the end of a sentence.

No alternative approaches were considered - the fix is a straightforward extension of the existing editor mutation pattern used throughout the file.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
