### PR TITLE
[BNE-108] Dragging a work package link should not reload the data via the network

### DIFF
--- a/lib/hooks/useWorkPackage.ts
+++ b/lib/hooks/useWorkPackage.ts
@@ -2,8 +2,12 @@ import { useEffect, useState, useCallback } from "react";
 import type { WorkPackage } from "../openProjectTypes";
 import { OpenProjectApiError, fetchWorkPackage } from "../services/openProjectApi";
 
+const wpCache: Record<number, WorkPackage> = {};
+
 export function useWorkPackage(wpid: number|undefined) {
-  const [workPackage, setWorkPackage] = useState<WorkPackage | null>(null);
+  const [workPackage, setWorkPackage] = useState<WorkPackage | null>(
+    () => (wpid != null ? wpCache[wpid] ?? null : null)
+  );
   const [loading, setLoading] = useState(false);
   const [unauthorized, setUnauthorized] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -13,10 +17,15 @@ export function useWorkPackage(wpid: number|undefined) {
       setWorkPackage(null);
       return;
     }
+    if (wpCache[wpid]) {
+      setWorkPackage(wpCache[wpid]);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
       const data = await fetchWorkPackage(wpid);
+      wpCache[wpid] = data as WorkPackage;
       setWorkPackage(data as WorkPackage);
     } catch (error) {
       if (error instanceof OpenProjectApiError && error.responseStatus === 404) {

--- a/lib/hooks/useWorkPackage.ts
+++ b/lib/hooks/useWorkPackage.ts
@@ -2,11 +2,11 @@ import { useEffect, useState, useCallback } from "react";
 import type { WorkPackage } from "../openProjectTypes";
 import { OpenProjectApiError, fetchWorkPackage } from "../services/openProjectApi";
 
-const wpCache: Record<number, WorkPackage> = {};
+const workPackageCache: Record<number, WorkPackage> = {};
 
 export function useWorkPackage(wpid: number|undefined) {
   const [workPackage, setWorkPackage] = useState<WorkPackage | null>(
-    () => (wpid != null ? wpCache[wpid] ?? null : null)
+    () => (wpid != null ? workPackageCache[wpid] ?? null : null)
   );
   const [loading, setLoading] = useState(false);
   const [unauthorized, setUnauthorized] = useState(false);
@@ -17,15 +17,15 @@ export function useWorkPackage(wpid: number|undefined) {
       setWorkPackage(null);
       return;
     }
-    if (wpCache[wpid]) {
-      setWorkPackage(wpCache[wpid]);
+    if (workPackageCache[wpid]) {
+      setWorkPackage(workPackageCache[wpid]);
       return;
     }
     setLoading(true);
     setError(null);
     try {
       const data = await fetchWorkPackage(wpid);
-      wpCache[wpid] = data as WorkPackage;
+      workPackageCache[wpid] = data as WorkPackage;
       setWorkPackage(data as WorkPackage);
     } catch (error) {
       if (error instanceof OpenProjectApiError && error.responseStatus === 404) {

--- a/lib/hooks/useWorkPackage.ts
+++ b/lib/hooks/useWorkPackage.ts
@@ -4,6 +4,12 @@ import { OpenProjectApiError, fetchWorkPackage } from "../services/openProjectAp
 
 const workPackageCache: Record<number, WorkPackage> = {};
 
+export function clearWorkPackageCache(): void {
+  for (const key in workPackageCache) {
+    delete workPackageCache[key as unknown as number];
+  }
+}
+
 export function useWorkPackage(wpid: number|undefined) {
   const [workPackage, setWorkPackage] = useState<WorkPackage | null>(
     () => (wpid != null ? workPackageCache[wpid] ?? null : null)

--- a/test/lib/components/integration/blockWorkPackageCopyPaste.browser.test.tsx
+++ b/test/lib/components/integration/blockWorkPackageCopyPaste.browser.test.tsx
@@ -37,7 +37,8 @@ describe('Block card - copy/paste independence', () => {
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
     await userEvent.click(page.getByTestId('remove-btn'));
 
-    expect((await page.getByTestId('block-card').all()).length).toBe(1);
+    await expect.element(page.getByTestId('block-card').nth(0)).toBeVisible();
+    await expect.element(page.getByTestId('block-card').nth(1)).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
   });
 
@@ -55,7 +56,8 @@ describe('Block card - copy/paste independence', () => {
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
     await userEvent.click(page.getByTestId('remove-btn'));
 
-    expect((await page.getByTestId('block-card').all()).length).toBe(1);
+    await expect.element(page.getByTestId('block-card').nth(0)).toBeVisible();
+    await expect.element(page.getByTestId('block-card').nth(1)).not.toBeInTheDocument();
     await expect.element(page.getByText('Fix login bug')).toBeVisible();
   });
 
@@ -76,8 +78,8 @@ describe('Block card - copy/paste independence', () => {
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
     // The pasted copy still shows the status
-    await expect.element(page.getByText('In Progress')).toBeVisible();
-    expect((await page.getByText('In Progress').all()).length).toBe(1);
+    await expect.element(page.getByText('In Progress').nth(0)).toBeVisible();
+    await expect.element(page.getByText('In Progress').nth(1)).not.toBeInTheDocument();
   });
 
   it('resizing the pasted copy does not affect the original', async () => {
@@ -97,6 +99,7 @@ describe('Block card - copy/paste independence', () => {
     await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
 
     // The original still shows the status
-    expect((await page.getByText('In Progress').all()).length).toBe(1);
+    await expect.element(page.getByText('In Progress').nth(0)).toBeVisible();
+    await expect.element(page.getByText('In Progress').nth(1)).not.toBeInTheDocument();
   });
 });

--- a/test/lib/components/integration/editor.drag.browser.test.tsx
+++ b/test/lib/components/integration/editor.drag.browser.test.tsx
@@ -1,9 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
+import { http, HttpResponse } from 'msw';
 import { renderEditor } from '../../../helpers/renderEditor';
 import { insertInlineWorkPackageViaSlashMenu, convertToCompactCard } from '../../../helpers/editorHelpers';
+import { worker } from '../../../mocks/browser';
+import { mockWorkPackage } from '../../../mocks/handlers';
 
 describe('Drag and drop - inline chip', () => {
+  afterEach(() => worker.resetHandlers());
+
   it('chip has data-drag-handle and is not independently draggable', async () => {
     renderEditor();
 
@@ -48,9 +53,39 @@ describe('Drag and drop - inline chip', () => {
     const chipBlock = chipEl.closest('[data-node-type="blockOuter"]');
     expect(chipBlock?.textContent).toContain('Last');
   });
+
+  it('drag and drop does not re-fetch the work package from the server', async () => {
+    renderEditor();
+
+    const editor = page.getByRole('textbox');
+    await userEvent.click(editor);
+    await insertInlineWorkPackageViaSlashMenu();
+    await userEvent.keyboard('{Enter}');
+    await userEvent.type(editor, 'Last line');
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+
+    let fetchCount = 0;
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/:id', ({ params }) => {
+        fetchCount++;
+        return HttpResponse.json({ ...mockWorkPackage, id: Number(params.id), displayId: String(params.id) });
+      })
+    );
+
+    await userEvent.dragAndDrop(
+      document.querySelector('.op-bn-inline-wp')!,
+      page.getByText('Last line'),
+    );
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+    expect(fetchCount).toBe(0);
+  });
 });
 
 describe('Drag and drop - block card', () => {
+  afterEach(() => worker.resetHandlers());
+
   it('block card container is draggable', async () => {
     renderEditor();
 
@@ -64,5 +99,38 @@ describe('Drag and drop - block card', () => {
     const blockContainer = page.getByTestId('block-card').element().closest('.op-bn-extensions') as HTMLElement;
     expect(blockContainer).not.toBeNull();
     expect(blockContainer.getAttribute('draggable')).toBe('true');
+  });
+
+  it('drag and drop does not re-fetch the work package from the server', async () => {
+    renderEditor();
+
+    const editor = page.getByRole('textbox');
+    await userEvent.click(editor);
+    await insertInlineWorkPackageViaSlashMenu();
+    await convertToCompactCard();
+    // Add a paragraph below the card to serve as the drop target
+    await userEvent.keyboard('{Enter}');
+    await userEvent.type(editor, 'After card');
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    let fetchCount = 0;
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/:id', ({ params }) => {
+        fetchCount++;
+        return HttpResponse.json({ ...mockWorkPackage, id: Number(params.id), displayId: String(params.id) });
+      })
+    );
+
+    // Drop onto the block-level container of the target paragraph, not the text span,
+    // so ProseMirror can resolve a valid block-level drop position.
+    const blockContainer = page.getByTestId('block-card').element().closest('.op-bn-extensions') as HTMLElement;
+    const dropTarget = page.getByText('After card').element().closest('[data-node-type="blockOuter"]') as HTMLElement;
+    await userEvent.dragAndDrop(blockContainer, dropTarget);
+
+    // Yield to the browser event loop so React effects have time to run
+    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+    expect(fetchCount).toBe(0);
   });
 });

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,6 +1,11 @@
-import { beforeAll, afterAll } from 'vitest';
+import { beforeAll, afterAll, beforeEach } from 'vitest';
 import { worker } from './mocks/browser';
 import { initializeOpBlockNoteExtensions } from '../lib';
+import { clearWorkPackageCache } from '../lib/hooks/useWorkPackage';
+
+beforeEach(() => {
+  clearWorkPackageCache();
+});
 
 beforeAll(async () => {
   initializeOpBlockNoteExtensions({ baseUrl: 'http://localhost:3000', locale: 'en' });


### PR DESCRIPTION
https://community.openproject.org/wp/BNE-108

Avoid network reloads by caching work package data while the document is used. I assume in the future we will have to find a way to get updated data when a work package was updated in the backend by another user, but it should not be "on drag and drop".

Also improve tests agains race conditions by using a form that allows the test to retry if the assertion is not met.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
