### PR TITLE
[BNE-83] & [BNE-94] Fix copy/paste and keyboard deletion of inline work package links - listeners approach

### DIFF
--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useWorkPackage } from '../../hooks/useWorkPackage';
 import { useColors } from '../../services/colors';
@@ -17,6 +17,12 @@ import { useTranslation } from 'react-i18next';
 import { defaultWpVariables } from '../WorkPackage/atoms';
 import { formatWorkPackageId } from '../../utils/id';
 import { useIsNodeInSelection } from '../../hooks/useIsNodeInSelection';
+import { placeCursorAfterInlineNode } from '../../utils/cursor';
+
+import {
+  buildWorkPackageInlineExternalDOM,
+  computeWorkPackageInlineExternalData,
+} from './externalHtml';
 
 export interface InlineWorkPackageChipProps {
   inlineContent:{ props:{ wpid:string; size:string; instanceId:string } };
@@ -80,17 +86,58 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }:Inli
     contentRef(node);
   };
 
-  // Close the options popover when the user clicks outside the chip
+  const deleteAndClose = useCallback(() => {
+    if (!wp) return;
+    wpBridge.delete({ instanceId, wpid: wp.id });
+    setIsSelected(false);
+  }, [instanceId, wp]);
+
   useEffect(() => {
     if (!isSelected) return;
+
     const onClickOutside = (e:MouseEvent) => {
       if (chipRef.current && !chipRef.current.contains(e.target as Node)) {
         setIsSelected(false);
       }
     };
+
+    const onKeyDown = (event:KeyboardEvent) => {
+      const target = event.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+
+      if (event.key === 'Backspace' || event.key === 'Delete') {
+        event.preventDefault();
+        event.stopPropagation();
+        deleteAndClose();
+        return;
+      }
+
+      if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault();
+      }
+    };
+
+    const onCopy = (event:ClipboardEvent) => {
+      const target = event.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+      const data = computeWorkPackageInlineExternalData({ wpid: rawWpid, instanceId, size });
+      if (!data || !event.clipboardData) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const dom = buildWorkPackageInlineExternalDOM(data, document);
+      event.clipboardData.setData('text/html', dom.outerHTML);
+      event.clipboardData.setData('text/plain', data.text);
+    };
+
     document.addEventListener('mousedown', onClickOutside);
-    return () => document.removeEventListener('mousedown', onClickOutside);
-  }, [isSelected]);
+    document.addEventListener('keydown', onKeyDown, true);
+    document.addEventListener('copy', onCopy, true);
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('keydown', onKeyDown, true);
+      document.removeEventListener('copy', onCopy, true);
+    };
+  }, [isSelected, instanceId, wp, rawWpid, size, deleteAndClose]);
 
   // Pending: waiting for user to pick a WP via search
   if (pendingCallbacks) {
@@ -134,7 +181,10 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }:Inli
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          setIsSelected((prev) => !prev);
+          const opening = !isSelected;
+          setIsSelected(opening);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          if (opening && editor) placeCursorAfterInlineNode(editor, instanceId);
         }}
       >
         {size === 'xxs' && <WpChipXXS wp={wp} />}
@@ -155,9 +205,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }:Inli
             onConvertToBlock={(blockSize) => {
               wpBridge.resize({ instanceId, wpid: wp.id, size: blockSize });
             }}
-            onRemove={() => {
-              wpBridge.delete({ instanceId, wpid: wp.id });
-            }}
+            onRemove={deleteAndClose}
           />
         )}
       </InlineChip>

--- a/lib/hooks/useInlineWpEvents.ts
+++ b/lib/hooks/useInlineWpEvents.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import type { BlockNoteEditor, InlineContentFromConfig } from '@blocknote/core';
+import { TextSelection } from 'prosemirror-state';
 import { wpBridge, makeInstanceId } from '../../lib';
 import type { InlineWpSize, BlockWpSize, WpSize } from '../../lib';
 import { moveCursorAfterBlock } from '../utils/cursor';
@@ -111,8 +112,27 @@ function handleResize(editor:AnyEditor, instanceId:string, size:WpSize):void {
 }
 
 function handleDelete(editor:AnyEditor, instanceId:string):void {
+  let chipPos:number | null = null;
+  editor.prosemirrorState.doc.descendants((node, pos) => {
+    if (chipPos !== null) return false;
+    if ((node.attrs as Record<string, unknown>)?.instanceId === instanceId) {
+      chipPos = pos;
+      return false;
+    }
+    return true;
+  });
+
   updateInlineChip(editor, instanceId, () => null);
+
+  if (chipPos !== null) {
+    const pos = chipPos;
+    editor.transact((tr) => {
+      const safePos = Math.min(pos, tr.doc.content.size);
+      tr.setSelection(TextSelection.near(tr.doc.resolve(safePos)));
+    });
+  }
 }
+
 
 function handlePromoteToBlock(
   editor:AnyEditor,

--- a/test/lib/components/integration/editor.chipKeyboardDeletion.browser.test.tsx
+++ b/test/lib/components/integration/editor.chipKeyboardDeletion.browser.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import {
+  insertInlineWorkPackageViaHash,
+  insertInlineWorkPackageViaHashWithTextBefore,
+  openInlineWorkPackagePopover,
+} from '../../../helpers/editorHelpers';
+
+afterEach(() => cleanup());
+
+async function setupEditorWithChipAndText() {
+  renderEditor();
+  await insertInlineWorkPackageViaHash('###');
+  await expect.element(page.getByText('Fix login bug')).toBeVisible();
+  await userEvent.click(page.getByRole('textbox'));
+  await userEvent.keyboard('{Enter}{Enter}');
+  await userEvent.keyboard('here');
+  await expect.element(page.getByText('here')).toBeVisible();
+}
+
+describe('Chip keyboard deletion (popover open)', () => {
+  it('Backspace removes the chip and leaves other content intact', async () => {
+    await setupEditorWithChipAndText();
+
+    await openInlineWorkPackagePopover();
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await userEvent.keyboard('{Backspace}');
+
+    await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();
+    await expect.element(page.getByTestId('popover-content')).not.toBeInTheDocument();
+    await expect.element(page.getByText('here')).toBeVisible();
+  });
+
+  it('Delete removes the chip and leaves other content intact', async () => {
+    await setupEditorWithChipAndText();
+
+    await openInlineWorkPackagePopover();
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await userEvent.keyboard('{Delete}');
+
+    await expect.element(page.getByText('Fix login bug')).not.toBeInTheDocument();
+    await expect.element(page.getByTestId('popover-content')).not.toBeInTheDocument();
+    await expect.element(page.getByText('here')).toBeVisible();
+  });
+});
+
+describe('Cursor position after chip keyboard deletion', () => {
+  async function setupEditorWithChipBetweenText() {
+    renderEditor();
+    await insertInlineWorkPackageViaHashWithTextBefore('before');
+    // cursor lands after the chip - type to create "before[chip]AFTER" in one block
+    await userEvent.keyboard('AFTER');
+  }
+
+  it('Backspace: cursor lands where the chip was', async () => {
+    await setupEditorWithChipBetweenText();
+
+    await openInlineWorkPackagePopover();
+    await userEvent.keyboard('{Backspace}');
+
+    // typing HERE should appear exactly where the chip was
+    await userEvent.keyboard('HERE');
+    await expect.element(page.getByRole('textbox')).toHaveTextContent('beforeHEREAFTER');
+  });
+
+  it('Delete: cursor lands where the chip was', async () => {
+    await setupEditorWithChipBetweenText();
+
+    await openInlineWorkPackagePopover();
+    await userEvent.keyboard('{Delete}');
+
+    await userEvent.keyboard('HERE');
+    await expect.element(page.getByRole('textbox')).toHaveTextContent('beforeHEREAFTER');
+  });
+});

--- a/test/lib/components/integration/inlineWorkPackageCopyPaste.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageCopyPaste.browser.test.tsx
@@ -1,7 +1,47 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
-import { insertInlineWorkPackageViaSlashMenu } from '../../../helpers/editorHelpers';
+import {
+  insertInlineWorkPackageViaSlashMenu,
+  insertInlineWorkPackageViaHash,
+  openInlineWorkPackagePopover,
+} from '../../../helpers/editorHelpers';
+
+describe('Inline chip - single chip copy', () => {
+  afterEach(() => cleanup());
+
+  it('copies a chip when the chip is clicked and Ctrl+C is pressed without surrounding text', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('###');
+
+    await openInlineWorkPackagePopover();
+    await userEvent.keyboard('{Control>}c{/Control}');
+    await userEvent.keyboard('{Control>}v{/Control}');
+
+    expect(document.querySelectorAll('.op-bn-inline-wp').length).toBe(2);
+  });
+
+  it('pasted copy is independent of the original after single-chip copy', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('###');
+
+    await openInlineWorkPackagePopover();
+    await userEvent.keyboard('{Control>}c{/Control}');
+    await userEvent.keyboard('{Control>}v{/Control}');
+
+    const chips = document.querySelectorAll('.op-bn-inline-wp');
+    expect(chips.length).toBe(2);
+
+    await userEvent.click(chips[1]);
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+    await userEvent.click(page.getByTitle('Change size'));
+    await expect.element(page.getByTestId('size-menu')).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
+
+    expect((await page.getByText('In Progress').all()).length).toBe(1);
+  });
+});
 
 describe('Inline chip - copy/paste independence', () => {
   it('resizing the original does not affect the copy', async () => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-94
https://community.openproject.org/wp/BNE-83

# What are you trying to accomplish?
Clicking an InlineWorkPackage chip to open its popover had two related problems:

- The editor cursor was placed somewhere else in the document instead of right behind the chip.
- Pressing Delete or Backspace removed other text at the cursor position rather than removing the chip itself.

# What approach did you choose and why?
Three changes in InlineWorkPackageChip.tsx:

Cursor placement - when opening the popover via click, we call placeCursorAfterInlineNode to explicitly position the editor cursor right behind the chip. This prevents stray deletions from hitting unrelated text if the user dismisses the popover without using a key.

Keyboard handling - while the popover is open (isSelected === true), we attach a single capturing keydown listener on document:

- Backspace / Delete: intercepted (inputs and textareas inside the popover are skipped), calls wpBridge.delete() and closes the popover. The cursor is automatically restored to the chip's former position by useInlineWpEvents.handleDelete.
- Printable characters (single-char keys without Ctrl/Meta/Alt): silently blocked, to match block work package behaviour where typing is not possible while a chip popover is open.

Chip-only copy - a capturing copy listener on document (also active while isSelected) intercepts Ctrl+C and writes the chip's external HTML and plain-text representation to the clipboard. Without this, user-select: none causes the browser to produce an empty copy.

## Alternative considered: 
The architecturally cleaner fix would be to set a ProseMirror NodeSelection on the chip node when it is clicked, then handle Backspace/Delete via a ProseMirror keymap plugin. This would keep the editor selection state in sync and avoid the document-level listener entirely. We decided against it because it would require a new ProseMirror plugin, a new hook to track NodeSelection state, and a new cursor utility - significantly more new code for a bug fix. The chosen approach is a contained workaround with a well-managed listener lifecycle.

I also considered adding tabIndex={-1} to the chip element and handling onKeyDown directly on it, so the chip receives keyboard events natively when focused. This approach was prototyped but abandoned: calling focus() on the chip element moved DOM focus away from the editor, which caused useIsNodeInSelection (which reads window.getSelection()) to return false - the blue selection outline no longer appeared when clicking the chip.

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
