### PR TITLE
[COMMS-866] Safari: Incorrect selection UI when clicking on inline wp link

### DIFF
--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -2,6 +2,12 @@ import type { BlockNoteEditor } from '@blocknote/core';
 import type { Node as PmNode } from 'prosemirror-model';
 import { NodeSelection, TextSelection } from 'prosemirror-state';
 
+const isSafari =
+  typeof navigator !== 'undefined' &&
+  /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+interface DomObserver { disconnectSelection:() => void; connectSelection:() => void; setCurSelection:() => void }
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyEditor = BlockNoteEditor<any, any, any>;
 
@@ -38,6 +44,24 @@ export function selectInlineNode(editor:AnyEditor, instanceId:string):void {
   if (!range) return;
   editor.transact((tr) => {
     tr.setSelection(NodeSelection.create(tr.doc, range.from));
+  });
+  if (!isSafari) return;
+  // Safari renders a phantom selection on contenteditable=false atoms when PM syncs
+  // NodeSelection to the DOM. Collapse the native selection to hide it while keeping
+  // PM's NodeSelection intact (so Cmd+C and Delete still work).
+  // Uses PM's own disconnect→collapseToEnd→setCurSelection→connect bracket to prevent
+  // the selectionchange from being re-read as a state change. collapseToEnd not
+  // removeAllRanges — removeAllRanges blurs the editor and breaks Cmd+C in Safari.
+  // domObserver is a PM internal — missing it degrades to the visual glitch, not a crash.
+  requestAnimationFrame(() => {
+    const domObserver = (editor.prosemirrorView as unknown as { domObserver?:DomObserver }).domObserver;
+    if (!domObserver) return;
+    const nativeSel = window.getSelection();
+    if (!nativeSel || nativeSel.rangeCount === 0) return;
+    domObserver.disconnectSelection();
+    nativeSel.collapseToEnd();
+    domObserver.setCurSelection();
+    domObserver.connectSelection();
   });
 }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-866

# What are you trying to accomplish?
Fix a Safari-specific visual bug where clicking an inline work package chip incorrectly highlights surrounding text in addition to the chip itself. The phantom selection was purely visual - Cmd+C correctly copied only the chip - but it looked broken and confused users.

## Screenshots
<img width="765" height="465" alt="image" src="https://github.com/user-attachments/assets/60fc415e-867d-4f57-92a8-b99945d3ebba" />

# What approach did you choose and why?
Root cause: PR #164 added a call to selectInlineNode() in the chip's onClick handler to fix copy (BNE-83) and keyboard deletion (BNE-94). The chip calls e.stopPropagation(), which prevents ProseMirror from seeing the click and updating its own selection - so selectInlineNode sets it programmatically instead. ProseMirror then syncs every selection to the native browser DOM via selectionToDOM -> setBaseAndExtent(). Safari renders any native selection that spans a contenteditable=false element as an OS-level "selected object" box - a visual that ignores CSS ::selection and user-select: none. Chrome and Firefox do not render this visual.

Why we can't simply remove the selection: NodeSelection is required for Cmd+C and Delete/Backspace to work - both operations read ProseMirror's internal selection state, not the native browser selection.

Fix: After setting the NodeSelection, we collapse the native browser selection to a cursor placed after the chip. The phantom disappears because there is no longer a native selection range spanning the contenteditable=false element. ProseMirror's internal NodeSelection is preserved throughout, so Cmd+C and Delete/Backspace continue to work.

To prevent ProseMirror from re-reading the collapsed cursor as a state change, we use PM's own disconnectSelection -> collapseToEnd -> setCurSelection -> connectSelection bracket - the same pattern PM uses internally in selectionToDOM for the same reason. collapseToEnd() is used instead of removeAllRanges() because removeAllRanges blurs the contenteditable in Safari, which stops the browser from delivering the copy event on Cmd+C.

The fix is gated behind an isSafari check to leave Chrome and Firefox behavior unchanged. domObserver is a ProseMirror-view internal - the if (!domObserver) return guard ensures a future rename degrades silently to the visual glitch rather than crashing.

# Alternatives considered:

- CSS ::selection { background: transparent } / user-select: none - Safari's "selected object" rendering on contenteditable=false elements is OS-level and ignores CSS entirely. No effect.
- TextSelection instead of NodeSelection - Avoids the phantom but breaks Delete/Backspace (PM no longer knows to delete the chip) and the selection visual on the chip itself was still incorrect in Safari.
- removeAllRanges() instead of collapseToEnd() - Removed the phantom but blurred the contenteditable in Safari, which caused the browser to stop delivering the copy event on Cmd+C. Copying a chip stopped working entirely.
- handleDOMEvents: { selectionchange } ProseMirror plugin - Would require registering a plugin at the engine level across multiple files, still needs setCurSelection internally, and is more complex with no functional advantage over the current approach.
- Keydown handler approach - Was already considered and rejected during the PR #164 review
- BlockNote / ProseMirror public API - Checked BlockNote docs (onSelectionChange, setSelection, onBeforeChange) and ProseMirror public API. No public hook exists to suppress or intercept the native selection sync layer where the phantom originates.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
