### PR TITLE
fix: use consistent border-radius for block work package chip

### DIFF
--- a/lib/components/BlockWorkPackage/BlockCards.tsx
+++ b/lib/components/BlockWorkPackage/BlockCards.tsx
@@ -48,7 +48,7 @@ const CardBase = styled.div<{ $inDropdown: boolean }>`
   ${defaultWpVariables}
   padding: var(--spacer-m) var(--spacer-l);
   background-color: var(--highlight-wp-background);
-  border-radius: var(--bn-border-radius-small);
+  border-radius: var(--bn-border-radius);
 
   ${({ $inDropdown }) =>
     $inDropdown &&

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -18,6 +18,7 @@ import { formatWorkPackageId } from "../../utils/id";
 const Block = styled.div.attrs({ className: "op-bn-extensions" })`
   ${defaultWpVariables}
   background-color: var(--op-chip-bg);
+  border-radius: var(--bn-border-radius);
 `;
 
 const BlockCardWrapper = styled.div`


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/75307

# What are you trying to accomplish?
Apply the same border-radius to the block work package chip as the inline chip uses, so both components share a consistent rounded corner style.

## Screenshots
<img width="226" height="97" alt="image" src="https://github.com/user-attachments/assets/057a1acc-a260-412f-805f-db39ab6c3cf6" />

# What approach did you choose and why?
Added `border-radius: var(--bn-border-radius)` to the `Block` wrapper in `BlockWorkPackage.tsx` and updated `CardBase` in `BlockCards.tsx` to use the same token instead of `var(--bn-border-radius-small)`. The `--bn-border-radius` token is already used by the inline chip (`InlineWorkPackageChip`)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
