### PR TITLE
[BNE-95] Blue border sometimes missing for Work Package Card in BlockNote

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -1,4 +1,5 @@
 import { BlockNoteEditor, SideMenuExtension } from '@blocknote/core';
+import { useSelectedBlocks } from '@blocknote/react';
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
@@ -14,14 +15,17 @@ import { WpOptionsPopover } from '../WorkPackage/OptionsPopover';
 import { SearchContainer, SearchLabel } from '../Search/SearchContainer';
 import { SearchDropdown } from '../Search/SearchDropdown';
 import { defaultWpVariables } from '../WorkPackage/atoms';
+import { CHIP_STYLES } from '../WorkPackage/tokens';
 import { moveCursorAfterBlock } from '../../utils/cursor';
 import { pendingBlockRegistry } from './pendingBlockRegistry';
 
-const Block = styled.div.attrs({ className: 'op-bn-extensions' })<{ $pending?:boolean }>`
+const Block = styled.div.attrs({ className: 'op-bn-extensions', 'data-testid': 'block-wp-wrapper' })<{ $pending?:boolean; $selected?:boolean }>`
   ${defaultWpVariables}
   background-color: ${({ $pending }) => ($pending ? 'transparent' : 'var(--op-chip-bg)')};
   user-select: all;
   border-radius: var(--bn-border-radius);
+  outline: ${({ $selected }) => ($selected ? CHIP_STYLES.focusOutline : 'none')};
+  outline-offset: 1px;
   ${({ $pending }) => $pending && 'position: relative;'}
 `;
 
@@ -51,6 +55,12 @@ export const BlockWorkPackageComponent = ({
   // The hook handles triggering re-renders when data arrives.
   useColors();
 
+  // BlockNote applies ProseMirror-selectednode (and its built-in outline CSS) only when ProseMirror creates a NodeSelection.
+  // When the cursor is in a paragraph above the WP block and the user clicks the block, ProseMirror resolves the click
+  // as a TextSelection at the end of that paragraph rather than a NodeSelection on the block. The class is never applied
+  // and the outline never appears. So we set the outline ourselves.
+  const selectedBlocks = useSelectedBlocks(editor);
+  const isBlockSelected = selectedBlocks.some((b) => b.id === block.id);
   const [isOptionsOpen, setIsOptionsOpen] = useState(false);
 
   const workPackageResult = useWorkPackage(block.props.wpid);
@@ -117,7 +127,7 @@ export const BlockWorkPackageComponent = ({
   const isPending = pendingBlockRegistry.has(block.id);
 
   return (
-    <Block $pending={isPending} draggable="true" onDragStart={handleBlockDragStart}>
+    <Block $pending={isPending} $selected={isBlockSelected} data-selected={isBlockSelected || undefined} draggable="true" onDragStart={handleBlockDragStart}>
       <div contentEditable={false} style={{ userSelect: 'none' }}>
         {isPending && (
           <SearchContainer $floating>

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -44,6 +44,24 @@ export async function openInlineWorkPackageSizeMenu(displayId = '#123') {
   await expect.element(page.getByTestId('size-menu')).toBeVisible();
 }
 
+export async function insertBlockWorkPackageViaSlashMenu(searchTerm = 'Fix', resultTerm = 'Fix login bug') {
+  const editorEl = page.getByRole('textbox');
+  await expect.element(editorEl).toBeVisible();
+  await userEvent.click(editorEl);
+  await userEvent.type(editorEl, '/');
+
+  await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
+  await userEvent.click(page.getByText('Link existing work package').first());
+
+  const searchInput = page.getByPlaceholder('Search by work package ID or subject');
+  await expect.element(searchInput).toBeVisible();
+  await userEvent.type(searchInput, searchTerm);
+  await expect.element(page.getByText(resultTerm)).toBeVisible();
+  await userEvent.click(page.getByText(resultTerm));
+
+  await expect.element(page.getByTestId('block-card')).toBeVisible();
+}
+
 // Block card - popover & size menu
 export async function openBlockCardPopover() {
   await userEvent.click(page.getByTestId('op-bn-work-package--type'));

--- a/test/lib/components/integration/selectionHighlight.browser.test.tsx
+++ b/test/lib/components/integration/selectionHighlight.browser.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import { insertBlockWorkPackageViaSlashMenu } from '../../../helpers/editorHelpers';
+
+const blockIsSelected = () =>
+  document.querySelector('[data-testid="block-wp-wrapper"][data-selected]') !== null;
+
+describe('Block WP – blue border on focus (BNE-95)', () => {
+  it('shows border when clicked after typing text below the block', async () => {
+    renderEditor();
+    await insertBlockWorkPackageViaSlashMenu();
+
+    // cursor lands below the block after insertion – press Enter twice then type
+    await userEvent.keyboard('{Enter}{Enter}');
+    await userEvent.keyboard('some text');
+
+    await userEvent.click(page.getByTestId('block-wp-wrapper'));
+    await expect.poll(blockIsSelected).toBe(true);
+  });
+
+  it('shows border when clicked after typing text above the block (exact BNE-95 scenario)', async () => {
+    renderEditor();
+    const editorEl = page.getByRole('textbox');
+    await userEvent.click(editorEl);
+
+    // type text first, then insert WP block below – text is now ABOVE the block
+    await userEvent.keyboard('some text{Enter}');
+    await insertBlockWorkPackageViaSlashMenu();
+
+    // move cursor to the text above
+    await userEvent.click(page.getByText('some text'));
+
+    await userEvent.click(page.getByTestId('block-wp-wrapper'));
+    await expect.poll(blockIsSelected).toBe(true);
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/BNE/work_packages/BNE-95

# What are you trying to accomplish?
Fix missing blue selection outline on the block work package card after an inline->block conversion cycle.

# What approach did you choose and why?
## Root cause

BlockNote applies ProseMirror-selectednode (and its built-in outline CSS) only when ProseMirror creates a NodeSelection. When the cursor is in a paragraph above the WP block and the user clicks the block, ProseMirror resolves the click as a TextSelection at the end of that paragraph rather than a NodeSelection on the block. The class is never applied and the outline never appears.

## Fix

Used approach with BlockNote's public React hook useSelectedBlocks from @blocknote/react:

```
const selectedBlocks = useSelectedBlocks(editor);
const isBlockSelected = selectedBlocks.some((b) => b.id === block.id);
```
useSelectedBlocks falls back to editor.getTextCursorPosition() when there is no explicit multi-block selection, which correctly covers both the text-above and text-below cases. The Block wrapper applies its own outline CSS driven by this value.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
