### PR TITLE
[BNE-114] Slash-command for linking work package should highlight first search result

### DIFF
--- a/lib/hooks/useWorkPackageSearchDropdown.ts
+++ b/lib/hooks/useWorkPackageSearchDropdown.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent, RefObject } from 'react';
 import type { WorkPackage } from '../openProjectTypes';
 import { useWorkPackageSearch } from './useWorkPackageSearch';
@@ -29,6 +29,11 @@ export function useWorkPackageSearchDropdown({
   const { searchQuery, setSearchQuery, searchResults } = useWorkPackageSearch();
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setFocusedIndex(searchResults.length > 0 ? 0 : -1);
+  }, [searchResults]);
 
   // useRef instead of useState changing this flag must not trigger a re-render,
   // it only needs to be readable in the onBlur timeout in SearchDropdown.

--- a/test/lib/components/integration/searchDropdown.browser.test.tsx
+++ b/test/lib/components/integration/searchDropdown.browser.test.tsx
@@ -3,7 +3,7 @@ import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
 import { SearchDropdown } from '../../../../lib/components/Search/SearchDropdown';
 import { BlockCard } from '../../../../lib/components/BlockWorkPackage/BlockCard';
-import { mockWorkPackage } from '../../../mocks/handlers';
+import { mockWorkPackage, mockWorkPackage2 } from '../../../mocks/handlers';
 import type { WorkPackage } from '../../../../lib/openProjectTypes';
 
 const renderItem = (wp:WorkPackage) => <BlockCard workPackage={wp} inDropdown />;
@@ -49,6 +49,22 @@ describe('SearchDropdown', () => {
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
+  it('selects first result with Enter without pressing arrow keys', async () => {
+    const onSelect = vi.fn();
+    render(
+      <SearchDropdown onSelect={onSelect} onCancel={vi.fn()} renderItem={renderItem} />
+    );
+
+    await userEvent.type(page.getByRole('searchbox'), 'Fix');
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+
+    await userEvent.keyboard('{Enter}');
+
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: mockWorkPackage.id })
+    );
+  });
+
   it('navigates results with arrow keys and selects with Enter', async () => {
     const onSelect = vi.fn();
     render(
@@ -58,10 +74,11 @@ describe('SearchDropdown', () => {
     await userEvent.type(page.getByRole('searchbox'), 'mode');
     await expect.element(page.getByText('Add dark mode')).toBeVisible();
 
+    // First item is auto-selected; ArrowDown moves to the second item.
     await userEvent.keyboard('{ArrowDown}{Enter}');
 
     expect(onSelect).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({ id: mockWorkPackage.id })
+        expect.objectContaining({ id: mockWorkPackage2.id })
     );
     });
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-114

# What are you trying to accomplish?
When searching for a work package via the /wp slash command, the first result in the dropdown is now automatically highlighted. This allows the user to press Enter immediately to insert it without having to press ArrowDown first.

The #-notation already had this behavior - this brings /wp to parity.

# What approach did you choose and why?
useWorkPackageSearchDropdown initialised focusedIndex at -1 (no selection) and never reset it when new results arrived. Added a useEffect that resets focusedIndex to 0 whenever searchResults changes and has at least one item - and back to -1 when results are empty.

```jsx
useEffect(() => {
  // eslint-disable-next-line react-hooks/set-state-in-effect
  setFocusedIndex(searchResults.length > 0 ? 0 : -1);
}, [searchResults]);
```
Alternative considered: React's derived-state pattern (if (prevResults !== searchResults) during render). Discarded in favour of useEffect - it requires an extra prevResults state variable and is less readable, while useEffect is already the established pattern in this codebase (useWorkPackageSearch.ts).



# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
