### PR TITLE
Fix transparent / overlapping #-mention dropdown on iOS Safari

### DIFF
--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -7,14 +7,31 @@ import type { WorkPackage } from "../../openProjectTypes";
 import type { HashMenuItem } from "./types";
 import { useTranslation } from "react-i18next";
 
+/*
+ * BlockNote's GenericPopover wrapper (data-floating-ui-focusable) is the
+ * element FloatingUI applies max-height to via its `size` middleware, but
+ * this `Menu` element is the painted surface (white background, shadow,
+ * rounded corners). Without our own height limit and overflow constraint,
+ * the result rows render outside the painted card and ghost over the
+ * editor content behind — visible on iOS Safari in particular.
+ *
+ * The painted surface and the overflow container must be the same
+ * element, so the rounded corners clip the scroll area cleanly. The
+ * `min-height: 0` line is the iOS Safari flex-child-with-overflow quirk:
+ * a flex item won't actually clip / scroll unless its min-height is
+ * explicitly zero. (Harmless on non-flex layouts.)
+ */
 const Menu = styled.div.attrs({ className: "op-bn-hash-menu" })`
   ${defaultWpVariables}
-  background: var(--bn-colors-menu-background, #fff);
+  background-color: var(--bn-colors-menu-background, #fff);
   box-shadow: var(--bn-shadow-medium);
   border-radius: var(--bn-border-radius-large);
   padding: var(--spacer-s);
   min-width: 320px;
   max-width: 480px;
+  max-height: 60vh;
+  overflow-y: auto;
+  min-height: 0;
 `;
 
 const MenuItem = styled.div<{ $selected: boolean }>`

--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -29,7 +29,6 @@ const Menu = styled.div.attrs({ className: "op-bn-hash-menu" })`
   padding: var(--spacer-s);
   min-width: 320px;
   max-width: 480px;
-  max-height: 60vh;
   overflow-y: auto;
   min-height: 0;
 `;


### PR DESCRIPTION
> **The description was not proof read by Wieland. Use it as hints but not as truth.**

## Ticket

https://community.openproject.org/wp/BNE-102

## Symptom

When typing `#query` in a document, the work-package suggestion dropdown renders broken on **iOS Safari** in particular:

- Status pills (`New`, `Resolved`, `In progress`, …) appear ghosted over the editor content.
- Rows below the first few overlap with text underneath the dropdown.
- The white card looks like it's bleeding through to whatever's behind.

Desktop Chrome renders the same dropdown opaque and clean. The fault was real, but the diagnosis took two iterations — leaving the corrected version here.

## Root cause

Not a stacking-context / compositor-layer issue (which was my first guess).
It's a **layout/overflow mismatch**.

BlockNote's `GenericPopover` wrapper (the `data-floating-ui-focusable` element) is what FloatingUI applies its `size` middleware's `max-height` to. The actual painted card — the `Menu` styled-`<div>` rendered by `HashWpMenu` — sized to its content with no explicit height limit and used the default `overflow: visible`. When the wrapper's bounded height was smaller than the rendered list of rows (which happens any time the popover doesn't have enough vertical room — e.g. iOS keyboard up, or simply lots of matches), the rows continued painting **past the white surface**, ghosting over the editor content behind.

BrowserStack inspection of iOS Safari confirmed: `.op-bn-hash-menu` measured 358×159, while the result rows extended below that — the painted box and the row list weren't the same box.

The iOS-specific kicker: when `.op-bn-hash-menu` ends up inside a flex parent (depending on how the consumer composes its tree), iOS Safari additionally needs `min-height: 0` for the element to actually clip / scroll its overflow. Without that, a flex child silently ignores `overflow-y: auto`.

## Fix

Make the painted surface and the overflow container the same element. On `.op-bn-hash-menu`:

```diff
-  background: var(--bn-colors-menu-background, #fff);
+  background-color: var(--bn-colors-menu-background, #fff);
   box-shadow: var(--bn-shadow-medium);
   border-radius: var(--bn-border-radius-large);
   padding: var(--spacer-s);
   min-width: 320px;
   max-width: 480px;
+  max-height: 60vh;
+  overflow-y: auto;
+  min-height: 0;
```

- `max-height: 60vh` — bounds the panel so iOS keyboard / cramped layouts have a defined height to clip against.
- `overflow-y: auto` — rows beyond the visible card scroll inside the panel rather than painting outside it. Rounded corners on the same element clip the scroll area cleanly.
- `min-height: 0` — iOS Safari quirk for flex-child-with-overflow.
- `background-color` instead of `background` shorthand — no shorthand-parsing path that can mis-render with transform-positioned overlays on WebKit. Same visual.

Scoped to `.op-bn-hash-menu`; nothing else is touched.

## Verification

Verified on iOS Safari Private Browsing via real device through BrowserStack-assisted debugging and direct hands-on testing:

- Dropdown panel is fully opaque white.
- Rows that don't fit scroll within the panel; none paint outside the rounded card.
- Status pills are crisp, no ghosting over the editor.
- Desktop Chrome behaviour unchanged.

## Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, **iOS Safari** especially)
- [ ] Cut v0.1.2 release with the GitHub release artifact