### PR TITLE
fix: prevent options popover from being clipped in first editor row

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -200,6 +200,7 @@ export const BlockWorkPackageComponent = ({
                       currentSize={undefined}
                       currentBlockSize={cardSize}
                       instanceId={undefined}
+                      anchorEl={cardRef.current}
                       onClose={() => setIsOptionsOpen(false)}
                       onConvertToInline={handleConvertToInline}
                       onConvertToBlock={handleResizeBlock}

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -153,6 +153,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }: Inl
             wp={wp}
             currentSize={size}
             instanceId={instanceId}
+            anchorEl={chipRef.current}
             onClose={() => setIsSelected(false)}
             onResize={(newSize) => {
               wpBridge.resize({ instanceId, wpid: wp.id, size: newSize });

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { WorkPackage } from "../../openProjectTypes";
@@ -64,7 +64,7 @@ export const WpOptionsPopover = ({
     };
   }, [anchorEl, onClose]);
 
-  const fixedStyle: React.CSSProperties | undefined = anchorRect
+  const fixedStyle: CSSProperties | undefined = anchorRect
     ? {
         position: "fixed",
         bottom: window.innerHeight - anchorRect.top + 6,

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { WorkPackage } from "../../openProjectTypes";
@@ -46,12 +46,29 @@ export const WpOptionsPopover = ({
   const { t } = useTranslation();
   const [showSizes, setShowSizes] = useState(false);
 
-  const rect = anchorEl?.getBoundingClientRect();
-  const fixedStyle: React.CSSProperties | undefined = rect
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(
+    () => anchorEl?.getBoundingClientRect() ?? null
+  );
+
+  useEffect(() => {
+    if (!anchorEl) return;
+    const update = () => setAnchorRect(anchorEl.getBoundingClientRect());
+    const handleScroll = () => onClose();
+
+    update();
+    window.addEventListener("scroll", handleScroll, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", handleScroll, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [anchorEl, onClose]);
+
+  const fixedStyle: React.CSSProperties | undefined = anchorRect
     ? {
         position: "fixed",
-        bottom: window.innerHeight - rect.top + 6,
-        left: rect.left,
+        bottom: window.innerHeight - anchorRect.top + 6,
+        left: anchorRect.left,
       }
     : undefined;
 

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { WorkPackage } from "../../openProjectTypes";
 import { linkToWorkPackage } from "../../services/openProjectApi";
@@ -17,6 +18,7 @@ export interface WpOptionsProps {
   currentSize?: InlineWpSize;
   currentBlockSize?: BlockWpSize;
   instanceId?: string;
+  anchorEl?: HTMLElement | null;
   onClose: () => void;
   onResize?: (size: InlineWpSize) => void;
   onRemove?: () => void;
@@ -33,6 +35,7 @@ export const WpOptionsPopover = ({
   currentSize,
   currentBlockSize,
   instanceId: _instanceId,
+  anchorEl,
   onClose,
   onResize,
   onRemove,
@@ -42,6 +45,15 @@ export const WpOptionsPopover = ({
 }: WpOptionsProps) => {
   const { t } = useTranslation();
   const [showSizes, setShowSizes] = useState(false);
+
+  const rect = anchorEl?.getBoundingClientRect();
+  const fixedStyle: React.CSSProperties | undefined = rect
+    ? {
+        position: "fixed",
+        bottom: window.innerHeight - rect.top + 6,
+        left: rect.left,
+      }
+    : undefined;
 
   const isBlock = currentSize === undefined;
   
@@ -53,9 +65,9 @@ export const WpOptionsPopover = ({
     onClose();
   };
 
-  return (
+  const content = (
     // Prevent editor/parent handlers from stealing focus or closing the popover
-    <Popover onMouseDown={(e) => e.stopPropagation()}>
+    <Popover style={fixedStyle} onMouseDown={(e) => e.stopPropagation()}>
       <PopBtn
         title={t("options.openInNewTab")}
         aria-label={t("options.openAriaLabel", { id: formatWorkPackageId(wp.displayId) })}
@@ -154,6 +166,12 @@ export const WpOptionsPopover = ({
       </PopBtn>
     </Popover>
   );
+
+  if (anchorEl) {
+    const portalTarget = (anchorEl.closest(".bn-container") as HTMLElement | null) ?? document.body;
+    return createPortal(content, portalTarget);
+  }
+  return content;
 };
 
 const Popover = styled.div.attrs({

--- a/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
+++ b/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
@@ -4,6 +4,12 @@ import { page, userEvent } from 'vitest/browser';
 import { useState, useEffect } from 'react';
 import { InlineWorkPackageChip } from '../../../../lib/components/InlineWorkPackage/InlineWorkPackageChip';
 import { wpBridge } from '../../../../lib/services/wpBridge';
+import { renderEditor } from '../../../helpers/renderEditor';
+import {
+  insertInlineChipViaSlashMenu,
+  convertToCompactCard,
+  openBlockCardPopover,
+} from '../../../helpers/editorHelpers';
 
 afterEach(() => {
   cleanup();
@@ -106,6 +112,44 @@ describe('Inline chip size transitions (user-visible content)', () => {
 
     expect(deleteWasCalled).toBe(true);
     await expect.element(page.getByTestId('popover-content')).not.toBeInTheDocument();
+  });
+});
+
+describe('Options popover portal', () => {
+  it('inline chip: popover is rendered outside the chip DOM so it is not clipped by overflow', async () => {
+    render(
+      <div data-testid="chip-wrapper">
+        <InlineWorkPackageChip
+          inlineContent={{ props: { wpid: '123', size: 's', instanceId: 'iid-portal' } }}
+          contentRef={vi.fn()}
+        />
+      </div>,
+    );
+
+    await waitForResolvedChip();
+    await openPopover();
+
+    const chipWrapper = document.querySelector('[data-testid="chip-wrapper"]');
+    const popoverInsideWrapper = chipWrapper?.querySelector('[data-testid="popover-content"]');
+    expect(popoverInsideWrapper).toBeNull();
+
+    const popoverInDocument = document.querySelector('[data-testid="popover-content"]');
+    expect(popoverInDocument).not.toBeNull();
+  });
+
+  it('block card: popover is rendered outside the block DOM so it is not clipped by overflow', async () => {
+    renderEditor();
+    await insertInlineChipViaSlashMenu();
+    await convertToCompactCard();
+
+    await openBlockCardPopover();
+
+    const blockEl = document.querySelector('[data-content-type="openProjectWorkPackageBlock"]');
+    const popoverInsideBlock = blockEl?.querySelector('[data-testid="popover-content"]');
+    expect(popoverInsideBlock).toBeNull();
+
+    const popoverInDocument = document.querySelector('[data-testid="popover-content"]');
+    expect(popoverInDocument).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/75273

# What are you trying to accomplish?
Fix the options popover being clipped when a work package chip (inline or block) is placed in the first row of the editor. Clicking the chip opened the popover above it, but an ancestor container with overflow: hidden cut it off before it could fully render.


## Screenshots
<img width="538" height="339" alt="image" src="https://github.com/user-attachments/assets/6c9a47ce-4a32-4d1c-a9b3-6ba27011a0cf" />
<img width="538" height="339" alt="image" src="https://github.com/user-attachments/assets/fe34a0d5-0d2c-4ae6-85f1-271f51d73543" />


# What approach did you choose and why?
The popover is rendered via createPortal into the nearest .bn-container ancestor, and repositioned using position: fixed with coordinates derived from the chip's getBoundingClientRect().

Portaling to .bn-container specifically (rather than document.body) was intentional - BlockNote defines its CSS variables (--bn-colors-menu-background, --bn-shadow-medium, --bn-border-radius-large, etc.) on that element. Portaling directly to document.body broke all popover styles because those variables were no longer in scope.

position: fixed is what actually escapes the overflow: hidden clipping - fixed elements are only constrained by ancestors with transform or filter, not by overflow. Regular position: absolute stays clipped regardless of z-index.

Alternative considered: move the popover's DOM node up the tree without a portal by changing the HTML structure. Discarded because it would require significant refactoring of how chips compose their children, and portaling is the standard React pattern for this exact problem.


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
