### PR TITLE
[COMMS-806] Documents: impossible to delete characters with backspace after adding a wp link

### DIFF
--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -4,7 +4,6 @@ import { makeInstanceId } from '../../utils/id.ts';
 import type { WorkPackage } from '../../openProjectTypes';
 import {
   placeCursorAfterInlineNode,
-  isInlineNodeAtBlockEnd,
 } from '../../utils/cursor.ts';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,9 +69,7 @@ export function insertWpChip(editor:AnyEditor, wp:WorkPackage, size:InlineWpSize
     // after the trailing space; it runs after placeCursorAfterInlineNode so it wins. Mid-block
     // we keep placeCursorAfterInlineNode's position, since BlockNote has no inline-offset API.
     const blockId = editor.getTextCursorPosition()?.block?.id;
-    if (blockId && isInlineNodeAtBlockEnd(editor, blockId, instanceId)) {
-      editor.setTextCursorPosition(blockId, 'end');
-    }
+    editor.setTextCursorPosition(blockId, 'end');
   });
 }
 

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -2,7 +2,10 @@ import type { BlockNoteEditor } from '@blocknote/core';
 import type { InlineWpSize } from '../WorkPackage/types';
 import { makeInstanceId } from '../../utils/id.ts';
 import type { WorkPackage } from '../../openProjectTypes';
-import { placeCursorAfterInlineNode } from '../../utils/cursor.ts';
+import {
+  placeCursorAfterInlineNode,
+  isInlineNodeAtBlockEnd,
+} from '../../utils/cursor.ts';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyEditor = BlockNoteEditor<any, any, any>;
@@ -61,6 +64,15 @@ export function insertWpChip(editor:AnyEditor, wp:WorkPackage, size:InlineWpSize
 
   requestAnimationFrame(() => {
     placeCursorAfterInlineNode(editor, instanceId);
+
+    // Additionally place the cursor via the BlockNote API. When the chip (plus its trailing
+    // space) is the last content of the block, setTextCursorPosition('end') lands the cursor
+    // after the trailing space; it runs after placeCursorAfterInlineNode so it wins. Mid-block
+    // we keep placeCursorAfterInlineNode's position, since BlockNote has no inline-offset API.
+    const blockId = editor.getTextCursorPosition()?.block?.id;
+    if (blockId && isInlineNodeAtBlockEnd(editor, blockId, instanceId)) {
+      editor.setTextCursorPosition(blockId, 'end');
+    }
   });
 }
 

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -6,7 +6,6 @@ import { registerInlineWpCallbacks, clearInlineWpCallbacks, makePendingWpid } fr
 import { makeInstanceId } from '../utils/id.ts';
 import {
   placeCursorAfterInlineNode,
-  isInlineNodeAtBlockEnd,
 } from '../utils/cursor.ts';
 import { pendingBlockRegistry } from './BlockWorkPackage/pendingBlockRegistry';
 import { isCurrentBlockEmpty } from '../utils/blockContent.ts';
@@ -61,13 +60,28 @@ function buildOnSelect(
       editor.focus();
       placeCursorAfterInlineNode(editor, instanceId);
 
-      // Additionally place the cursor via the BlockNote API. When the chip (plus its trailing
-      // space) is the last content of the block, setTextCursorPosition('end') lands the cursor
-      // after the trailing space; it runs after placeCursorAfterInlineNode so it wins. Mid-block
-      // we keep placeCursorAfterInlineNode's position, since BlockNote has no inline-offset API.
-      if (isInlineNodeAtBlockEnd(editor, current.blockId, instanceId)) {
-        editor.setTextCursorPosition(current.blockId, 'end');
-      }
+      // Mitigate bug where backspace would not work on text typed directly after adding
+      // a new inline work package link.
+      // Tiptap's built-in Backspace handler only covers special cases - undoing input
+      // rules, deleting a non-empty selection, joining blocks at the start of a line.
+      // For a normal cursor sitting in the middle of text, every registered handler
+      // returns false. ProseMirror then falls back to letting the browser handle the
+      // keystroke natively.
+      //
+      // The native path:
+      //
+      //     Browser modifies the DOM
+      //     ProseMirror's domObserver detects the change and creates a transaction
+      //     Transaction is sent to Yjs via ySyncPlugin
+      //
+      // Step 2 becomes unreliable when a WP chip is present. The chip is an atom node
+      // rendered with contenteditable="false". Combined with y-prosemirror's own DOM
+      // instrumentation, the domObserver either misses the change or produces an empty
+      // no-op transaction. ProseMirror and Yjs states diverge - Backspace does nothing.
+      //
+      // A re-sync event (timeout, click, or next edit) restores normal behavior.
+      // We're setting the cursor position to trigger this re-sync event.
+      editor.setTextCursorPosition(current.blockId, 'end');
     });
   };
 }

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -4,7 +4,10 @@ import i18n from '../services/i18n.ts';
 import { getAliases } from '../services/slashMenuAliases';
 import { registerInlineWpCallbacks, clearInlineWpCallbacks, makePendingWpid } from './InlineWorkPackage/callbacks';
 import { makeInstanceId } from '../utils/id.ts';
-import { placeCursorAfterInlineNode } from '../utils/cursor.ts';
+import {
+  placeCursorAfterInlineNode,
+  isInlineNodeAtBlockEnd,
+} from '../utils/cursor.ts';
 import { pendingBlockRegistry } from './BlockWorkPackage/pendingBlockRegistry';
 import { isCurrentBlockEmpty } from '../utils/blockContent.ts';
 import type { AnyEditor } from './HashMenu/editorUtils';
@@ -57,6 +60,14 @@ function buildOnSelect(
     requestAnimationFrame(() => {
       editor.focus();
       placeCursorAfterInlineNode(editor, instanceId);
+
+      // Additionally place the cursor via the BlockNote API. When the chip (plus its trailing
+      // space) is the last content of the block, setTextCursorPosition('end') lands the cursor
+      // after the trailing space; it runs after placeCursorAfterInlineNode so it wins. Mid-block
+      // we keep placeCursorAfterInlineNode's position, since BlockNote has no inline-offset API.
+      if (isInlineNodeAtBlockEnd(editor, current.blockId, instanceId)) {
+        editor.setTextCursorPosition(current.blockId, 'end');
+      }
     });
   };
 }

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -19,41 +19,6 @@ export function moveCursorAfterBlock(editor:AnyEditor, blockId:string):void {
   }
 }
 
-/**
- * Reports whether the inline node identified by `instanceId` is the last meaningful content
- * of `blockId` — i.e. nothing follows it, or only a single trailing space text node does.
- * Uses the BlockNote API only. When true, the cursor can be placed after the node via the
- * block-level `setTextCursorPosition(blockId, 'end')`, which BlockNote does support; mid-block
- * positions have no BlockNote API and need `placeCursorAfterInlineNode`.
- */
-export function isInlineNodeAtBlockEnd(
-  editor:AnyEditor,
-  blockId:string,
-  instanceId:string,
-):boolean {
-  const block = editor.getBlock(blockId);
-  if (!block) return false;
-
-  const content = (block.content ?? []) as {
-    type:string;
-    text?:string;
-    props?:{ instanceId?:string };
-  }[];
-
-  const index = content.findIndex(
-    (node) =>
-      node.type === 'openProjectWorkPackageInline' &&
-      node.props?.instanceId === instanceId,
-  );
-  if (index === -1) return false;
-
-  const after = content.slice(index + 1);
-  if (after.length === 0) return true;
-  return (
-    after.length === 1 && after[0].type === 'text' && after[0].text === ' '
-  );
-}
-
 export function placeCursorAfterInlineNode(
   editor:AnyEditor,
   instanceId:string,

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -19,7 +19,45 @@ export function moveCursorAfterBlock(editor:AnyEditor, blockId:string):void {
   }
 }
 
-export function placeCursorAfterInlineNode(editor:AnyEditor, instanceId:string):void {
+/**
+ * Reports whether the inline node identified by `instanceId` is the last meaningful content
+ * of `blockId` — i.e. nothing follows it, or only a single trailing space text node does.
+ * Uses the BlockNote API only. When true, the cursor can be placed after the node via the
+ * block-level `setTextCursorPosition(blockId, 'end')`, which BlockNote does support; mid-block
+ * positions have no BlockNote API and need `placeCursorAfterInlineNode`.
+ */
+export function isInlineNodeAtBlockEnd(
+  editor:AnyEditor,
+  blockId:string,
+  instanceId:string,
+):boolean {
+  const block = editor.getBlock(blockId);
+  if (!block) return false;
+
+  const content = (block.content ?? []) as {
+    type:string;
+    text?:string;
+    props?:{ instanceId?:string };
+  }[];
+
+  const index = content.findIndex(
+    (node) =>
+      node.type === 'openProjectWorkPackageInline' &&
+      node.props?.instanceId === instanceId,
+  );
+  if (index === -1) return false;
+
+  const after = content.slice(index + 1);
+  if (after.length === 0) return true;
+  return (
+    after.length === 1 && after[0].type === 'text' && after[0].text === ' '
+  );
+}
+
+export function placeCursorAfterInlineNode(
+  editor:AnyEditor,
+  instanceId:string,
+):void {
   const { doc } = editor.prosemirrorState;
   let targetPos:number | null = null;
 

--- a/test/lib/components/integration/editor.cursorPosition.browser.test.tsx
+++ b/test/lib/components/integration/editor.cursorPosition.browser.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
+import {
+  insertInlineWorkPackageViaHash,
+  insertInlineWorkPackageViaSlashMenu,
+} from '../../../helpers/editorHelpers';
 
 async function setupEditorWithSurroundingText() {
   const editor = page.getByRole('textbox');


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-806

SO FAR THIS IS JUST A PROOF OF CONCEPT - the cursor placement needs to be refined, but overall it's having the expected effect to make backspace work again.

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
