### PR TITLE
Wrong cursor placement after inserting links to Work Packages in BlockNote

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -14,6 +14,7 @@ import { SearchContainer, SearchLabel } from "../Search/SearchContainer";
 import { SearchDropdown } from "../Search/SearchDropdown";
 import { defaultWpVariables } from "../WorkPackage/atoms";
 import { formatWorkPackageId } from "../../utils/id";
+import { moveCursorAfterBlock } from "../../utils/cursor";
 
 const Block = styled.div.attrs({ className: "op-bn-extensions" })`
   ${defaultWpVariables}
@@ -59,7 +60,7 @@ export const BlockWorkPackageComponent = ({
     editor.updateBlock(block, {
       props: { ...block.props, wpid: wp.id, initialized: true },
     });
-    requestAnimationFrame(() => moveCursorToNextBlock(editor, block.id));
+    requestAnimationFrame(() => moveCursorAfterBlock(editor, block.id));
   };
 
   useEffect(() => {
@@ -216,18 +217,3 @@ export const BlockWorkPackageComponent = ({
   );
 };
 
-function moveCursorToNextBlock(editor: BlockNoteEditor<any>, blockId: string) {
-  editor.focus();
-  editor.setTextCursorPosition(blockId, "end");
-
-  const cursor = editor.getTextCursorPosition();
-
-  if (!cursor?.nextBlock && cursor?.block) {
-    editor.insertBlocks([{ type: "paragraph", content: [] }], cursor.block.id, "after");
-  }
-
-  const updatedCursor = editor.getTextCursorPosition();
-  if (updatedCursor?.nextBlock) {
-    editor.setTextCursorPosition(updatedCursor.nextBlock.id, "start");
-  }
-}

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -2,6 +2,7 @@ import type { BlockNoteEditor } from "@blocknote/core";
 import type { InlineWpSize } from "../WorkPackage/types";
 import { makeInstanceId } from "../../utils/id.ts";
 import type { WorkPackage } from "../../openProjectTypes";
+import { placeCursorAfterInlineNode } from "../../utils/cursor.ts";
 
 export type AnyEditor = BlockNoteEditor<any, any, any>;
 
@@ -36,8 +37,8 @@ export function getSizeFromCurrentBlock(editor: AnyEditor): InlineWpSize {
 }
 
 /**
- * Inserts a chip at the cursor and removes the `#query` trigger before it.
- * The chip acts as a position anchor so we don't need cursor offsets.
+ * Inserts a chip at the cursor, removes the `#query` trigger before it,
+ * then repositions the cursor right after the chip via its instanceId.
  */
 export function insertWpChip(editor: AnyEditor, wp: WorkPackage, size: InlineWpSize): void {
   const instanceId = makeInstanceId();
@@ -48,8 +49,11 @@ export function insertWpChip(editor: AnyEditor, wp: WorkPackage, size: InlineWpS
   ]);
 
   removeTriggerBeforeChip(editor, instanceId);
-
   editor.focus();
+
+  requestAnimationFrame(() => {
+    placeCursorAfterInlineNode(editor, instanceId);
+  });
 }
 
 /**

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -4,6 +4,7 @@ import i18n from "../services/i18n.ts";
 import { getAliases } from "../services/slashMenuAliases";
 import { registerInlineWpCallbacks, clearInlineWpCallbacks, makePendingWpid } from "./InlineWorkPackage/callbacks";
 import { makeInstanceId } from "../utils/id.ts";
+import { placeCursorAfterInlineNode } from "../utils/cursor.ts";
 
 type AnyEditor = BlockNoteEditor<any, any, any>;
 type AnyInlineNode = InlineContentFromConfig<any, any>;
@@ -50,7 +51,7 @@ function buildOnSelect(
 
     requestAnimationFrame(() => {
       editor.focus();
-      editor.setTextCursorPosition(current.blockId, "end");
+      placeCursorAfterInlineNode(editor, instanceId);
     });
   };
 }

--- a/lib/hooks/useInlineWpEvents.ts
+++ b/lib/hooks/useInlineWpEvents.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import type { BlockNoteEditor, InlineContentFromConfig } from '@blocknote/core';
 import { wpBridge, makeInstanceId } from '../../lib';
 import type { InlineWpSize, BlockWpSize, WpSize } from '../../lib';
+import { moveCursorAfterBlock } from '../utils/cursor';
 
 type AnyEditor = BlockNoteEditor<any, any, any>;
 type AnyInlineNode = InlineContentFromConfig<any, any>;
@@ -93,27 +94,6 @@ function updateInlineChip(
   return found;
 }
 
-function moveCursorAfter(editor:AnyEditor, blockId:string):void {
-  requestAnimationFrame(() => {
-    editor.focus();
-    editor.setTextCursorPosition(blockId, 'end');
-
-    const cursor = editor.getTextCursorPosition();
-    if (!cursor?.nextBlock && cursor?.block) {
-      editor.insertBlocks(
-        [{ type:'paragraph', content:[] }],
-        cursor.block.id,
-        'after'
-      );
-    }
-
-    const updated = editor.getTextCursorPosition();
-    if (updated?.nextBlock) {
-      editor.setTextCursorPosition(updated.nextBlock.id, 'start');
-    }
-  });
-}
-
 function handleResize(editor:AnyEditor, instanceId:string, size:WpSize):void {
   const isBlockSize = size === 'm' || size === 'l' || size === 'xl';
 
@@ -158,7 +138,7 @@ function handlePromoteToBlock(
   );
 
   if (insertedBlock?.id) {
-    moveCursorAfter(editor, insertedBlock.id);
+    requestAnimationFrame(() => moveCursorAfterBlock(editor, insertedBlock.id));
   }
 }
 

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -1,0 +1,40 @@
+import type { BlockNoteEditor } from "@blocknote/core";
+import { TextSelection } from "prosemirror-state";
+
+type AnyEditor = BlockNoteEditor<any, any, any>;
+
+export function moveCursorAfterBlock(editor: AnyEditor, blockId: string): void {
+  editor.focus();
+  editor.setTextCursorPosition(blockId, "end");
+
+  const cursor = editor.getTextCursorPosition();
+  if (!cursor?.nextBlock && cursor?.block) {
+    editor.insertBlocks([{ type: "paragraph", content: [] }], cursor.block.id, "after");
+  }
+
+  const updated = editor.getTextCursorPosition();
+  if (updated?.nextBlock) {
+    editor.setTextCursorPosition(updated.nextBlock.id, "start");
+  }
+}
+
+export function placeCursorAfterInlineNode(editor: AnyEditor, instanceId: string): void {
+  const { doc } = editor.prosemirrorState;
+  let targetPos: number | null = null;
+
+  doc.descendants((node, pos) => {
+    if (targetPos !== null) return false;
+    if ((node.attrs as Record<string, unknown>)?.instanceId === instanceId) {
+      targetPos = pos + node.nodeSize;
+      return false;
+    }
+    return true;
+  });
+
+  if (targetPos !== null) {
+    const pos = targetPos;
+    editor.transact((tr) => {
+      tr.setSelection(TextSelection.create(tr.doc, pos));
+    });
+  }
+}

--- a/test/lib/components/integration/editor.cursorPosition.browser.test.tsx
+++ b/test/lib/components/integration/editor.cursorPosition.browser.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+
+async function setupEditorWithSurroundingText() {
+  const editor = page.getByRole('textbox');
+  await userEvent.click(editor);
+  await userEvent.type(editor, 'beforeTAIL');
+  await userEvent.keyboard('{Home}{ArrowRight>6}');
+  return editor;
+}
+
+describe('Cursor position after chip insertion', () => {
+  describe('/wp slash command (S chip)', () => {
+    it('cursor lands right after the chip, not at end of line', async () => {
+      renderEditor();
+      const editor = await setupEditorWithSurroundingText();
+
+      await userEvent.keyboard('/');
+      await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
+      await userEvent.click(page.getByText('Link existing work package').first());
+
+      const searchInput = page.getByPlaceholder('Search by work package ID or subject');
+      await userEvent.type(searchInput, 'Fix');
+      await expect.element(page.getByText('Fix login bug')).toBeVisible();
+      await userEvent.click(page.getByText('Fix login bug'));
+
+      await expect.element(page.getByText('Fix login bug')).toBeVisible();
+
+      await userEvent.keyboard('HERE');
+
+      await expect.element(editor).toHaveTextContent(/before.*#123.*HERE.*TAIL/);
+    });
+  });
+
+  describe('# hash menu (XXS chip — ID only)', () => {
+    it('cursor lands right after the chip, not on the next line', async () => {
+      renderEditor();
+      const editor = await setupEditorWithSurroundingText();
+
+      await userEvent.keyboard('#Fix');
+      await expect.element(page.getByText('Fix login bug')).toBeVisible();
+      await userEvent.click(page.getByText('Fix login bug'));
+      await expect.element(page.getByText('#123')).toBeVisible();
+
+      await userEvent.keyboard('HERE');
+
+      await expect.element(editor).toHaveTextContent(/before.*#123.*HERE.*TAIL/);
+    });
+  });
+
+  describe('## hash menu (XS chip — ID + type + subject)', () => {
+    it('cursor lands right after the chip, not on the next line', async () => {
+      renderEditor();
+      const editor = await setupEditorWithSurroundingText();
+
+      await userEvent.keyboard('##Fix');
+      await expect.element(page.getByText('Fix login bug')).toBeVisible();
+      await userEvent.click(page.getByText('Fix login bug'));
+      await expect.element(page.getByText('#123')).toBeVisible();
+
+      await userEvent.keyboard('HERE');
+
+      await expect.element(editor).toHaveTextContent(/before.*#123.*HERE.*TAIL/);
+    });
+  });
+
+  describe('### hash menu (S chip — ID + type + status + subject)', () => {
+    it('cursor lands right after the chip, not on the next line', async () => {
+      renderEditor();
+      const editor = await setupEditorWithSurroundingText();
+
+      await userEvent.keyboard('###Fix');
+      await expect.element(page.getByText('Fix login bug')).toBeVisible();
+      await userEvent.click(page.getByText('Fix login bug'));
+      await expect.element(page.getByText('#123')).toBeVisible();
+
+      await userEvent.keyboard('HERE');
+
+      await expect.element(editor).toHaveTextContent(/before.*#123.*HERE.*TAIL/);
+    });
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74397

# What are you trying to accomplish?
Fix incorrect cursor positioning after inserting or pasting a WP chip. Previously, after selecting a work package from the hash menu, the cursor would jump to the end of the line or the beginning of the next block instead of landing right after the inserted chip.

# What approach did you choose and why?
For inline chips, the cursor is now repositioned by finding the inserted node in the ProseMirror document via its instanceId and placing the selection directly after it (placeCursorAfterInlineNode). The previous approach relied on BlockNote's setTextCursorPosition which doesn't have enough precision for inline nodes - it snapped to block-level positions.

For block chips, the existing logic was correct but was duplicated across BlockWorkPackage.tsx and useInlineWpEvents.ts. It's now extracted into a shared moveCursorAfterBlock utility in lib/utils/cursor.ts

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
