### PR TITLE
[#75026] Don't throw errors (to not kill Hocuspocus)

### DIFF
--- a/lib/hooks/useWorkPackageSearch.ts
+++ b/lib/hooks/useWorkPackageSearch.ts
@@ -39,9 +39,10 @@ export function useWorkPackageSearch(
             setSearchResults(results);
           }
         })
-        .catch((err) => {
+        .catch((error) => {
           if (active) {
-            setError(err.message || "Unknown error");
+            setError(error.message || "Unknown error");
+            console.error("[work package search] Failed to load work packages from OpenProject:", error);
             setSearchResults([]);
           }
         })

--- a/lib/services/colors.ts
+++ b/lib/services/colors.ts
@@ -58,7 +58,9 @@ export function cacheColors(): Promise<void> {
         }
       });
     })(),
-  ]).then(() => {});
+  ]).then(() => {}).catch((error) => {
+    console.error("[colors] Failed to load colors from OpenProject:", error);
+  });
 
   return colorsPromise;
 }

--- a/lib/services/openProjectApi.ts
+++ b/lib/services/openProjectApi.ts
@@ -44,11 +44,17 @@ export function fetchWorkPackage(id: number): Promise<WorkPackage> {
 }
 
 export function fetchStatuses(): Promise<StatusCollection> {
-  return get<StatusCollection>(`/api/v3/statuses`);
+  return get<StatusCollection>(`/api/v3/statuses`).catch((error) => {
+    console.error("[OpenProjectApi] fetchStatuses failed:", error);
+    return Promise.reject(error);
+  });
 }
 
 export function fetchTypes(): Promise<TypeCollection> {
-  return get<TypeCollection>(`/api/v3/types`);
+  return get<TypeCollection>(`/api/v3/types`).catch((error) => {
+    console.error("[OpenProjectApi] fetchTypes failed:", error);
+    return Promise.reject(error);
+  });
 }
 
 export async function searchWorkPackages(query: string): Promise<WorkPackage[]> {

--- a/test/lib/services/openProjectApi.test.ts
+++ b/test/lib/services/openProjectApi.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  fetchStatuses,
+  fetchTypes,
   fetchWorkPackage,
   initOpenProjectApi,
   linkToWorkPackage,
+  OpenProjectApiError,
   searchWorkPackages
 } from "../../../lib/services/openProjectApi";
 
@@ -25,12 +28,14 @@ describe("openProjectApi", () => {
         json: async () => ({ _embedded: { elements: [] } }),
       } as Response);
 
-      searchWorkPackages("test query");
+      try {
+        searchWorkPackages("test query");
 
-      const calledUrl = fetchSpy.mock.calls[0][0] as string;
-      expect(calledUrl).toContain("sortBy=%5B%5B%22updatedAt%22%2C%22desc%22%5D%5D");
-
-      fetchSpy.mockRestore();
+        const calledUrl = fetchSpy.mock.calls[0][0] as string;
+        expect(calledUrl).toContain("sortBy=%5B%5B%22updatedAt%22%2C%22desc%22%5D%5D");
+      } finally {
+        fetchSpy.mockRestore();
+      }
     })
   });
 
@@ -62,6 +67,84 @@ describe("openProjectApi", () => {
       await expect(fetchWorkPackage(0)).rejects.toHaveProperty("message", "Invalid work package ID: 0");
       await expect(fetchWorkPackage(NaN)).rejects.toHaveProperty("message", "Invalid work package ID: NaN");
       await expect(fetchWorkPackage("abublé" as unknown as number)).rejects.toHaveProperty("message", "Invalid work package ID: abublé");
+    });
+  });
+
+  describe("fetchStatuses", () => {
+    it("resolves with data on success", async () => {
+      initOpenProjectApi({ baseUrl: "http://localhost:3000" });
+      const mockData = { _embedded: { elements: [] } };
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+
+      try {
+        const result = await fetchStatuses();
+        expect(result).toEqual(mockData);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("logs to console and rejects on HTTP error", async () => {
+      initOpenProjectApi({ baseUrl: "http://localhost:3000" });
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response);
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await expect(fetchStatuses()).rejects.toBeInstanceOf(OpenProjectApiError);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "[OpenProjectApi] fetchStatuses failed:",
+          expect.any(OpenProjectApiError)
+        );
+      } finally {
+        fetchSpy.mockRestore();
+        consoleSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("fetchTypes", () => {
+    it("resolves with data on success", async () => {
+      initOpenProjectApi({ baseUrl: "http://localhost:3000" });
+      const mockData = { _embedded: { elements: [] } };
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+
+      try {
+        const result = await fetchTypes();
+        expect(result).toEqual(mockData);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("logs to console and rejects on HTTP error", async () => {
+      initOpenProjectApi({ baseUrl: "http://localhost:3000" });
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      } as Response);
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await expect(fetchTypes()).rejects.toBeInstanceOf(OpenProjectApiError);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "[OpenProjectApi] fetchTypes failed:",
+          expect.any(OpenProjectApiError)
+        );
+      } finally {
+        fetchSpy.mockRestore();
+        consoleSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
https://community.openproject.org/wp/75026

We still need the errors to handle e.g. authentication issues. So we can not drop them completely, but we can catch them and handle them differently, e.g. through logging to the console.