### PR TITLE
[BNE-83] & [BNE-94] Fix copy/paste and keyboard deletion of inline work package links - selection approach

### DIFF
--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -135,7 +135,10 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }:Inli
           e.preventDefault();
           e.stopPropagation();
           setIsSelected((prev) => !prev);
-          if (editor) selectInlineNode(editor, instanceId);
+          if (editor) {
+            selectInlineNode(editor, instanceId);
+            editor.getExtension('formattingToolbar')?.store?.setState(false);
+          }
         }}
       >
         {size === 'xxs' && <WpChipXXS wp={wp} />}

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -12,17 +12,19 @@ import { getPendingCallbacks, clearInlineWpCallbacks } from './callbacks';
 import { updateInlineChip } from '../../hooks/useInlineWpEvents';
 import type { InlineWpSize } from '../WorkPackage/types';
 import { wpBridge } from '../../services/wpBridge';
+import { selectInlineNode } from '../../utils/cursor';
 import { BlockCard } from '../BlockWorkPackage/BlockCard';
 import { useTranslation } from 'react-i18next';
 import { defaultWpVariables } from '../WorkPackage/atoms';
 import { formatWorkPackageId } from '../../utils/id';
 import { useIsNodeInSelection } from '../../hooks/useIsNodeInSelection';
+import type { BlockNoteEditor } from '@blocknote/core';
 
 export interface InlineWorkPackageChipProps {
   inlineContent:{ props:{ wpid:string; size:string; instanceId:string } };
   contentRef:(node:HTMLElement | null) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  editor?:any;
+  editor?:BlockNoteEditor<any, any, any>;
 }
 
 const InlineChip = styled.span.attrs({
@@ -65,14 +67,12 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }:Inli
     if (!wp || !editor) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     if (wp.displayId === ((inlineContent.props as any).displayId ?? '')) return;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     updateInlineChip(editor, instanceId, (chip) => ({ ...chip, props: { ...chip.props, displayId: wp.displayId } }));
   }, [wp?.displayId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [isSelected, setIsSelected] = useState(false);
   const chipRef = useRef<HTMLElement | null>(null);
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const isEditorSelected = useIsNodeInSelection(chipRef, editor);
 
   const setRef = (node:HTMLElement | null) => {
@@ -135,6 +135,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }:Inli
           e.preventDefault();
           e.stopPropagation();
           setIsSelected((prev) => !prev);
+          if (editor) selectInlineNode(editor, instanceId);
         }}
       >
         {size === 'xxs' && <WpChipXXS wp={wp} />}

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -1,6 +1,6 @@
 import type { BlockNoteEditor } from '@blocknote/core';
 import type { Node as PmNode } from 'prosemirror-model';
-import { TextSelection } from 'prosemirror-state';
+import { NodeSelection, TextSelection } from 'prosemirror-state';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyEditor = BlockNoteEditor<any, any, any>;
@@ -37,7 +37,7 @@ export function selectInlineNode(editor:AnyEditor, instanceId:string):void {
   const range = findInlineNodeRange(editor.prosemirrorState.doc, instanceId);
   if (!range) return;
   editor.transact((tr) => {
-    tr.setSelection(TextSelection.create(tr.doc, range.from, range.to));
+    tr.setSelection(NodeSelection.create(tr.doc, range.from));
   });
 }
 

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -1,4 +1,5 @@
 import type { BlockNoteEditor } from '@blocknote/core';
+import type { Node as PmNode } from 'prosemirror-model';
 import { TextSelection } from 'prosemirror-state';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,23 +20,31 @@ export function moveCursorAfterBlock(editor:AnyEditor, blockId:string):void {
   }
 }
 
-export function placeCursorAfterInlineNode(editor:AnyEditor, instanceId:string):void {
-  const { doc } = editor.prosemirrorState;
-  let targetPos:number | null = null;
-
+function findInlineNodeRange(doc:PmNode, instanceId:string):{ from:number; to:number } | null {
+  let result:{ from:number; to:number } | null = null;
   doc.descendants((node, pos) => {
-    if (targetPos !== null) return false;
+    if (result) return false;
     if ((node.attrs as Record<string, unknown>)?.instanceId === instanceId) {
-      targetPos = pos + node.nodeSize;
+      result = { from: pos, to: pos + node.nodeSize };
       return false;
     }
     return true;
   });
+  return result;
+}
 
-  if (targetPos !== null) {
-    const pos = targetPos;
-    editor.transact((tr) => {
-      tr.setSelection(TextSelection.create(tr.doc, pos));
-    });
-  }
+export function selectInlineNode(editor:AnyEditor, instanceId:string):void {
+  const range = findInlineNodeRange(editor.prosemirrorState.doc, instanceId);
+  if (!range) return;
+  editor.transact((tr) => {
+    tr.setSelection(TextSelection.create(tr.doc, range.from, range.to));
+  });
+}
+
+export function placeCursorAfterInlineNode(editor:AnyEditor, instanceId:string):void {
+  const range = findInlineNodeRange(editor.prosemirrorState.doc, instanceId);
+  if (!range) return;
+  editor.transact((tr) => {
+    tr.setSelection(TextSelection.create(tr.doc, range.to));
+  });
 }

--- a/test/lib/components/integration/inlineWorkPackageCopyPaste.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageCopyPaste.browser.test.tsx
@@ -1,7 +1,27 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
-import { insertInlineWorkPackageViaSlashMenu } from '../../../helpers/editorHelpers';
+import { insertInlineWorkPackageViaSlashMenu, insertInlineWorkPackageViaHash } from '../../../helpers/editorHelpers';
+
+describe('Inline chip - single block copy/paste', () => {
+  it('copies a chip when the chip is clicked and Ctrl+C is pressed without surrounding text', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await userEvent.click(page.getByText('#123').first());
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await userEvent.keyboard('{Control>}c{/Control}');
+
+    await userEvent.keyboard('{Control>}{End}{/Control}');
+    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard('{Control>}v{/Control}');
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('.op-bn-inline-wp').length).toBe(2);
+    });
+  });
+});
 
 describe('Inline chip - copy/paste independence', () => {
   it('resizing the original does not affect the copy', async () => {
@@ -84,3 +104,4 @@ describe('Inline chip - copy/paste independence', () => {
     await expect.element(page.getByText('In Progress')).toBeVisible();
   });
 });
+

--- a/test/lib/components/integration/inlineWorkPackageFormattingToolbar.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageFormattingToolbar.browser.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import { insertInlineWorkPackageViaHash, openEditorAndType } from '../../../helpers/editorHelpers';
+
+describe('Inline chip - formatting toolbar suppression', () => {
+  it('clicking a chip does not open the formatting toolbar', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await userEvent.click(page.getByText('#123').first());
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await expect.element(page.getByRole('toolbar')).not.toBeInTheDocument();
+  });
+
+  it('clicking a chip hides the formatting toolbar when it was already open', async () => {
+    renderEditor();
+    await openEditorAndType('select me');
+    await userEvent.keyboard('{Enter}');
+    await insertInlineWorkPackageViaHash('#');
+
+    // Select the text to open the formatting toolbar
+    await userEvent.tripleClick(page.getByText('select me'));
+    await expect.element(page.getByRole('toolbar')).toBeVisible();
+
+    // Clicking the chip should close the toolbar
+    await userEvent.click(page.getByText('#123').first());
+    await expect.element(page.getByRole('toolbar')).not.toBeInTheDocument();
+  });
+});

--- a/test/lib/components/integration/inlineWorkPackageKeyboardDeletion.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageKeyboardDeletion.browser.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import { insertInlineWorkPackageViaHash, openEditorAndType } from '../../../helpers/editorHelpers';
+
+describe('Inline chip - keyboard deletion', () => {
+  it('Backspace removes the chip without affecting other text in the document', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await userEvent.keyboard('{Enter}');
+    await openEditorAndType('keep this text');
+
+    await userEvent.click(page.getByText('#123').first());
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await userEvent.keyboard('{Backspace}');
+
+    await expect.element(page.getByText('#123')).not.toBeInTheDocument();
+    await expect.element(page.getByText('keep this text')).toBeVisible();
+  });
+
+  it('Delete removes the chip without affecting other text in the document', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await userEvent.keyboard('{Enter}');
+    await openEditorAndType('keep this text');
+
+    await userEvent.click(page.getByText('#123').first());
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await userEvent.keyboard('{Delete}');
+
+    await expect.element(page.getByText('#123')).not.toBeInTheDocument();
+    await expect.element(page.getByText('keep this text')).toBeVisible();
+  });
+});


### PR DESCRIPTION
# Tickets
https://community.openproject.org/projects/STC/work_packages/BNE-83
https://community.openproject.org/projects/BNE/work_packages/BNE-94

# What are you trying to accomplish?
Fix two related bugs: BNE-83 (Ctrl+C on a clicked chip produces nothing) and BNE-94 (Backspace/Delete after clicking a chip deletes surrounding text instead of the chip).

# What approach did you choose and why?
Both bugs share the same root cause: the chip's onClick calls stopPropagation() to prevent ProseMirror from seeing the click. Without the click, ProseMirror never updates its selection - it stays empty or wherever it was before. BlockNote's copy handler skips serialization when selection.empty === true, so Ctrl+C does nothing. Backspace/Delete then acts on whatever text happens to be under the stale cursor.

The fix: call selectInlineNode(editor, instanceId) in onClick, which sets a TextSelection spanning the chip via a ProseMirror transaction. One call, both bugs fixed - copy now sees a non-empty selection, and Delete/Backspace deletes the selected chip rather than unrelated text. BlockNote's higher-level API (setTextCursorPosition) works only with blocks, not inline nodes, so this goes through ProseMirror directly.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
