### PR TITLE
[BNE-93] Semantic ID and markdown support for copy-paste

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -61,7 +61,7 @@ export const BlockWorkPackageComponent = ({
 
   const handleSelectWorkPackage = (wp: WorkPackage) => {
     editor.updateBlock(block, {
-      props: { ...block.props, wpid: wp.id, initialized: true },
+      props: { ...block.props, wpid: wp.id, displayId: wp.displayId, initialized: true },
     });
     requestAnimationFrame(() => moveCursorAfterBlock(editor, block.id));
   };

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -57,6 +57,14 @@ export const BlockWorkPackageComponent = ({
   const workPackageResult = useWorkPackage(block.props.wpid);
   const selectedWorkPackage = workPackageResult.workPackage;
 
+  useEffect(() => {
+    if (!selectedWorkPackage) return;
+    if (selectedWorkPackage.displayId === (block.props as any).displayId) return;
+    editor.updateBlock(block, {
+      props: { ...block.props, displayId: selectedWorkPackage.displayId },
+    });
+  }, [selectedWorkPackage?.displayId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const cardSize: BlockWpSize = block.props.size ?? "m";
 
   const handleSelectWorkPackage = (wp: WorkPackage) => {

--- a/lib/components/BlockWorkPackage/blockConfig.ts
+++ b/lib/components/BlockWorkPackage/blockConfig.ts
@@ -7,6 +7,7 @@ export const blockConfig = createBlockConfig((() => ({
     initialized: { default: false, type: "boolean" },
     size: { default: "m", type: "string" },
     instanceId: { default: "", type: "string" },
+    displayId: { default: "", type: "string" },
   },
   content: "none",
   isSelectable: false,

--- a/lib/components/BlockWorkPackage/externalHtml.ts
+++ b/lib/components/BlockWorkPackage/externalHtml.ts
@@ -10,12 +10,14 @@
 // The React spec applies the same data via JSX so the produced HTML matches
 // byte-for-byte.
 
-import { buildExternalDOM } from "../WorkPackage/externalHtml";
+import { buildExternalDOM, hashPrefixForSize } from "../WorkPackage/externalHtml";
+import { linkToWorkPackage } from "../../services/openProjectApi";
 
 export interface WorkPackageBlockProps {
   wpid?: number | string;
   instanceId?: string;
   size?: string;
+  displayId?: string;
 }
 
 export interface WorkPackageBlockExternalData {
@@ -24,8 +26,10 @@ export interface WorkPackageBlockExternalData {
     "data-wpid": string;
     "data-instance-id": string;
     "data-size": string;
+    "data-display-id": string;
   };
   text: string;
+  href: string;
 }
 
 export function computeWorkPackageBlockExternalData(
@@ -33,14 +37,17 @@ export function computeWorkPackageBlockExternalData(
 ): WorkPackageBlockExternalData | null {
   const wpid = props.wpid;
   if (!wpid) return null;
+  const displayId = props.displayId || String(wpid);
   return {
     attrs: {
       "data-block-content-type": "openProjectWorkPackageBlock",
       "data-wpid": String(wpid),
       "data-instance-id": props.instanceId ?? "",
       "data-size": props.size ?? "m",
+      "data-display-id": displayId,
     },
-    text: `#${wpid}`,
+    text: hashPrefixForSize(props.size) + displayId,
+    href: linkToWorkPackage(String(wpid)),
   };
 }
 
@@ -48,7 +55,7 @@ export function buildWorkPackageBlockExternalDOM(
   data: WorkPackageBlockExternalData,
   doc: Document,
 ): HTMLElement {
-  return buildExternalDOM("div", data.attrs, data.text, doc);
+  return buildExternalDOM("div", data.attrs, data.text, doc, data.href);
 }
 
 export function parseWorkPackageBlockExternalHTML(
@@ -60,9 +67,11 @@ export function parseWorkPackageBlockExternalHTML(
   const wpid = element.getAttribute("data-wpid");
   const instanceId = element.getAttribute("data-instance-id") ?? "";
   const size = element.getAttribute("data-size") ?? "m";
+  const displayId = element.getAttribute("data-display-id") ?? "";
   return {
     wpid: wpid ? Number(wpid) : undefined,
     instanceId,
     size,
+    displayId,
   };
 }

--- a/lib/components/BlockWorkPackage/spec.tsx
+++ b/lib/components/BlockWorkPackage/spec.tsx
@@ -18,10 +18,12 @@ export const openProjectWorkPackageBlockSpec = createReactBlockSpec(
       />
     ),
 
+    // Produces the same HTML as buildWorkPackageBlockExternalDOM (used by staticSpec.ts).
+    // Uses JSX because React's toExternalHTML must return a React element, not a DOM node.
     toExternalHTML: ({ block }) => {
       const data = computeWorkPackageBlockExternalData(block.props);
       if (!data) return <></>;
-      return <div {...data.attrs}>{data.text}</div>;
+      return <div {...data.attrs}><a href={data.href}>{data.text}</a></div>;
     },
 
     parse: (element) => parseWorkPackageBlockExternalHTML(element),

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -44,7 +44,7 @@ export function insertWpChip(editor: AnyEditor, wp: WorkPackage, size: InlineWpS
   const instanceId = makeInstanceId();
 
   (editor.insertInlineContent as (content: unknown[]) => void)([
-    { type: "openProjectWorkPackageInline", props: { wpid: String(wp.id), instanceId, size } },
+    { type: "openProjectWorkPackageInline", props: { wpid: String(wp.id), instanceId, size, displayId: wp.displayId } },
     { type: "text", text: " ", styles: {} },
   ]);
 

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -87,7 +87,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }: Inl
       <InlineChip ref={setRef}>
         <WorkPackageSearchPopover
           onSelect={(selectedWp) => {
-            pendingCallbacks.onSelect(selectedWp.id);
+            pendingCallbacks.onSelect(selectedWp.id, selectedWp.displayId);
             clearInlineWpCallbacks(instanceId);
           }}
           onCancel={() => {

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -9,6 +9,7 @@ import { WpChipXXS, WpChipXS, WpChipS } from "./InlineChips";
 import { WorkPackageSearchPopover } from "../Search/WorkPackageSearchPopover";
 import { WpOptionsPopover } from "../WorkPackage/OptionsPopover";
 import { getPendingCallbacks, clearInlineWpCallbacks } from "./callbacks";
+import { updateInlineChip } from "../../hooks/useInlineWpEvents";
 import type { InlineWpSize } from "../WorkPackage/types";
 import { wpBridge } from "../../services/wpBridge";
 import { BlockCard } from "../BlockWorkPackage/BlockCard";
@@ -58,6 +59,12 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }: Inl
   useColors();
 
   const { workPackage: wp, loading } = useWorkPackage(wpid);
+
+  useEffect(() => {
+    if (!wp || !editor) return;
+    if (wp.displayId === ((inlineContent.props as any).displayId || '')) return;
+    updateInlineChip(editor, instanceId, (chip) => ({ ...chip, props: { ...chip.props, displayId: wp.displayId } }));
+  }, [wp?.displayId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [isSelected, setIsSelected] = useState(false);
   const chipRef = useRef<HTMLElement | null>(null);

--- a/lib/components/InlineWorkPackage/callbacks.ts
+++ b/lib/components/InlineWorkPackage/callbacks.ts
@@ -6,7 +6,7 @@
 // and calls `onSelect` / `onCancel` when the user picks a WP or dismisses.
 
 
-type WpSelectedCallback = (wpid: number) => void;
+type WpSelectedCallback = (wpid: number, displayId: string) => void;
 type WpCancelCallback = () => void;
 
 export interface PendingCallbacks {

--- a/lib/components/InlineWorkPackage/externalHtml.ts
+++ b/lib/components/InlineWorkPackage/externalHtml.ts
@@ -4,12 +4,14 @@
 // Mirrors the structure of BlockWorkPackage/externalHtml.ts so that the React
 // spec and the static spec produce byte-identical output.
 
-import { buildExternalDOM } from "../WorkPackage/externalHtml";
+import { buildExternalDOM, hashPrefixForSize } from "../WorkPackage/externalHtml";
+import { linkToWorkPackage } from "../../services/openProjectApi";
 
 export interface WorkPackageInlineProps {
   wpid?: string;
   instanceId?: string;
   size?: string;
+  displayId?: string;
 }
 
 export interface WorkPackageInlineExternalData {
@@ -18,8 +20,10 @@ export interface WorkPackageInlineExternalData {
     "data-wpid": string;
     "data-instance-id": string;
     "data-size": string;
+    "data-display-id": string;
   };
   text: string;
+  href: string;
 }
 
 export function computeWorkPackageInlineExternalData(
@@ -27,14 +31,17 @@ export function computeWorkPackageInlineExternalData(
 ): WorkPackageInlineExternalData | null {
   const { wpid, instanceId, size } = props;
   if (!wpid || wpid.startsWith("pending:")) return null;
+  const displayId = props.displayId || wpid;
   return {
     attrs: {
       "data-inline-content-type": "openProjectWorkPackageInline",
       "data-wpid": wpid,
       "data-instance-id": instanceId ?? "",
       "data-size": size ?? "s",
+      "data-display-id": displayId,
     },
-    text: `#${wpid}`,
+    text: hashPrefixForSize(size) + displayId,
+    href: linkToWorkPackage(wpid),
   };
 }
 
@@ -42,7 +49,7 @@ export function buildWorkPackageInlineExternalDOM(
   data: WorkPackageInlineExternalData,
   doc: Document,
 ): HTMLElement {
-  return buildExternalDOM("span", data.attrs, data.text, doc);
+  return buildExternalDOM("span", data.attrs, data.text, doc, data.href);
 }
 
 export function parseWorkPackageInlineExternalHTML(
@@ -55,5 +62,6 @@ export function parseWorkPackageInlineExternalHTML(
     wpid: element.getAttribute("data-wpid") ?? "",
     instanceId: element.getAttribute("data-instance-id") ?? "",
     size: element.getAttribute("data-size") ?? "s",
+    displayId: element.getAttribute("data-display-id") ?? "",
   };
 }

--- a/lib/components/InlineWorkPackage/inlineConfig.ts
+++ b/lib/components/InlineWorkPackage/inlineConfig.ts
@@ -4,6 +4,7 @@ export const inlineConfig = {
     wpid: { default: "" },
     instanceId: { default: "" },
     size: { default: "s" },
+    displayId: { default: "", type: "string" },
   },
   content: "none" as const,
 };

--- a/lib/components/InlineWorkPackage/spec.tsx
+++ b/lib/components/InlineWorkPackage/spec.tsx
@@ -13,14 +13,17 @@ export const openProjectWorkPackageInlineSpec = createReactInlineContentSpec(
       <InlineWorkPackageChip inlineContent={inlineContent} contentRef={contentRef} editor={editor}/>
     ),
 
-    // BlockNote's InlineContentWrapper already wraps this output in a span carrying
-    // data-inline-content-type, data-wpid, and data-instance-id from the prop schema.
-    // data-size is also serialised onto the outer span for non-default values by BlockNote.
-    // Returning just the text avoids a duplicate inner span with the same attributes.
+    // toExternalHTML is used by two paths:
+    //   1. renderHTML (TipTap/ProseMirror clipboard) — addInlineContentAttributes decorates
+    //      the root DOM element with data-inline-content-type etc.
+    //   2. External HTML exporter — InlineContentWrapper adds a span with the same attrs.
+    // Using <a> as root in path 1 causes ProseMirror's Link mark parseDOM rule to fire on
+    // paste, turning the chip back into a plain link.  A <span> root avoids that conflict
+    // while still emitting a real hyperlink inside the span for external/markdown use.
     toExternalHTML: ({ inlineContent }) => {
       const data = computeWorkPackageInlineExternalData(inlineContent.props);
       if (!data) return <></>;
-      return <>{data.text}</>;
+      return <span><a href={data.href}>{data.text}</a></span>;
     },
 
     parse: (element) => parseWorkPackageInlineExternalHTML(element),

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -23,8 +23,8 @@ function buildOnSelect(
   blockId: string,
   pendingWpid: string,
   instanceId: string
-): (wpid: number) => void {
-  return (wpid: number) => {
+): (wpid: number, displayId: string) => void {
+  return (wpid: number, displayId: string) => {
     const current = getBlockContent(editor, blockId);
     if (!current) return;
 
@@ -36,7 +36,7 @@ function buildOnSelect(
     const updatedContent = current.content.map((node) => {
       const n = node as { type: string; props?: { wpid?: string; instanceId?: string } };
       if (n.type === "openProjectWorkPackageInline" && n.props?.wpid === pendingWpid) {
-        return { ...n, props: { ...n.props, wpid: String(wpid), instanceId } };
+        return { ...n, props: { ...n.props, wpid: String(wpid), instanceId, displayId } };
       }
       return node;
     });

--- a/lib/components/WorkPackage/externalHtml.ts
+++ b/lib/components/WorkPackage/externalHtml.ts
@@ -1,13 +1,23 @@
+export function hashPrefixForSize(size: string | undefined): string {
+  if (size === 'xxs') return '#';
+  if (size === 'xs') return '##';
+  return '###'; // s, m, l, xl, undefined
+}
+
 export function buildExternalDOM(
   tag: "div" | "span",
   attrs: Record<string, string>,
   text: string,
   doc: Document,
+  href: string,
 ): HTMLElement {
-  const el = doc.createElement(tag);
+  const element = doc.createElement(tag);
   for (const [name, value] of Object.entries(attrs)) {
-    el.setAttribute(name, value);
+    element.setAttribute(name, value);
   }
-  el.textContent = text;
-  return el;
+  const a = doc.createElement("a");
+  a.setAttribute("href", href);
+  a.textContent = text;
+  element.appendChild(a);
+  return element;
 }

--- a/lib/hooks/useInlineWpEvents.ts
+++ b/lib/hooks/useInlineWpEvents.ts
@@ -72,7 +72,7 @@ function findInlineChip(editor:AnyEditor, instanceId:string):FoundInlineBlock | 
 
 // The updater returns the updated node, or null to remove it.
 // Returns found so the caller can use it without a second traversal.
-function updateInlineChip(
+export function updateInlineChip(
   editor:AnyEditor,
   instanceId:string,
   updater:(chip:InlineWpNode) => InlineWpNode | null

--- a/lib/hooks/useInlineWpEvents.ts
+++ b/lib/hooks/useInlineWpEvents.ts
@@ -123,6 +123,7 @@ function handlePromoteToBlock(
   // wpid must be a positive integer
   const wpid = Number(found.chip.props.wpid);
   if (Number.isNaN(wpid) || wpid <= 0) return;
+  const displayId = (found.chip.props as any).displayId || String(found.chip.props.wpid);
 
   const chipIndex = found.content.findIndex(
     (node) => isInlineWpNode(node) && node.props.instanceId === instanceId
@@ -134,7 +135,7 @@ function handlePromoteToBlock(
 
   const blockNode = {
     type: 'openProjectWorkPackageBlock',
-    props: { wpid, initialized: true, size },
+    props: { wpid, initialized: true, size, displayId },
   } as Parameters<typeof editor.insertBlocks>[0][number];
 
   if (contentBefore.length > 0) {
@@ -178,6 +179,7 @@ function handleConvertToInline(
 ):void {
   const block = editor.getBlock(blockId);
   if (!block) return;
+  const displayId = (block?.props as any)?.displayId || String(wpid);
 
   const instanceId = makeInstanceId();
 
@@ -186,7 +188,7 @@ function handleConvertToInline(
     content:[
       {
         type:'openProjectWorkPackageInline',
-        props:{ wpid:String(wpid), instanceId, size },
+        props:{ wpid:String(wpid), instanceId, size, displayId },
       },
     ],
   } as Parameters<typeof editor.insertBlocks>[0][number];

--- a/test/lib/components/BlockWorkPackage/externalHtml.test.ts
+++ b/test/lib/components/BlockWorkPackage/externalHtml.test.ts
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
+import { initOpenProjectApi } from "../../../../lib/services/openProjectApi";
 import {
   computeWorkPackageBlockExternalData,
   buildWorkPackageBlockExternalDOM,
   parseWorkPackageBlockExternalHTML,
 } from "../../../../lib/components/BlockWorkPackage/externalHtml";
+
+beforeAll(() => {
+  initOpenProjectApi({ baseUrl: "http://localhost:3000" });
+});
 
 describe("computeWorkPackageBlockExternalData", () => {
   it("returns null when wpid is absent", () => {
@@ -15,48 +20,64 @@ describe("computeWorkPackageBlockExternalData", () => {
     expect(computeWorkPackageBlockExternalData({ wpid: 0 })).toBeNull();
   });
 
-  it("returns correct attrs for a numeric wpid", () => {
-    const result = computeWorkPackageBlockExternalData({ wpid: 42, instanceId: "inst1", size: "l" });
+  it("returns correct attrs and link for a numeric wpid with displayId", () => {
+    const result = computeWorkPackageBlockExternalData({ wpid: 42, instanceId: "inst1", size: "l", displayId: "PROJ-42" });
     expect(result).toEqual({
       attrs: {
         "data-block-content-type": "openProjectWorkPackageBlock",
         "data-wpid": "42",
         "data-instance-id": "inst1",
         "data-size": "l",
+        "data-display-id": "PROJ-42",
       },
-      text: "#42",
+      text: "###PROJ-42",
+      href: "http://localhost:3000/wp/42",
     });
   });
 
-  it("returns correct attrs for a string wpid", () => {
-    const result = computeWorkPackageBlockExternalData({ wpid: "99" });
-    expect(result?.attrs["data-wpid"]).toBe("99");
-    expect(result?.text).toBe("#99");
+  it("falls back to wpid as displayId when displayId is absent", () => {
+    const result = computeWorkPackageBlockExternalData({ wpid: 42 });
+    expect(result?.attrs["data-display-id"]).toBe("42");
+    expect(result?.text).toBe("###42");
   });
 
-  it("defaults size to \"m\" when absent", () => {
-    expect(computeWorkPackageBlockExternalData({ wpid: 1 })?.attrs["data-size"]).toBe("m");
+  it("uses ### prefix for all block sizes (m/l/xl)", () => {
+    expect(computeWorkPackageBlockExternalData({ wpid: 1, size: "m" })?.text).toMatch(/^###/);
+    expect(computeWorkPackageBlockExternalData({ wpid: 1, size: "l" })?.text).toMatch(/^###/);
+    expect(computeWorkPackageBlockExternalData({ wpid: 1, size: "xl" })?.text).toMatch(/^###/);
   });
 
-  it("defaults instanceId to empty string when absent", () => {
-    expect(computeWorkPackageBlockExternalData({ wpid: 1 })?.attrs["data-instance-id"]).toBe("");
+  it("href always uses the numeric wpid", () => {
+    const result = computeWorkPackageBlockExternalData({ wpid: 99, displayId: "PROJ-99" });
+    expect(result?.href).toBe("http://localhost:3000/wp/99");
+  });
+
+  it("defaults size to \"m\" and instanceId to empty string when absent", () => {
+    const result = computeWorkPackageBlockExternalData({ wpid: 1 });
+    expect(result?.attrs["data-size"]).toBe("m");
+    expect(result?.attrs["data-instance-id"]).toBe("");
   });
 });
 
 describe("buildWorkPackageBlockExternalDOM", () => {
-  it("returns a <div> with all four data attributes", () => {
-    const data = computeWorkPackageBlockExternalData({ wpid: 42, instanceId: "inst1", size: "l" })!;
+  it("returns a <div> with all five data attributes", () => {
+    const data = computeWorkPackageBlockExternalData({ wpid: 42, instanceId: "inst1", size: "l", displayId: "PROJ-42" })!;
     const el = buildWorkPackageBlockExternalDOM(data, document);
     expect(el.tagName.toLowerCase()).toBe("div");
     expect(el.getAttribute("data-block-content-type")).toBe("openProjectWorkPackageBlock");
     expect(el.getAttribute("data-wpid")).toBe("42");
     expect(el.getAttribute("data-instance-id")).toBe("inst1");
     expect(el.getAttribute("data-size")).toBe("l");
+    expect(el.getAttribute("data-display-id")).toBe("PROJ-42");
   });
 
-  it("sets text content to '#<wpid>'", () => {
-    const data = computeWorkPackageBlockExternalData({ wpid: 42 })!;
-    expect(buildWorkPackageBlockExternalDOM(data, document).textContent).toBe("#42");
+  it("contains an <a> child with the correct href and text", () => {
+    const data = computeWorkPackageBlockExternalData({ wpid: 42, displayId: "PROJ-42" })!;
+    const el = buildWorkPackageBlockExternalDOM(data, document);
+    const a = el.querySelector("a");
+    expect(a).not.toBeNull();
+    expect(a!.textContent).toBe("###PROJ-42");
+    expect(a!.getAttribute("href")).toBe("http://localhost:3000/wp/42");
   });
 });
 
@@ -77,7 +98,8 @@ describe("parseWorkPackageBlockExternalHTML", () => {
     el.setAttribute("data-wpid", "42");
     el.setAttribute("data-instance-id", "inst1");
     el.setAttribute("data-size", "l");
-    expect(parseWorkPackageBlockExternalHTML(el)).toEqual({ wpid: 42, instanceId: "inst1", size: "l" });
+    el.setAttribute("data-display-id", "PROJ-42");
+    expect(parseWorkPackageBlockExternalHTML(el)).toEqual({ wpid: 42, instanceId: "inst1", size: "l", displayId: "PROJ-42" });
   });
 
   it("converts data-wpid to a number", () => {
@@ -87,18 +109,20 @@ describe("parseWorkPackageBlockExternalHTML", () => {
     expect(parseWorkPackageBlockExternalHTML(el)?.wpid).toBe(99);
   });
 
-  it("falls back to size \"m\" when data-size is absent", () => {
+  it("falls back to size \"m\" and empty displayId when attrs are absent", () => {
     const el = document.createElement("div");
     el.setAttribute("data-block-content-type", "openProjectWorkPackageBlock");
     el.setAttribute("data-wpid", "1");
-    expect(parseWorkPackageBlockExternalHTML(el)?.size).toBe("m");
+    const result = parseWorkPackageBlockExternalHTML(el);
+    expect(result?.size).toBe("m");
+    expect(result?.displayId).toBe("");
   });
 });
 
 describe("round-trip: compute → build → parse", () => {
-  it("recovers wpid (as number), instanceId, and size", () => {
-    const data = computeWorkPackageBlockExternalData({ wpid: 42, instanceId: "inst1", size: "l" })!;
+  it("recovers wpid (as number), instanceId, size, and displayId", () => {
+    const data = computeWorkPackageBlockExternalData({ wpid: 42, instanceId: "inst1", size: "l", displayId: "PROJ-42" })!;
     const el = buildWorkPackageBlockExternalDOM(data, document);
-    expect(parseWorkPackageBlockExternalHTML(el)).toEqual({ wpid: 42, instanceId: "inst1", size: "l" });
+    expect(parseWorkPackageBlockExternalHTML(el)).toEqual({ wpid: 42, instanceId: "inst1", size: "l", displayId: "PROJ-42" });
   });
 });

--- a/test/lib/components/InlineWorkPackage/externalHtml.test.ts
+++ b/test/lib/components/InlineWorkPackage/externalHtml.test.ts
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
+import { initOpenProjectApi } from "../../../../lib/services/openProjectApi";
 import {
   computeWorkPackageInlineExternalData,
   buildWorkPackageInlineExternalDOM,
   parseWorkPackageInlineExternalHTML,
 } from "../../../../lib/components/InlineWorkPackage/externalHtml";
+
+beforeAll(() => {
+  initOpenProjectApi({ baseUrl: "http://localhost:3000" });
+});
 
 describe("computeWorkPackageInlineExternalData", () => {
   it("returns null when wpid is absent", () => {
@@ -19,42 +24,70 @@ describe("computeWorkPackageInlineExternalData", () => {
     expect(computeWorkPackageInlineExternalData({ wpid: "pending:abc123" })).toBeNull();
   });
 
-  it("returns correct attrs for a valid wpid", () => {
-    const result = computeWorkPackageInlineExternalData({ wpid: "57", instanceId: "inst1", size: "xs" });
+  it("returns correct attrs and link for a valid wpid with displayId", () => {
+    const result = computeWorkPackageInlineExternalData({ wpid: "57", instanceId: "inst1", size: "xs", displayId: "PROJ-57" });
     expect(result).toEqual({
       attrs: {
         "data-inline-content-type": "openProjectWorkPackageInline",
         "data-wpid": "57",
         "data-instance-id": "inst1",
         "data-size": "xs",
+        "data-display-id": "PROJ-57",
       },
-      text: "#57",
+      text: "##PROJ-57",
+      href: "http://localhost:3000/wp/57",
     });
   });
 
-  it("defaults size to \"s\" when absent", () => {
-    expect(computeWorkPackageInlineExternalData({ wpid: "1" })?.attrs["data-size"]).toBe("s");
+  it("falls back to wpid as displayId when displayId is absent", () => {
+    const result = computeWorkPackageInlineExternalData({ wpid: "57" });
+    expect(result?.attrs["data-display-id"]).toBe("57");
+    expect(result?.text).toBe("###57");
   });
 
-  it("defaults instanceId to empty string when absent", () => {
-    expect(computeWorkPackageInlineExternalData({ wpid: "1" })?.attrs["data-instance-id"]).toBe("");
+  it("uses # prefix for xxs", () => {
+    expect(computeWorkPackageInlineExternalData({ wpid: "1", displayId: "X", size: "xxs" })?.text).toBe("#X");
+  });
+
+  it("uses ## prefix for xs", () => {
+    expect(computeWorkPackageInlineExternalData({ wpid: "1", displayId: "X", size: "xs" })?.text).toBe("##X");
+  });
+
+  it("uses ### prefix for s", () => {
+    expect(computeWorkPackageInlineExternalData({ wpid: "1", displayId: "X", size: "s" })?.text).toBe("###X");
+  });
+
+  it("href always uses the wpid, not the displayId", () => {
+    const result = computeWorkPackageInlineExternalData({ wpid: "57", displayId: "PROJ-57" });
+    expect(result?.href).toBe("http://localhost:3000/wp/57");
+  });
+
+  it("defaults size to \"s\" and instanceId to empty string when absent", () => {
+    const result = computeWorkPackageInlineExternalData({ wpid: "1" });
+    expect(result?.attrs["data-size"]).toBe("s");
+    expect(result?.attrs["data-instance-id"]).toBe("");
   });
 });
 
 describe("buildWorkPackageInlineExternalDOM", () => {
-  it("returns a <span> with all four data attributes", () => {
-    const data = computeWorkPackageInlineExternalData({ wpid: "57", instanceId: "inst1", size: "xs" })!;
+  it("returns a <span> with all five data attributes", () => {
+    const data = computeWorkPackageInlineExternalData({ wpid: "57", instanceId: "inst1", size: "xs", displayId: "PROJ-57" })!;
     const el = buildWorkPackageInlineExternalDOM(data, document);
     expect(el.tagName.toLowerCase()).toBe("span");
     expect(el.getAttribute("data-inline-content-type")).toBe("openProjectWorkPackageInline");
     expect(el.getAttribute("data-wpid")).toBe("57");
     expect(el.getAttribute("data-instance-id")).toBe("inst1");
     expect(el.getAttribute("data-size")).toBe("xs");
+    expect(el.getAttribute("data-display-id")).toBe("PROJ-57");
   });
 
-  it("sets text content to '#<wpid>'", () => {
-    const data = computeWorkPackageInlineExternalData({ wpid: "57" })!;
-    expect(buildWorkPackageInlineExternalDOM(data, document).textContent).toBe("#57");
+  it("contains an <a> child with the correct href and text", () => {
+    const data = computeWorkPackageInlineExternalData({ wpid: "57", displayId: "PROJ-57", size: "xs" })!;
+    const el = buildWorkPackageInlineExternalDOM(data, document);
+    const a = el.querySelector("a");
+    expect(a).not.toBeNull();
+    expect(a!.textContent).toBe("##PROJ-57");
+    expect(a!.getAttribute("href")).toBe("http://localhost:3000/wp/57");
   });
 });
 
@@ -75,21 +108,24 @@ describe("parseWorkPackageInlineExternalHTML", () => {
     el.setAttribute("data-wpid", "57");
     el.setAttribute("data-instance-id", "inst1");
     el.setAttribute("data-size", "xs");
-    expect(parseWorkPackageInlineExternalHTML(el)).toEqual({ wpid: "57", instanceId: "inst1", size: "xs" });
+    el.setAttribute("data-display-id", "PROJ-57");
+    expect(parseWorkPackageInlineExternalHTML(el)).toEqual({ wpid: "57", instanceId: "inst1", size: "xs", displayId: "PROJ-57" });
   });
 
-  it("falls back to size \"s\" when data-size is absent", () => {
+  it("falls back to size \"s\" and empty displayId when attrs are absent", () => {
     const el = document.createElement("span");
     el.setAttribute("data-inline-content-type", "openProjectWorkPackageInline");
     el.setAttribute("data-wpid", "57");
-    expect(parseWorkPackageInlineExternalHTML(el)?.size).toBe("s");
+    const result = parseWorkPackageInlineExternalHTML(el);
+    expect(result?.size).toBe("s");
+    expect(result?.displayId).toBe("");
   });
 });
 
 describe("round-trip: compute → build → parse", () => {
-  it("recovers wpid, instanceId, and size", () => {
-    const data = computeWorkPackageInlineExternalData({ wpid: "57", instanceId: "inst1", size: "xs" })!;
+  it("recovers wpid, instanceId, size, and displayId", () => {
+    const data = computeWorkPackageInlineExternalData({ wpid: "57", instanceId: "inst1", size: "xs", displayId: "PROJ-57" })!;
     const el = buildWorkPackageInlineExternalDOM(data, document);
-    expect(parseWorkPackageInlineExternalHTML(el)).toEqual({ wpid: "57", instanceId: "inst1", size: "xs" });
+    expect(parseWorkPackageInlineExternalHTML(el)).toEqual({ wpid: "57", instanceId: "inst1", size: "xs", displayId: "PROJ-57" });
   });
 });

--- a/test/lib/components/staticSpec.test.ts
+++ b/test/lib/components/staticSpec.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
+import { initOpenProjectApi } from "../../../lib/services/openProjectApi";
 import { openProjectWorkPackageStaticBlockSpec } from "../../../lib/components/BlockWorkPackage/staticSpec";
 import { openProjectWorkPackageStaticInlineSpec } from "../../../lib/components/InlineWorkPackage/staticSpec";
 import {
@@ -17,6 +18,10 @@ import {openProjectWorkPackageBlockSpec, openProjectWorkPackageInlineSpec} from 
 // toExternalHTML and parse are consistent with the underlying functions so that
 // Hocuspocus (server-side) and the React spec always produce identical HTML.
 
+beforeAll(() => {
+  initOpenProjectApi({ baseUrl: "http://localhost:3000" });
+});
+
 // createBlockSpec returns a creator function; call it to get the spec.
 // createInlineContentSpec returns the spec directly.
 const blockImpl = (openProjectWorkPackageStaticBlockSpec as any)().implementation;
@@ -25,8 +30,8 @@ const inlineImpl = (openProjectWorkPackageStaticInlineSpec as any).implementatio
 const reactInlineImpl = (openProjectWorkPackageInlineSpec as any).implementation;
 
 describe("static block spec — toExternalHTML", () => {
-  it("produces a DOM node matching buildWorkPackageBlockExternalDOM", () => {
-    const props = { wpid: 42, instanceId: "inst1", size: "l" };
+  it("produces a DOM node whose innerHTML matches buildWorkPackageBlockExternalDOM", () => {
+    const props = { wpid: 42, instanceId: "inst1", size: "l", displayId: "PROJ-42" };
     const specResult = blockImpl.toExternalHTML({ props }) as { dom: HTMLElement } | undefined;
     const expected = buildWorkPackageBlockExternalDOM(computeWorkPackageBlockExternalData(props)!, document);
     // BlockNote wraps the returned dom in an outer block-content div;
@@ -46,12 +51,13 @@ describe("static block spec — parse", () => {
     element.setAttribute("data-wpid", "42");
     element.setAttribute("data-instance-id", "inst1");
     element.setAttribute("data-size", "l");
+    element.setAttribute("data-display-id", "PROJ-42");
     return element;
   };
 
   it("parses the HTML element", () => {
     const element = makeBlockElement();
-    expect(blockImpl.parse(element)).toEqual({ wpid: 42, instanceId: "inst1", size: "l" });
+    expect(blockImpl.parse(element)).toEqual({ wpid: 42, instanceId: "inst1", size: "l", "displayId": "PROJ-42" });
   });
 
   it("parses the HTML element in the same way as the react block spec", () => {
@@ -66,7 +72,7 @@ describe("static block spec — parse", () => {
 
 describe("static inline spec — toExternalHTML", () => {
   it("produces a DOM node matching buildWorkPackageInlineExternalDOM", () => {
-    const props = { wpid: "57", instanceId: "inst1", size: "xs" };
+    const props = { wpid: "57", instanceId: "inst1", size: "xs", displayId: "PROJ-57" };
     const specResult = inlineImpl.toExternalHTML({ props }) as { dom: HTMLElement } | undefined;
     const expected = buildWorkPackageInlineExternalDOM(computeWorkPackageInlineExternalData(props)!, document);
     expect(specResult?.dom.outerHTML).toBe(expected.outerHTML);
@@ -88,12 +94,13 @@ describe("static inline spec — parse", () => {
     element.setAttribute("data-wpid", "57");
     element.setAttribute("data-instance-id", "inst1");
     element.setAttribute("data-size", "xs");
+    element.setAttribute("data-display-id", "PROJ-57");
     return element;
   };
 
   it("parses the HTML element", () => {
     const element = makeInlineElement();
-    expect(inlineImpl.parse(element)).toEqual({ wpid: "57", instanceId: "inst1", size: "xs" });
+    expect(inlineImpl.parse(element)).toEqual({ wpid: "57", instanceId: "inst1", size: "xs", "displayId": "PROJ-57" });
   });
 
   it("parses the HTML element in the same way as the react inline spec", () => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-93

# What are you trying to accomplish?
Copy-paste data (plaintext and HTML) and the data we use to generate Markdown in Hocuspocus should:
- Use semantic IDs if the instance uses them
- Should use proper links (in HTML and Markdown)

