### PR TITLE
[STC-806] Documents: impossible to delete characters with backspace after adding a wp link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const schema = BlockNoteSchema.create().extend({
 type EditorType = typeof schema.BlockNoteEditor;
 ```
 
-Create the editor, passing `PasteDeduplicateInstanceIdsExtension` in `extensions`.
+Create the editor, passing `OpBlockNoteExtensions` in `extensions`.
 This must be done at construction time — registering the plugin post-mount via
 `editor.registerPlugin()` triggers ProseMirror's `reconfigure()`, which destroys
 the Y.js `UndoManager` and silently breaks Ctrl+Z.
@@ -51,9 +51,14 @@ the Y.js `UndoManager` and silently breaks Ctrl+Z.
 ```tsx
 const editor = useCreateBlockNote({
   schema,
-  extensions: [PasteDeduplicateInstanceIdsExtension],
+  extensions: [OpBlockNoteExtensions],
 });
 ```
+
+`OpBlockNoteExtensions` bundles:
+
+- **`PasteDeduplicateExtension`** — regenerates a fresh `instanceId` for every WP chip found in pasted content, preventing two chips from sharing the same ID.
+- **`KeyboardDeleteExtension`** — intercepts `Backspace` and `Delete` keystrokes and dispatches explicit ProseMirror transactions instead of falling through to the browser. Required when using Hocuspocus/Yjs, where the native DOM path becomes unreliable around atom nodes (WP chips) and causes keystrokes to silently do nothing.
 
 Wire the runtime hooks and build the slash and hash menus:
 

--- a/lib/hooks/useOpBlockNoteExtensions.ts
+++ b/lib/hooks/useOpBlockNoteExtensions.ts
@@ -5,9 +5,8 @@ import { useInlineWpEvents } from './useInlineWpEvents';
  * Wires up the runtime hooks that BlockNote integration needs *after* the
  * editor is mounted.
  *
- * Use {@link PasteDeduplicateInstanceIdsExtension} in your editor's
- * `extensions: [...]` array instead of calling `useDeduplicateInstanceIds`
- * from here. Registering ProseMirror plugins post-mount via
+ * Use {@link OpBlockNoteExtensions} in your editor's `extensions: [...]`
+ * array at construction time. Registering ProseMirror plugins post-mount via
  * `editor.registerPlugin(...)` triggers ProseMirror's `reconfigure()` and
  * destroys the y-prosemirror UndoManager, breaking Ctrl+Z.
  */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,4 +15,4 @@ export type { HashMenuItem } from './components/HashMenu';
 export { useWorkPackageSearch } from './hooks/useWorkPackageSearch';
 export type { WorkPackage } from './openProjectTypes';
 export { useOpBlockNoteExtensions } from './hooks/useOpBlockNoteExtensions';
-export { PasteDeduplicateInstanceIdsExtension } from './plugins/pasteDeduplicateExtension';
+export { OpBlockNoteExtensions } from './plugins/opBlockNoteExtensions';

--- a/lib/plugins/keyboardDeleteExtension.ts
+++ b/lib/plugins/keyboardDeleteExtension.ts
@@ -1,0 +1,94 @@
+import { createExtension } from '@blocknote/core';
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
+
+const pluginKey = new PluginKey('opKeyboardDelete');
+
+// Intl.Segmenter is ES2022; cast to avoid bumping tsconfig lib target.
+interface SegmenterEntry {segment:string}
+type SegmenterCtor = new (locale?:string, opts?:{granularity?:string}) => {segment(text:string):Iterable<SegmenterEntry>};
+const SegmenterCls = (Intl as {Segmenter?:SegmenterCtor}).Segmenter;
+const segmenter = SegmenterCls ? new SegmenterCls(undefined, { granularity: 'grapheme' }) : null;
+
+function graphemes(text:string):string[] {
+  if (segmenter) {
+    return [...segmenter.segment(text)].map(e => e.segment);
+  }
+  return [...text];
+}
+
+function backwardCharSize(node:{isText:boolean; text?:string|null; nodeSize:number}):number {
+  if (!node.isText) return node.nodeSize;
+  const g = graphemes(node.text!);
+  return g[g.length - 1]?.length ?? 1;
+}
+
+function forwardCharSize(node:{isText:boolean; text?:string|null; nodeSize:number}):number {
+  if (!node.isText) return node.nodeSize;
+  return graphemes(node.text!)[0]?.length ?? 1;
+}
+
+const keyboardDeletePlugin = new Plugin({
+  key: pluginKey,
+  props: {
+    handleKeyDown(view, event) {
+      const isBackspace = event.key === 'Backspace';
+      const isDelete = event.key === 'Delete';
+      if ((!isBackspace && !isDelete) || event.isComposing) return false;
+
+      const { selection } = view.state;
+      if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+      const $cursor = selection.$cursor;
+      if (!$cursor) return false;
+
+      const isLineDelete = event.metaKey && !event.ctrlKey && !event.altKey;
+      const isWordDelete = event.ctrlKey || event.altKey;
+
+      if (isBackspace) {
+        if ($cursor.parentOffset === 0) return false;
+        const nodeBefore = $cursor.nodeBefore;
+        if (!nodeBefore) return false;
+
+        let from:number;
+        if (isLineDelete) {
+          from = $cursor.pos - $cursor.parentOffset;
+        } else if (isWordDelete && nodeBefore.isText) {
+          const text = nodeBefore.text!;
+          let i = text.length;
+          while (i > 0 && /\s/.test(text[i - 1])) i -= 1;
+          while (i > 0 && !/\s/.test(text[i - 1])) i -= 1;
+          from = $cursor.pos - (text.length - i);
+        } else {
+          from = $cursor.pos - backwardCharSize(nodeBefore);
+        }
+
+        view.dispatch(view.state.tr.delete(from, $cursor.pos));
+        return true;
+      }
+
+      const nodeAfter = $cursor.nodeAfter;
+      if (!nodeAfter) return false;
+
+      let to:number;
+      if (isLineDelete) {
+        to = $cursor.end();
+      } else if (isWordDelete && nodeAfter.isText) {
+        const text = nodeAfter.text!;
+        let i = 0;
+        while (i < text.length && !/\s/.test(text[i])) i += 1;
+        while (i < text.length && /\s/.test(text[i])) i += 1;
+        to = $cursor.pos + i;
+      } else {
+        to = $cursor.pos + forwardCharSize(nodeAfter);
+      }
+
+      view.dispatch(view.state.tr.delete($cursor.pos, to));
+      return true;
+    },
+  },
+});
+
+export const KeyboardDeleteExtension = createExtension({
+  key: 'opKeyboardDelete',
+  prosemirrorPlugins: [keyboardDeletePlugin],
+});

--- a/lib/plugins/opBlockNoteExtensions.ts
+++ b/lib/plugins/opBlockNoteExtensions.ts
@@ -1,0 +1,14 @@
+import { createExtension } from '@blocknote/core';
+import { KeyboardDeleteExtension } from './keyboardDeleteExtension';
+import { PasteDeduplicateExtension } from './pasteDeduplicateExtension';
+
+/**
+ * Required extensions for op-blocknote-extensions.
+ *
+ * Must be added to `editorOptions.extensions: [...]` at editor construction
+ * time, not registered post-mount via `editor.registerPlugin(...)`.
+ */
+export const OpBlockNoteExtensions = createExtension({
+  key: 'opBlockNoteExtensions',
+  blockNoteExtensions: [PasteDeduplicateExtension, KeyboardDeleteExtension],
+});

--- a/lib/plugins/pasteDeduplicateExtension.ts
+++ b/lib/plugins/pasteDeduplicateExtension.ts
@@ -18,7 +18,7 @@ import { pasteDeduplicatePlugin } from './pasteDeduplicatePlugin';
  * Adding the plugin to the editor's initial extension list avoids the
  * `reconfigure` pass entirely.
  */
-export const PasteDeduplicateInstanceIdsExtension = createExtension({
+export const PasteDeduplicateExtension = createExtension({
   key: 'pasteDeduplicateInstanceIds',
   prosemirrorPlugins: [pasteDeduplicatePlugin],
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import {
   workPackageSlashMenu,
   useHashWpMenu,
   useOpBlockNoteExtensions,
-  PasteDeduplicateInstanceIdsExtension,
+  OpBlockNoteExtensions,
 } from '../lib';
 import './fetchOverride';
 
@@ -45,7 +45,7 @@ function buildSlashMenuItems(editor:EditorType) {
 }
 
 export default function App() {
-  const editor = useCreateBlockNote({ schema, extensions: [PasteDeduplicateInstanceIdsExtension] });
+  const editor = useCreateBlockNote({ schema, extensions: [OpBlockNoteExtensions] });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
   useOpBlockNoteExtensions(editor as any);

--- a/test/helpers/renderEditor.tsx
+++ b/test/helpers/renderEditor.tsx
@@ -10,7 +10,7 @@ import {
   workPackageSlashMenu,
   useHashWpMenu,
   useOpBlockNoteExtensions,
-  PasteDeduplicateInstanceIdsExtension,
+  OpBlockNoteExtensions,
 } from '../../lib';
 
 import '@blocknote/core/fonts/inter.css';
@@ -26,7 +26,7 @@ const schema = BlockNoteSchema.create().extend({
 });
 
 function Editor({ onEditor }:{ onEditor?:(editor:any) => void }) {
-  const editor = useCreateBlockNote({ schema, extensions: [PasteDeduplicateInstanceIdsExtension] });
+  const editor = useCreateBlockNote({ schema, extensions: [OpBlockNoteExtensions] });
   onEditor?.(editor);
   useOpBlockNoteExtensions(editor as any);
 

--- a/test/lib/components/integration/editor.backspaceDelete.browser.test.tsx
+++ b/test/lib/components/integration/editor.backspaceDelete.browser.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import {
+  insertInlineWorkPackageViaHash,
+  insertInlineWorkPackageViaSlashMenu,
+  convertToCompactCard,
+} from '../../../helpers/editorHelpers';
+
+describe('Backspace - inline WP', () => {
+  it('deletes text typed after inline chip, character by character', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    const editor = page.getByRole('textbox');
+    await userEvent.type(editor, 'abc');
+    await expect.element(editor).toHaveTextContent('abc');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).not.toHaveTextContent('abc');
+    await expect.element(editor).toHaveTextContent('ab');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).not.toHaveTextContent('ab');
+    await expect.element(editor).toHaveTextContent('a');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).not.toHaveTextContent('a');
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+  });
+
+  it('deletes the inline WP itself with Backspace', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    // Cursor is right after the WP
+    await userEvent.keyboard('{Backspace}');
+
+    await expect.element(page.getByText('#123')).not.toBeInTheDocument();
+  });
+
+  it('deletes typed text and then the WP with successive Backspace presses', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    const editor = page.getByRole('textbox');
+    await userEvent.type(editor, 'hi');
+    await expect.element(editor).toHaveTextContent('hi');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).toHaveTextContent('h');
+    await expect.element(editor).not.toHaveTextContent('hi');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).not.toHaveTextContent('h');
+
+    // Cursor is now right after the WP - Backspace removes the WP
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(page.getByText('#123')).not.toBeInTheDocument();
+  });
+});
+
+describe('Backspace - block WP', () => {
+  it('deletes text typed after a block WP, character by character', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaSlashMenu();
+    await convertToCompactCard();
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    // After conversion the cursor lands in the empty paragraph following the block card
+    const editor = page.getByRole('textbox');
+    await userEvent.type(editor, 'abc');
+    await expect.element(editor).toHaveTextContent('abc');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).not.toHaveTextContent('abc');
+    await expect.element(editor).toHaveTextContent('ab');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).not.toHaveTextContent('ab');
+    await expect.element(editor).toHaveTextContent('a');
+
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(editor).not.toHaveTextContent('a');
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+  });
+});
+
+describe('Delete - inline WP', () => {
+  it('deletes text in front of the cursor, character by character', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    const editor = page.getByRole('textbox');
+    await userEvent.type(editor, 'abc');
+    await expect.element(editor).toHaveTextContent('abc');
+
+    // Move cursor before 'a' (right after the chip)
+    await userEvent.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
+
+    await userEvent.keyboard('{Delete}');
+    await expect.element(editor).not.toHaveTextContent('abc');
+    await expect.element(editor).toHaveTextContent('bc');
+
+    await userEvent.keyboard('{Delete}');
+    await expect.element(editor).not.toHaveTextContent('bc');
+    await expect.element(editor).toHaveTextContent('c');
+
+    await userEvent.keyboard('{Delete}');
+    await expect.element(editor).not.toHaveTextContent('c');
+
+    await expect.element(page.getByText('#123')).toBeVisible();
+  });
+
+  it('deletes the inline WP itself with Delete', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    // Move cursor before the chip
+    await userEvent.keyboard('{ArrowLeft}');
+
+    await userEvent.keyboard('{Delete}');
+
+    await expect.element(page.getByText('#123')).not.toBeInTheDocument();
+  });
+
+});
+
+describe('Delete - block WP', () => {
+  it('deletes text in front of the cursor, character by character', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaSlashMenu();
+    await convertToCompactCard();
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    // After conversion the cursor lands in the empty paragraph following the block card
+    const editor = page.getByRole('textbox');
+    await userEvent.type(editor, 'abc');
+    await expect.element(editor).toHaveTextContent('abc');
+
+    // Move cursor before 'a'
+    await userEvent.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
+
+    await userEvent.keyboard('{Delete}');
+    await expect.element(editor).not.toHaveTextContent('abc');
+    await expect.element(editor).toHaveTextContent('bc');
+
+    await userEvent.keyboard('{Delete}');
+    await expect.element(editor).not.toHaveTextContent('bc');
+    await expect.element(editor).toHaveTextContent('c');
+
+    await userEvent.keyboard('{Delete}');
+    await expect.element(editor).not.toHaveTextContent('c');
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/STC-806

# What are you trying to accomplish?
After inserting a work package link via #, any text typed afterwards cannot be deleted with Backspace. The editor appears frozen until a re-sync event (timeout, click, or next edit) restores normal behavior.

# Why does this happen?
The bug is specific to OpenProject's Documents module because it uses Hocuspocus (WebSocket + Yjs) for collaborative editing.

Tiptap's built-in Backspace handler only covers special cases - undoing input rules, deleting a non-empty selection, joining blocks at the start of a line. For a normal cursor sitting in the middle of text, every registered handler returns false. ProseMirror then falls back to letting the browser handle the keystroke natively.

The native path:

- Browser modifies the DOM
- ProseMirror's domObserver detects the change and creates a transaction
- Transaction is sent to Yjs via ySyncPlugin

Step 2 becomes unreliable when a WP chip is present. The chip is an atom node rendered with contenteditable="false". Combined with y-prosemirror's own DOM instrumentation, the domObserver either misses the change or produces an empty no-op transaction. ProseMirror and Yjs states diverge - Backspace does nothing. The "gets unstuck after a while" behavior is Yjs's afterAllTransactions cycle forcing a document reconstruct from Y.Doc, which resets the diverged state.

This doesn't happen in standard editors because without Yjs there's no DOM instrumentation and domObserver works cleanly around atom nodes.

This doesn't happen in standard editors because without Yjs there's no DOM instrumentation and domObserver works cleanly around atom nodes.

# What approach did you choose and why?
A shared package op-blocknote-extensions with two extensions bundled as OpBlockNoteExtensions.

_KeyboardDeleteExtension_

Intercepts Backspace and Delete keystrokes and dispatches an explicit tr.delete() ProseMirror transaction instead of falling through to the browser. Handles the full range of deletion shortcuts:

| Key | Modifier | Behavior|
| :--- | :---: | ---: |
| Backspace / Delete | — | Delete one grapheme cluster (or one atom node) |
| Backspace / Delete | Ctrl / Alt  | Word delete |
| Backspace / Delete | Cmd (macOS) | Delete to block boundary |

Implemented as a raw ProseMirror plugin (prosemirrorPlugins) rather than BlockNote's keyboardShortcuts API - this gives access to the raw KeyboardEvent, which is needed to skip IME composition events and to use Intl.Segmenter for correct grapheme cluster deletion (emoji, ZWJ sequences).

```jsx
handleKeyDown(view, event) {
  const isBackspace = event.key === 'Backspace';
  const isDelete = event.key === 'Delete';
  if ((!isBackspace && !isDelete) || event.isComposing) return false;
  if (!(selection instanceof TextSelection) || !selection.empty) return false;
  if (!$cursor) return false;

  const isLineDelete = event.metaKey && !event.ctrlKey && !event.altKey;
  const isWordDelete = event.ctrlKey || event.altKey;

  // compute from/to based on direction and modifier, then:
  view.dispatch(view.state.tr.delete(from, to));
  return true;
}
```

An explicit tr.delete() bypasses the entire native browser -> DOM change -> domObserver -> PM transaction chain. ProseMirror dispatches the transaction directly, ySyncPlugin picks it up cleanly, Yjs updates reliably.

_PasteDeduplicateExtension_

A separate but related issue: when a WP chip is copy-pasted, BlockNote duplicates all node props verbatim including instanceId. Two chips sharing the same ID means any resize or delete action always targets the first chip in the document, not the pasted copy. This extension regenerates a fresh instanceId for every chip found in pasted content via ProseMirror's transformPasted hook.

Important: registration at construction time

Both extensions must be added to editorOptions.extensions: [OpBlockNoteExtensions] at editor construction time, not via editor.registerPlugin() post-mount. Post-mount registration triggers Tiptap's reconfigure(), which destroys the yUndoPlugin view and removes the afterTransaction listener from Y.Doc. The plugin state carries over (so init never re-runs), but the listener is permanently gone - Ctrl+Z silently stops working for the rest of the session.



**The openproject PR**: https://github.com/opf/openproject/pull/23840

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
