### PR TITLE
[BNE-110] Work package titles should not be cut off for inline work package links in documents

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -24,8 +24,7 @@ const Block = styled.div.attrs({ className: 'op-bn-extensions', 'data-testid': '
   background-color: ${({ $pending }) => ($pending ? 'transparent' : 'var(--op-chip-bg)')};
   user-select: all;
   border-radius: var(--bn-border-radius);
-  outline: ${({ $selected }) => ($selected ? CHIP_STYLES.focusOutline : 'none')};
-  outline-offset: 1px;
+  box-shadow: ${({ $selected }) => ($selected ? CHIP_STYLES.focusShadow : 'none')};
   ${({ $pending }) => $pending && 'position: relative;'}
 `;
 

--- a/lib/components/InlineWorkPackage/InlineChips.tsx
+++ b/lib/components/InlineWorkPackage/InlineChips.tsx
@@ -18,6 +18,7 @@ import {
 import { formatWorkPackageId } from '../../utils/id';
 
 const resolvedDisplayId = (wp:WorkPackage) => wp.displayId ?? String(wp.id);
+const WRAP_OPPORTUNITY = '\u200B'; /*zero-width space*/
 
 const titleLinkProps = (wp:WorkPackage) => ({
   as: 'a' as const,
@@ -39,11 +40,13 @@ export const WpChipXXS = ({ wp }:{ wp:WorkPackage }) => (
 export const WpChipXS = ({ wp }:{ wp:WorkPackage }) => (
   <ChipBaseXS>
     <WorkPackageId as="span" $compact>{formatWorkPackageId(resolvedDisplayId(wp))}</WorkPackageId>
+    {WRAP_OPPORTUNITY}
     {wp._links?.type?.title && (
       <WorkPackageType as="span" $compact $color={typeColor(wp)}>
         {wp._links.type.title}
       </WorkPackageType>
     )}
+    {WRAP_OPPORTUNITY}
     <WorkPackageTitleLink {...titleLinkProps(wp)}>
       {wp.subject}
     </WorkPackageTitleLink>
@@ -54,11 +57,13 @@ export const WpChipXS = ({ wp }:{ wp:WorkPackage }) => (
 export const WpChipS = ({ wp }:{ wp:WorkPackage }) => (
   <ChipBaseS>
     <WorkPackageId as="span" $compact>{formatWorkPackageId(resolvedDisplayId(wp))}</WorkPackageId>
+    {WRAP_OPPORTUNITY}
     {wp._links?.type?.title && (
       <WorkPackageType as="span" $compact $color={typeColor(wp)}>
         {wp._links.type.title}
       </WorkPackageType>
     )}
+    {WRAP_OPPORTUNITY}
     {wp._links?.status?.title && (
       <WorkPackageStatus
         as="span"
@@ -70,6 +75,7 @@ export const WpChipS = ({ wp }:{ wp:WorkPackage }) => (
         {wp._links.status.title}
       </WorkPackageStatus>
     )}
+    {WRAP_OPPORTUNITY}
     <WorkPackageTitleLink {...titleLinkProps(wp)}>
       {wp.subject}
     </WorkPackageTitleLink>

--- a/lib/components/InlineWorkPackage/InlineChips.tsx
+++ b/lib/components/InlineWorkPackage/InlineChips.tsx
@@ -28,14 +28,14 @@ const titleLinkProps = (wp:WorkPackage) => ({
   onClick: (e:React.MouseEvent) => e.stopPropagation(),
 });
 
-// XXS — "#ID"  (padding 2px 8px)
+// XXS — "#ID"
 export const WpChipXXS = ({ wp }:{ wp:WorkPackage }) => (
   <ChipBaseXXS>
     <WorkPackageId as="span" $compact>{formatWorkPackageId(resolvedDisplayId(wp))}</WorkPackageId>
   </ChipBaseXXS>
 );
 
-// XS — "#ID  TYPE  [Title]"  (padding 8px)
+// XS — "#ID TYPE subject"
 export const WpChipXS = ({ wp }:{ wp:WorkPackage }) => (
   <ChipBaseXS>
     <WorkPackageId as="span" $compact>{formatWorkPackageId(resolvedDisplayId(wp))}</WorkPackageId>
@@ -50,7 +50,7 @@ export const WpChipXS = ({ wp }:{ wp:WorkPackage }) => (
   </ChipBaseXS>
 );
 
-// S — "#ID  TYPE  [Status]  [Title]"  (padding 8px)
+// S — "#ID TYPE [Status] subject"
 export const WpChipS = ({ wp }:{ wp:WorkPackage }) => (
   <ChipBaseS>
     <WorkPackageId as="span" $compact>{formatWorkPackageId(resolvedDisplayId(wp))}</WorkPackageId>

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useWorkPackage } from '../../hooks/useWorkPackage';
 import { useColors } from '../../services/colors';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
@@ -33,19 +33,29 @@ const InlineChip = styled.span.attrs({
 })<{ selected?:boolean }>`
   ${defaultWpVariables}
   display: inline;
-  vertical-align: middle;
   cursor: pointer;
   user-select: none;
   border-radius: ${CHIP_STYLES.radius};
-  outline: ${({ selected }) => (selected ? CHIP_STYLES.focusOutline : 'none')};
-  outline-offset: 1px;
-  box-shadow: ${({ selected }) => (selected ? CHIP_STYLES.focusShadow : 'none')};
+  margin: 0 var(--spacer-s); // necessary so blue outline will not cover adjacent characters
   position: relative;
   line-height: 1;
 
   &:active {
     cursor: grabbing;
   }
+
+  /* Paint the selection ring on the chip surface (the grey-background element) so it shares
+     the exact same box and clones onto every line fragment of a wrapped subject. */
+  ${({ selected }) =>
+    selected &&
+    css`
+      /* selection should be above other elements in adjacent lines */
+      z-index: 1;
+
+      & > .op-bn-inline-wp-base {
+        box-shadow: ${CHIP_STYLES.focusShadow};
+      }
+    `}
 `;
 
 export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor }:InlineWorkPackageChipProps) => {

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -36,7 +36,6 @@ const InlineChip = styled.span.attrs({
   cursor: pointer;
   user-select: none;
   border-radius: ${CHIP_STYLES.radius};
-  margin: 0 var(--spacer-s); // necessary so blue outline will not cover adjacent characters
   position: relative;
   line-height: 1;
 
@@ -44,16 +43,11 @@ const InlineChip = styled.span.attrs({
     cursor: grabbing;
   }
 
-  /* Paint the selection ring on the chip surface (the grey-background element) so it shares
-     the exact same box and clones onto every line fragment of a wrapped subject. */
   ${({ selected }) =>
     selected &&
     css`
-      /* selection should be above other elements in adjacent lines */
-      z-index: 1;
-
       & > .op-bn-inline-wp-base {
-        box-shadow: ${CHIP_STYLES.focusShadow};
+        box-shadow: ${CHIP_STYLES.inlineFocusShadow};
       }
     `}
 `;

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -32,8 +32,7 @@ const InlineChip = styled.span.attrs({
   contentEditable: false,
 })<{ selected?:boolean }>`
   ${defaultWpVariables}
-  display: inline-flex;
-  align-items: center;
+  display: inline;
   vertical-align: middle;
   cursor: pointer;
   user-select: none;
@@ -42,7 +41,6 @@ const InlineChip = styled.span.attrs({
   outline-offset: 1px;
   box-shadow: ${({ selected }) => (selected ? CHIP_STYLES.focusShadow : 'none')};
   position: relative;
-  max-width: 100%;
   line-height: 1;
 
   &:active {

--- a/lib/components/InlineWorkPackage/chipLayouts.tsx
+++ b/lib/components/InlineWorkPackage/chipLayouts.tsx
@@ -25,9 +25,8 @@ const chipBaseStyles = css`
     }
   }
 
-  /* gap equivalent for display:inline — applies left margin to every child except the first */
-  & > * + * {
-    margin-left: ${CHIP_STYLES.gap};
+  & > *:not(:last-child) {
+    margin-right: ${CHIP_STYLES.gap};
   }
 `;
 

--- a/lib/components/InlineWorkPackage/chipLayouts.tsx
+++ b/lib/components/InlineWorkPackage/chipLayouts.tsx
@@ -3,15 +3,17 @@ import styled from 'styled-components';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
 
 const chipBaseStyles = css`
-  display: inline-flex;
-  align-items: center;
-  gap: ${CHIP_STYLES.gap};
+  display: inline;
   border-radius: ${CHIP_STYLES.radius};
   background: ${CHIP_STYLES.bg};
-  white-space: nowrap;
-  max-width: 480px;
-  overflow: hidden;
   font-size: ${CHIP_STYLES.fontSize};
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+
+  /* gap equivalent for display:inline — applies left margin to every child except the first */
+  & > * + * {
+    margin-left: ${CHIP_STYLES.gap};
+  }
 `;
 
 export const ChipBaseXXS = styled.span`

--- a/lib/components/InlineWorkPackage/chipLayouts.tsx
+++ b/lib/components/InlineWorkPackage/chipLayouts.tsx
@@ -10,23 +10,38 @@ const chipBaseStyles = css`
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
 
+  /* Align ID, type, status and subject on the shared text baseline.
+     Correct in Gecko (Firefox) and WebKit (Safari). */
+  & > * {
+    vertical-align: baseline;
+  }
+
+  /* Blink (Chrome/Edge) renders the smaller 12px ID/meta text too low with
+     baseline alignment when mixed with the 14px subject, which also skewed the
+     selection outline. */
+  @supports (-webkit-app-region: drag) {
+    & > * {
+      vertical-align: middle;
+    }
+  }
+
   /* gap equivalent for display:inline — applies left margin to every child except the first */
   & > * + * {
     margin-left: ${CHIP_STYLES.gap};
   }
 `;
 
-export const ChipBaseXXS = styled.span`
+export const ChipBaseXXS = styled.span.attrs({ className: 'op-bn-inline-wp-base' })`
   ${chipBaseStyles}
   padding: ${CHIP_STYLES.padding.xxs};
 `;
 
-export const ChipBaseXS = styled.span`
+export const ChipBaseXS = styled.span.attrs({ className: 'op-bn-inline-wp-base' })`
   ${chipBaseStyles}
   padding: ${CHIP_STYLES.padding.xs};
 `;
 
-export const ChipBaseS = styled.span`
+export const ChipBaseS = styled.span.attrs({ className: 'op-bn-inline-wp-base' })`
   ${chipBaseStyles}
   padding: ${CHIP_STYLES.padding.s};
 `;

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -10,6 +10,9 @@ export const defaultWpVariables = css`
   --spacer-l: 12px;
   --spacer-xl: 16px;
 
+  /* BlockNote's node-selection outline color; not exposed by BlockNote as a variable, so defined here */
+  --blocknote-focus-color: rgb(100, 160, 255);
+
   --lightness-threshold: 0.453;
   --background-alpha: 0.18;
 

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -89,27 +89,15 @@ export const WorkPackageStatus = styled.span.attrs({
       font-weight: 600;
       display: inline-flex;
       align-items: center;
-      gap: 4px;
     `}
 `;
 
 export const WorkPackageTitle = styled.span.attrs({
   className: 'op-bn-work-package--title',
-})<{ $compact?:boolean }>`
+})`
   color: var(--bn-colors-editor-text);
   font-weight: 500;
   overflow-wrap: anywhere;
-
-  ${({ $compact }) =>
-    $compact &&
-    css`
-      font-size: 14px;
-      font-weight: 600;
-      color: var(--bn-colors-highlights-blue-text);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    `}
 `;
 
 export const WorkPackageTitleLink = styled.a<{ $compact?:boolean }>`

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -40,7 +40,7 @@ export const WorkPackageId = styled.span.attrs({
     css`
       font-size: 12px;
       font-weight: 400;
-      flex-shrink: 0;
+      white-space: nowrap;
     `}
 `;
 
@@ -124,8 +124,5 @@ export const WorkPackageTitleLink = styled.a<{ $compact?:boolean }>`
     css`
       font-size: 14px;
       font-weight: 600;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
     `}
 `;

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -61,7 +61,6 @@ export const WorkPackageType = styled.span.attrs({
     $compact &&
     css`
       font-size: 12px;
-      flex-shrink: 0;
     `}
 `;
 
@@ -79,7 +78,6 @@ export const WorkPackageStatus = styled.span.attrs({
   border-radius: 100px;
   border: 1px solid ${({ $borderColor }) => $borderColor ?? 'transparent'};
   padding: 0 7px;
-  align-content: center;
   color: ${({ $textColor }) => $textColor} !important;
   background-color: ${({ $bgColor }) => $bgColor};
   white-space: nowrap;
@@ -89,7 +87,6 @@ export const WorkPackageStatus = styled.span.attrs({
     css`
       font-size: 12px;
       font-weight: 600;
-      flex-shrink: 0;
       display: inline-flex;
       align-items: center;
       gap: 4px;
@@ -99,7 +96,6 @@ export const WorkPackageStatus = styled.span.attrs({
 export const WorkPackageTitle = styled.span.attrs({
   className: 'op-bn-work-package--title',
 })<{ $compact?:boolean }>`
-  flex-basis: max-content;
   color: var(--bn-colors-editor-text);
   font-weight: 500;
   overflow-wrap: anywhere;

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -37,13 +37,13 @@ export const WorkPackageId = styled.span.attrs({
   className: 'op-bn-work-package--id',
 })<{ $compact?:boolean }>`
   color: var(--op-wp-meta-color) !important;
+  white-space: nowrap;
 
   ${({ $compact }) =>
     $compact &&
     css`
       font-size: 12px;
       font-weight: 400;
-      white-space: nowrap;
     `}
 `;
 
@@ -55,6 +55,7 @@ export const WorkPackageType = styled.span.attrs({
   font-weight: ${({ $compact }) => ($compact ? 600 : 500)};
   text-transform: uppercase;
   color: ${typeTextColor} !important;
+  white-space: nowrap;
 
   ${({ $compact }) =>
     $compact &&
@@ -81,6 +82,7 @@ export const WorkPackageStatus = styled.span.attrs({
   align-content: center;
   color: ${({ $textColor }) => $textColor} !important;
   background-color: ${({ $bgColor }) => $bgColor};
+  white-space: nowrap;
 
   ${({ $compact }) =>
     $compact &&
@@ -100,6 +102,7 @@ export const WorkPackageTitle = styled.span.attrs({
   flex-basis: max-content;
   color: var(--bn-colors-editor-text);
   font-weight: 500;
+  overflow-wrap: anywhere;
 
   ${({ $compact }) =>
     $compact &&
@@ -117,6 +120,7 @@ export const WorkPackageTitleLink = styled.a<{ $compact?:boolean }>`
   cursor: pointer;
   text-decoration: none;
   color: var(--bn-colors-highlights-blue-text);
+  overflow-wrap: anywhere;
 
   &:hover {
     text-decoration: underline;

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -42,6 +42,5 @@ export const CHIP_STYLES = {
     },
   },
 
-  focusOutline: '4px solid var(--mantine-color-blue-4)',
-  focusShadow: 'none',
+  focusShadow: '0 0 0 4px var(--blocknote-focus-color)',
 } as const;

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -10,37 +10,5 @@ export const CHIP_STYLES = {
 
   fontSize: '12px',
 
-  id: {
-    color: 'var(--op-wp-meta-color)',
-    fontWeight: 400,
-  },
-
-  type: {
-    fontWeight: 600,
-    letterSpacing: '0.04em',
-    textTransform: 'uppercase' as const,
-  },
-
-  subject: {
-    color: 'var(--bn-colors-highlights-blue-text)',
-    fontWeight: 600,
-    fontSize: '14px',
-  },
-
-  status: {
-    bg: 'var(--op-status-bg)',
-    border: '1px solid var(--op-status-border-color)',
-    padding: '1px 8px',
-    radius: '100px',
-    color: 'var(--bn-colors-editor-text)',
-    fontWeight: 600,
-    gap: '4px',
-    chevron: {
-      color: 'var(--bn-colors-highlights-gray-text)',
-      width: '7.29px',
-      height: '3.90px',
-    },
-  },
-
   focusShadow: '0 0 0 4px var(--blocknote-focus-color)',
 } as const;

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -11,4 +11,10 @@ export const CHIP_STYLES = {
   fontSize: '12px',
 
   focusShadow: '0 0 0 4px var(--blocknote-focus-color)',
+  // Inline chips draw the selection ring mostly inward (so it doesn't cover adjacent characters and
+  // the chip stays flush at line starts) plus a thin 1px outward band so it reads like a slightly
+  // smaller version of the block card ring. Keeping it mostly inset is what removes the need for a
+  // horizontal margin that would otherwise indent the chip at line starts.
+  inlineFocusShadow:
+    'inset 0 0 0 2px var(--blocknote-focus-color), 0 0 0 1px var(--blocknote-focus-color)',
 } as const;

--- a/test/lib/components/integration/inlineWorkPackageLongSubject.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageLongSubject.browser.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page } from 'vitest/browser';
+import { WpChipXS, WpChipS } from '../../../../lib/components/InlineWorkPackage/InlineChips';
+import { mockWorkPackage } from '../../../mocks/handlers';
+
+const longSubject = 'This is a very long work package subject that must always be shown in full without any truncation';
+
+const mockWpWithLongSubject = {
+  ...mockWorkPackage,
+  subject: longSubject,
+};
+
+describe('InlineChips - long subject', () => {
+  it('WpChipXS shows the full subject and wraps instead of overflowing a narrow container', async () => {
+    render(
+      <div data-testid="narrow-wrapper" style={{ width: '300px' }}>
+        <WpChipXS wp={mockWpWithLongSubject} />
+      </div>
+    );
+
+    const wrapperLocator = page.getByTestId('narrow-wrapper');
+    await expect.element(wrapperLocator).toBeVisible();
+    await expect.element(page.getByText(longSubject)).toBeVisible();
+
+    const wrapperElement = await wrapperLocator.element();
+    // scrollWidth > clientWidth means content overflows horizontally (chip extends past the
+    // right edge of the editor). Wrapping keeps scrollWidth === clientWidth.
+    expect(wrapperElement.scrollWidth).toBeLessThanOrEqual(wrapperElement.clientWidth);
+  });
+
+  it('WpChipS shows the full subject and wraps instead of overflowing a narrow container', async () => {
+    render(
+      <div data-testid="narrow-wrapper" style={{ width: '300px' }}>
+        <WpChipS wp={mockWpWithLongSubject} />
+      </div>
+    );
+
+    const wrapperLocator = page.getByTestId('narrow-wrapper');
+    await expect.element(wrapperLocator).toBeVisible();
+    await expect.element(page.getByText(longSubject)).toBeVisible();
+
+    const wrapperElement = await wrapperLocator.element();
+    // scrollWidth > clientWidth means content overflows horizontally (chip extends past the
+    // right edge of the editor). Wrapping keeps scrollWidth === clientWidth.
+    expect(wrapperElement.scrollWidth).toBeLessThanOrEqual(wrapperElement.clientWidth);
+  });
+});

--- a/test/lib/components/integration/inlineWorkPackageMetaWrap.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageMetaWrap.browser.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page } from 'vitest/browser';
+import { WpChipXS, WpChipS } from '../../../../lib/components/InlineWorkPackage/InlineChips';
+import { mockWorkPackage } from '../../../mocks/handlers';
+
+// Container narrow enough that the meta cluster (#ID TYPE [STATUS]) cannot sit on a single
+// line, but wide enough for the widest single part. Each part is `white-space: nowrap`, so the
+// only way to avoid horizontal overflow is to wrap *between* parts. Before the fix the parts
+// had no soft-wrap opportunity between them and the cluster overflowed; now a zero-width space
+// between parts lets it wrap. The S chip has the extra (wide) status pill, so it needs more
+// room for its widest single part than the XS chip does.
+const S_NARROW_WIDTH = '110px';
+const XS_NARROW_WIDTH = '80px';
+
+describe('InlineChips - wrap between meta parts', () => {
+  it('WpChipS wraps between parts instead of overflowing a narrow container', async () => {
+    render(
+      <div data-testid="narrow-wrapper" style={{ width: S_NARROW_WIDTH }}>
+        <WpChipS wp={mockWorkPackage} />
+      </div>
+    );
+
+    const wrapperLocator = page.getByTestId('narrow-wrapper');
+    await expect.element(wrapperLocator).toBeVisible();
+    // All parts remain fully visible — wrapping between them, never truncating within them.
+    await expect.element(page.getByText(`#${mockWorkPackage.displayId}`)).toBeVisible();
+    await expect.element(page.getByText(mockWorkPackage._links.status.title)).toBeVisible();
+    await expect.element(page.getByText(mockWorkPackage.subject)).toBeVisible();
+
+    const wrapperElement = await wrapperLocator.element();
+    // scrollWidth > clientWidth means the chip overflows horizontally (the meta cluster could
+    // not break). Wrapping between parts keeps scrollWidth === clientWidth.
+    expect(wrapperElement.scrollWidth).toBeLessThanOrEqual(wrapperElement.clientWidth);
+  });
+
+  it('WpChipXS wraps between parts instead of overflowing a narrow container', async () => {
+    render(
+      <div data-testid="narrow-wrapper" style={{ width: XS_NARROW_WIDTH }}>
+        <WpChipXS wp={mockWorkPackage} />
+      </div>
+    );
+
+    const wrapperLocator = page.getByTestId('narrow-wrapper');
+    await expect.element(wrapperLocator).toBeVisible();
+    await expect.element(page.getByText(`#${mockWorkPackage.displayId}`)).toBeVisible();
+    await expect.element(page.getByText(mockWorkPackage.subject)).toBeVisible();
+
+    const wrapperElement = await wrapperLocator.element();
+    expect(wrapperElement.scrollWidth).toBeLessThanOrEqual(wrapperElement.clientWidth);
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-110

# What are you trying to accomplish?
- long subjects should not be cut off but wrap nicely instead
- ID, type, status should not wrap but it should be possible to wrap between them
- Improve blue outline for multiple lines

## Screenshots
<img width="1361" height="326" alt="image" src="https://github.com/user-attachments/assets/71743894-40a1-4ce5-b6ad-f60d1ffcc826" />

# What approach did you choose and why?
- Don't use flexbox for the inline work package link CSS any more
- Insert zero-width-whitespace between ID, type and status so breaking is possible there
- render outline with box shadow instead of outline (to avoid gap between grey background and blue line)
- ensure the new outline does not "hide" behind other inline work package links in adjacent lines (by using `z-index: 1`)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
