### PR TITLE
/wp on an empty line should create a block work-package link, not an inline one

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -14,11 +14,13 @@ import { SearchContainer, SearchLabel } from "../Search/SearchContainer";
 import { SearchDropdown } from "../Search/SearchDropdown";
 import { defaultWpVariables } from "../WorkPackage/atoms";
 import { moveCursorAfterBlock } from "../../utils/cursor";
+import { formatWorkPackageId } from "../../utils/id";
+import { pendingBlockRegistry } from "./pendingBlockRegistry";
 
-const Block = styled.div.attrs({ className: "op-bn-extensions" })`
+const Block = styled.div.attrs({ className: "op-bn-extensions" })<{ $pending?: boolean }>`
   ${defaultWpVariables}
-  background-color: var(--op-chip-bg);  
-  user-select: all; 
+  background-color: ${({ $pending }) => ($pending ? "transparent" : "var(--op-chip-bg)")};
+  user-select: all;
   border-radius: var(--bn-border-radius);
 `;
 
@@ -33,6 +35,8 @@ interface BlockProps {
   id: string;
   props: {
     wpid?: number;
+    // Not used for render logic - only written on select so the spec serialises
+    // data-initialized="true" in toExternalHTML.
     initialized?: boolean;
     size?: BlockWpSize;
   };
@@ -51,7 +55,6 @@ export const BlockWorkPackageComponent = ({
   // The hook handles triggering re-renders when data arrives.
   useColors();
 
-  const [isActive, setIsActive] = useState(false);
   const [isOptionsOpen, setIsOptionsOpen] = useState(false);
 
   const workPackageResult = useWorkPackage(block.props.wpid);
@@ -67,7 +70,12 @@ export const BlockWorkPackageComponent = ({
 
   const cardSize: BlockWpSize = block.props.size ?? "m";
 
+  useEffect(() => {
+    return () => { pendingBlockRegistry.delete(block.id); };
+  }, [block.id]);
+
   const handleSelectWorkPackage = (wp: WorkPackage) => {
+    pendingBlockRegistry.delete(block.id);
     editor.updateBlock(block, {
       props: { ...block.props, wpid: wp.id, displayId: wp.displayId, initialized: true },
     });
@@ -81,25 +89,12 @@ export const BlockWorkPackageComponent = ({
     sideMenu?.blockDragStart(e.nativeEvent, block as any);
   };
 
-  useEffect(() => {
-    // accessing private tiptap instance until public API is available
-    const tiptap = (editor as any)._tiptapEditor;
-    if (!tiptap) return;
-
-    const updateActiveState = () => {
-      setIsActive(editor.getTextCursorPosition()?.block?.id === block.id);
-    };
-
-    tiptap.on("selectionUpdate", updateActiveState);
-    updateActiveState();
-    return () => { tiptap.off("selectionUpdate", updateActiveState); };
-  }, [editor, block.id]);
-
   // Close options popover on outside click
   useEffect(() => {
     if (!isOptionsOpen) return;
     const handleClickOutside = (e: MouseEvent) => {
-      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+      const path = e.composedPath();
+      if (cardRef.current && !path.includes(cardRef.current as EventTarget)) {
         setIsOptionsOpen(false);
       }
     };
@@ -122,17 +117,12 @@ export const BlockWorkPackageComponent = ({
     editor.removeBlocks([block]);
   };
 
-  const disableFocus = block.props.initialized && !block.props.wpid;
+  const isPending = pendingBlockRegistry.has(block.id);
 
   return (
-    <Block
-      tabIndex={disableFocus ? -1 : 0}
-      style={disableFocus ? { pointerEvents: "none" } : undefined}
-      draggable="true"
-      onDragStart={handleBlockDragStart}
-    >
+    <Block $pending={isPending} draggable="true" onDragStart={handleBlockDragStart}>
       <div contentEditable={false} style={{ userSelect: "none" }}>
-        {!block.props.wpid && !block.props.initialized && isActive && (
+        {isPending && (
           <SearchContainer>
             <SearchLabel>
               {t("search.label")}
@@ -141,9 +131,8 @@ export const BlockWorkPackageComponent = ({
               autoFocus
               onSelect={handleSelectWorkPackage}
               onCancel={() => {
-                editor.updateBlock(block, {
-                  props: { ...block.props, initialized: true },
-                });
+                pendingBlockRegistry.delete(block.id);
+                editor.removeBlocks([block]);
                 editor.focus();
               }}
               renderItem={(wp) => <BlockCard workPackage={wp} inDropdown />}

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -74,7 +74,7 @@ export const BlockWorkPackageComponent = ({
   const handleSelectWorkPackage = (wp: WorkPackage) => {
     pendingBlockRegistry.delete(block.id);
     editor.updateBlock(block, {
-      props: { ...block.props, wpid: wp.id },
+      props: { ...block.props, wpid: wp.id, displayId: wp.displayId },
     });
     requestAnimationFrame(() => moveCursorAfterBlock(editor, block.id));
   };

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -14,7 +14,6 @@ import { SearchContainer, SearchLabel } from "../Search/SearchContainer";
 import { SearchDropdown } from "../Search/SearchDropdown";
 import { defaultWpVariables } from "../WorkPackage/atoms";
 import { moveCursorAfterBlock } from "../../utils/cursor";
-import { formatWorkPackageId } from "../../utils/id";
 import { pendingBlockRegistry } from "./pendingBlockRegistry";
 
 const Block = styled.div.attrs({ className: "op-bn-extensions" })<{ $pending?: boolean }>`
@@ -22,6 +21,7 @@ const Block = styled.div.attrs({ className: "op-bn-extensions" })<{ $pending?: b
   background-color: ${({ $pending }) => ($pending ? "transparent" : "var(--op-chip-bg)")};
   user-select: all;
   border-radius: var(--bn-border-radius);
+  ${({ $pending }) => $pending && "position: relative;"}
 `;
 
 const BlockCardWrapper = styled.div`
@@ -35,9 +35,6 @@ interface BlockProps {
   id: string;
   props: {
     wpid?: number;
-    // Not used for render logic - only written on select so the spec serialises
-    // data-initialized="true" in toExternalHTML.
-    initialized?: boolean;
     size?: BlockWpSize;
   };
 }
@@ -77,7 +74,7 @@ export const BlockWorkPackageComponent = ({
   const handleSelectWorkPackage = (wp: WorkPackage) => {
     pendingBlockRegistry.delete(block.id);
     editor.updateBlock(block, {
-      props: { ...block.props, wpid: wp.id, displayId: wp.displayId, initialized: true },
+      props: { ...block.props, wpid: wp.id },
     });
     requestAnimationFrame(() => moveCursorAfterBlock(editor, block.id));
   };
@@ -123,7 +120,7 @@ export const BlockWorkPackageComponent = ({
     <Block $pending={isPending} draggable="true" onDragStart={handleBlockDragStart}>
       <div contentEditable={false} style={{ userSelect: "none" }}>
         {isPending && (
-          <SearchContainer>
+          <SearchContainer $floating>
             <SearchLabel>
               {t("search.label")}
             </SearchLabel>

--- a/lib/components/BlockWorkPackage/blockConfig.ts
+++ b/lib/components/BlockWorkPackage/blockConfig.ts
@@ -4,7 +4,6 @@ export const blockConfig = createBlockConfig((() => ({
   type: "openProjectWorkPackageBlock" as const,
   propSchema: {
     wpid: { default: undefined, type: "number" },
-    initialized: { default: false, type: "boolean" },
     size: { default: "m", type: "string" },
     instanceId: { default: "", type: "string" },
     displayId: { default: "", type: "string" },

--- a/lib/components/BlockWorkPackage/pendingBlockRegistry.ts
+++ b/lib/components/BlockWorkPackage/pendingBlockRegistry.ts
@@ -1,0 +1,7 @@
+const pending = new Set<string>();
+
+export const pendingBlockRegistry = {
+  add: (blockId: string) => pending.add(blockId),
+  has: (blockId: string) => pending.has(blockId),
+  delete: (blockId: string) => pending.delete(blockId),
+};

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -6,6 +6,7 @@ import { registerInlineWpCallbacks, clearInlineWpCallbacks, makePendingWpid } fr
 import { makeInstanceId } from "../utils/id.ts";
 import { placeCursorAfterInlineNode } from "../utils/cursor.ts";
 import { pendingBlockRegistry } from "./BlockWorkPackage/pendingBlockRegistry";
+import { isCurrentBlockEmpty } from "../utils/blockContent.ts";
 
 type AnyEditor = BlockNoteEditor<any, any, any>;
 type AnyInlineNode = InlineContentFromConfig<any, any>;
@@ -77,20 +78,13 @@ function buildOnCancel(
   };
 }
 
-function isCurrentBlockEmpty(editor: AnyEditor): boolean {
-  const block = editor.getTextCursorPosition()?.block;
-  if (!block) return false;
-  const content = (block as any).content;
-  return Array.isArray(content) && content.length === 0;
-}
-
-function handleBlockWorkPackageClick(editor: AnyEditor): void {
+function insertBlockWorkPackage(editor: AnyEditor): void {
   const blockId = editor.getTextCursorPosition()?.block?.id as string | undefined;
   if (!blockId) return;
 
   const block = {
     type: "openProjectWorkPackageBlock" as const,
-    props: { initialized: false },
+    props: {},
   } as Parameters<typeof editor.insertBlocks>[0][number];
 
   const [insertedBlock] = editor.insertBlocks([block], blockId, "after");
@@ -100,7 +94,7 @@ function handleBlockWorkPackageClick(editor: AnyEditor): void {
   editor.removeBlocks([blockId]);
 }
 
-function handleInlineWorkPackageClick(editor: AnyEditor): void {
+function insertInlineWorkPackage(editor: AnyEditor): void {
   const instanceId = makeInstanceId();
   const pendingWpid = makePendingWpid(instanceId);
 
@@ -127,9 +121,9 @@ export const workPackageSlashMenu = (editor: BlockNoteEditor<any>) => ({
   title: i18n.t("slashMenu.title"),
   onItemClick: () => {
     if (isCurrentBlockEmpty(editor)) {
-      handleBlockWorkPackageClick(editor);
+      insertBlockWorkPackage(editor);
     } else {
-      handleInlineWorkPackageClick(editor);
+      insertInlineWorkPackage(editor);
     }
   },
   aliases: [...getAliases()],

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -5,6 +5,7 @@ import { getAliases } from "../services/slashMenuAliases";
 import { registerInlineWpCallbacks, clearInlineWpCallbacks, makePendingWpid } from "./InlineWorkPackage/callbacks";
 import { makeInstanceId } from "../utils/id.ts";
 import { placeCursorAfterInlineNode } from "../utils/cursor.ts";
+import { pendingBlockRegistry } from "./BlockWorkPackage/pendingBlockRegistry";
 
 type AnyEditor = BlockNoteEditor<any, any, any>;
 type AnyInlineNode = InlineContentFromConfig<any, any>;
@@ -76,6 +77,29 @@ function buildOnCancel(
   };
 }
 
+function isCurrentBlockEmpty(editor: AnyEditor): boolean {
+  const block = editor.getTextCursorPosition()?.block;
+  if (!block) return false;
+  const content = (block as any).content;
+  return Array.isArray(content) && content.length === 0;
+}
+
+function handleBlockWorkPackageClick(editor: AnyEditor): void {
+  const blockId = editor.getTextCursorPosition()?.block?.id as string | undefined;
+  if (!blockId) return;
+
+  const block = {
+    type: "openProjectWorkPackageBlock" as const,
+    props: { initialized: false },
+  } as Parameters<typeof editor.insertBlocks>[0][number];
+
+  const [insertedBlock] = editor.insertBlocks([block], blockId, "after");
+  if (!insertedBlock?.id) return;
+
+  pendingBlockRegistry.add(insertedBlock.id);
+  editor.removeBlocks([blockId]);
+}
+
 function handleInlineWorkPackageClick(editor: AnyEditor): void {
   const instanceId = makeInstanceId();
   const pendingWpid = makePendingWpid(instanceId);
@@ -101,7 +125,13 @@ function handleInlineWorkPackageClick(editor: AnyEditor): void {
 
 export const workPackageSlashMenu = (editor: BlockNoteEditor<any>) => ({
   title: i18n.t("slashMenu.title"),
-  onItemClick: () => handleInlineWorkPackageClick(editor),
+  onItemClick: () => {
+    if (isCurrentBlockEmpty(editor)) {
+      handleBlockWorkPackageClick(editor);
+    } else {
+      handleInlineWorkPackageClick(editor);
+    }
+  },
   aliases: [...getAliases()],
   group: "OpenProject",
   icon: <LinkIcon size={18} />,

--- a/lib/hooks/useInlineWpEvents.ts
+++ b/lib/hooks/useInlineWpEvents.ts
@@ -135,7 +135,7 @@ function handlePromoteToBlock(
 
   const blockNode = {
     type: 'openProjectWorkPackageBlock',
-    props: { wpid, initialized: true, size, displayId },
+    props: { wpid, size, displayId },
   } as Parameters<typeof editor.insertBlocks>[0][number];
 
   if (contentBefore.length > 0) {

--- a/lib/utils/blockContent.ts
+++ b/lib/utils/blockContent.ts
@@ -1,0 +1,10 @@
+import type { BlockNoteEditor } from "@blocknote/core";
+
+type AnyEditor = BlockNoteEditor<any, any, any>;
+
+export function isCurrentBlockEmpty(editor: AnyEditor): boolean {
+  const block = editor.getTextCursorPosition()?.block;
+  if (!block) return false;
+  const content = (block as any).content;
+  return Array.isArray(content) && content.length === 0;
+}

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -10,7 +10,7 @@ export async function openEditorAndType(text: string) {
 }
 
 export async function insertInlineWorkPackageViaSlashMenu(searchTerm:string='Fix', resultTerm:string='Fix login bug') {
-  await openEditorAndType('/');
+  await openEditorAndType(' /');
   await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
   await userEvent.click(page.getByText('Link existing work package').first());
 

--- a/test/lib/components/integration/editor.slashMenu.browser.test.tsx
+++ b/test/lib/components/integration/editor.slashMenu.browser.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+
+async function openSlashMenuAndSelectWp() {
+  await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
+  await userEvent.click(page.getByText('Link existing work package').first());
+
+  const searchInput = page.getByPlaceholder('Search by work package ID or subject');
+  await expect.element(searchInput).toBeVisible();
+  await userEvent.type(searchInput, 'Fix');
+  await expect.element(page.getByText('Fix login bug')).toBeVisible();
+  await userEvent.click(page.getByText('Fix login bug'));
+  await expect.element(searchInput).not.toBeInTheDocument();
+}
+
+describe('Slash menu - block vs inline routing', () => {
+  it('inserts a block card when triggered on an empty line', async () => {
+    renderEditor();
+    const editorEl = page.getByRole('textbox');
+    await userEvent.click(editorEl);
+    await userEvent.type(editorEl, '/');
+
+    await openSlashMenuAndSelectWp();
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+    await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
+  });
+
+  it('inserts an inline chip when triggered on a non-empty line', async () => {
+    renderEditor();
+    const editorEl = page.getByRole('textbox');
+    await userEvent.click(editorEl);
+    await userEvent.type(editorEl, 'Some text ');
+    await userEvent.type(editorEl, '/');
+
+    await openSlashMenuAndSelectWp();
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(page.getByTestId('block-card')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/75310

# What are you trying to accomplish?
When a user triggers the slash menu on an empty line and selects "Link existing work package", the work package should be inserted as a full-width block card rather than an inline chip. On a non-empty line the existing inline chip behaviour is preserved.

# What approach did you choose and why?
At slash menu selection time we check whether the current block's content is empty. If it is, we insert an openProjectWorkPackageBlock in place of the empty paragraph and register its ID in a module-level pendingBlockRegistry - a local in-memory Set, never synced to the document. The block component reads this registry to decide whether to render the search dropdown, which means only the user who triggered the insertion sees it; collaborators sharing the same document never get a search UI they did not ask for. This mirrors the existing pattern used by inline chips (registerInlineWpCallbacks). On cancel the block is removed entirely; on confirm the registry entry is cleared and the block receives its wpid. The mousedown outside-click handler in BlockWorkPackage was also updated to use e.composedPath() instead of contains(e.target) so the popover close logic works correctly inside a Shadow DOM.

As a side effect, the previous implementation accessed TipTap's private _tiptapEditor instance to subscribe to selectionUpdate events in order to track whether the block was "active". That coupling is now removed - the search dropdown visibility is driven entirely by the registry, with no dependency on editor internals.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
