### PR TITLE
[BNE-113] Inline work package links which the user can not access should have a speaking message

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -9,6 +9,7 @@ import { convertBlockToInlineChip } from '../../utils/inlineChipActions';
 import type { WorkPackage } from '../../openProjectTypes';
 import type { InlineWpSize, BlockWpSize } from '../WorkPackage/types';
 import type { BlockWorkPackageProps } from './types';
+import { EyeClosedIcon, AlertIcon } from '@primer/octicons-react';
 import { BlockCard } from './BlockCard';
 import { UnavailableCard } from '../WorkPackage/UnavailableCard';
 import { WpOptionsPopover } from '../WorkPackage/OptionsPopover';
@@ -156,12 +157,14 @@ export const BlockWorkPackageComponent = ({
             )}
             {!workPackageResult.loading && workPackageResult.error && (
               <UnavailableCard
+                icon={<AlertIcon size={16} />}
                 header={t('unavailableWorkPackage.error.header')}
                 message={t('unavailableWorkPackage.error.message')}
               />
             )}
             {!workPackageResult.loading && !workPackageResult.error && workPackageResult.unauthorized && (
               <UnavailableCard
+                icon={<EyeClosedIcon size={16} />}
                 header={t('unavailableWorkPackage.unauthorized.header')}
                 message={t('unavailableWorkPackage.unauthorized.message')}
               />

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { useWorkPackage } from '../../hooks/useWorkPackage';
 import { useColors } from '../../services/colors';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
-import { ChipBase } from './chipLayouts';
+import { ChipBase, ChipBaseXXS } from './chipLayouts';
 import { WorkPackageId } from '../WorkPackage/atoms';
 import { WpChipXXS, WpChipXS, WpChipS } from './InlineChips';
 import { WorkPackageSearchPopover } from '../Search/WorkPackageSearchPopover';
@@ -36,16 +36,8 @@ export interface InlineWorkPackageChipProps {
   }) => void;
 }
 
-const UnavailableIcon = styled.span`
-  display: inline-block;
-  vertical-align: middle;
-  line-height: 0;
-`;
-
 const UnavailableLabel = styled.span`
   color: var(--bn-colors-editor-text);
-  font-size: ${CHIP_STYLES.fontSize};
-  vertical-align: middle;
 `;
 
 const InlineChip = styled.span.attrs({
@@ -99,6 +91,13 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
   const setRef = (node:HTMLElement | null) => {
     chipRef.current = node;
     contentRef(node);
+  };
+
+  const selectWorkPackageNode = () => {
+    if (!editor || !chipRef.current) return;
+    const chip = findInlineChipAtDOM(editor, chipRef.current);
+    if (chip) selectInlineChipAt(editor, chip.position);
+    editor.getExtension('formattingToolbar')?.store?.setState(false);
   };
 
   // Close the options popover when the user clicks outside the chip
@@ -156,11 +155,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
           e.preventDefault();
           e.stopPropagation();
           setIsSelected((prev) => !prev);
-          if (editor && chipRef.current) {
-            const chip = findInlineChipAtDOM(editor, chipRef.current);
-            if (chip) selectInlineChipAt(editor, chip.position);
-            editor.getExtension('formattingToolbar')?.store?.setState(false);
-          }
+          selectWorkPackageNode();
         }}
       >
         {size === 'xxs' && <WpChipXXS wp={wp} />}
@@ -193,17 +188,34 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     );
   }
 
-  const unavailableWorkPackage = (icon:ReactNode, label:string) => (
-    <InlineChip ref={setRef} data-drag-handle selected={isEditorSelected}>
-      <ChipBase>
-        <UnavailableIcon>{icon}</UnavailableIcon>
-        <UnavailableLabel>{label}</UnavailableLabel>
-      </ChipBase>
-    </InlineChip>
-  );
+  const unavailableWorkPackage = (icon:ReactNode, label:string) => {
+    // xxs stays tiny: icon only, with the label as a tooltip instead
+    const iconOnly = size === 'xxs';
+    const Base = iconOnly ? ChipBaseXXS : ChipBase;
+    return (
+      <InlineChip
+        ref={setRef}
+        data-drag-handle
+        selected={isEditorSelected}
+        // xxs shows no text, so expose the message to the tooltip and to assistive tech
+        title={iconOnly ? label : undefined}
+        aria-label={iconOnly ? label : undefined}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          selectWorkPackageNode();
+        }}
+      >
+        <Base>
+          {icon}
+          {!iconOnly && <UnavailableLabel>{label}</UnavailableLabel>}
+        </Base>
+      </InlineChip>
+    );
+  };
 
-  if (wpid && unauthorized) return unavailableWorkPackage(<EyeClosedIcon size={12} />, t('unavailableWorkPackage.unauthorized.chip'));
-  if (wpid && error) return unavailableWorkPackage(<AlertIcon size={12} />, t('unavailableWorkPackage.error.chip'));
+  if (wpid && unauthorized) return unavailableWorkPackage(<EyeClosedIcon size={12} verticalAlign="middle" />, t('unavailableWorkPackage.unauthorized.short_message'));
+  if (wpid && error) return unavailableWorkPackage(<AlertIcon size={12} verticalAlign="middle" />, t('unavailableWorkPackage.error.short_message'));
 
   // Unknown / transitional
   if (wpid) {

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import { useWorkPackage } from '../../hooks/useWorkPackage';
 import { useColors } from '../../services/colors';
@@ -16,6 +16,7 @@ import {
   removeInlineChipAt,
   promoteInlineChipToBlockAt,
 } from '../../utils/inlineChipActions';
+import { EyeClosedIcon, AlertIcon } from '@primer/octicons-react';
 import { BlockCard } from '../BlockWorkPackage/BlockCard';
 import { useTranslation } from 'react-i18next';
 import { defaultWpVariables } from '../WorkPackage/atoms';
@@ -34,6 +35,18 @@ export interface InlineWorkPackageChipProps {
     props:{ wpid:string; size:string; displayId:string };
   }) => void;
 }
+
+const UnavailableIcon = styled.span`
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 0;
+`;
+
+const UnavailableLabel = styled.span`
+  color: var(--bn-colors-editor-text);
+  font-size: ${CHIP_STYLES.fontSize};
+  vertical-align: middle;
+`;
 
 const InlineChip = styled.span.attrs({
   className: 'op-bn-inline-wp',
@@ -70,7 +83,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
 
   useColors();
 
-  const { workPackage: wp, loading } = useWorkPackage(wpid);
+  const { workPackage: wp, loading, unauthorized, error } = useWorkPackage(wpid);
 
   useEffect(() => {
     if (!wp || !updateInlineContent) return;
@@ -180,7 +193,19 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     );
   }
 
-  // Error / unknown
+  const unavailableWorkPackage = (icon:ReactNode, label:string) => (
+    <InlineChip ref={setRef} data-drag-handle selected={isEditorSelected}>
+      <ChipBase>
+        <UnavailableIcon>{icon}</UnavailableIcon>
+        <UnavailableLabel>{label}</UnavailableLabel>
+      </ChipBase>
+    </InlineChip>
+  );
+
+  if (wpid && unauthorized) return unavailableWorkPackage(<EyeClosedIcon size={12} />, t('unavailableWorkPackage.unauthorized.chip'));
+  if (wpid && error) return unavailableWorkPackage(<AlertIcon size={12} />, t('unavailableWorkPackage.error.chip'));
+
+  // Unknown / transitional
   if (wpid) {
     return (
       <InlineChip ref={setRef} data-drag-handle selected={isEditorSelected} style={{ opacity: 0.6 }}>

--- a/lib/components/WorkPackage/UnavailableCard.tsx
+++ b/lib/components/WorkPackage/UnavailableCard.tsx
@@ -1,9 +1,12 @@
+import type { ReactNode } from 'react';
 import styled from 'styled-components';
 import { defaultWpVariables } from './atoms';
+import { CHIP_STYLES } from './tokens';
 
 interface UnavailableCardProps {
   header:string;
   message:string;
+  icon?:ReactNode;
 }
 
 const UnavailableWorkPackage = styled.div.attrs({
@@ -26,12 +29,16 @@ const UnavailableMessageHeader = styled.div.attrs({
 })`
   font-weight: 600;
   color: var(--bn-colors-editor-text) !important;
+  display: flex;
+  align-items: center;
+  gap: ${CHIP_STYLES.gap};
 `;
 
-export const UnavailableCard = ({ header, message }:UnavailableCardProps) => (
+export const UnavailableCard = ({ header, message, icon }:UnavailableCardProps) => (
   <UnavailableWorkPackage>
     <UnavailableMessage>
       <UnavailableMessageHeader>
+        {icon}
         {header}
       </UnavailableMessageHeader>
       {message}

--- a/lib/hooks/useWorkPackage.ts
+++ b/lib/hooks/useWorkPackage.ts
@@ -29,6 +29,7 @@ export function useWorkPackage(wpid:number|undefined) {
     }
     setLoading(true);
     setError(null);
+    setUnauthorized(false);
     try {
       const data = await fetchWorkPackage(wpid);
       workPackageCache[wpid] = data;

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -23,12 +23,12 @@ export const en = {
       'unauthorized': {
         'header': 'Linked work package unavailable',
         'message': 'You do not have permission to see this',
-        'chip': 'Unavailable: No permission'
+        'short_message': 'Unavailable: No permission'
       },
       'error': {
         'header': 'Error',
         'message': 'Could not load work package',
-        'chip': 'Unavailable: error'
+        'short_message': 'Unavailable: error'
       }
     },
     'options': {

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -22,11 +22,13 @@ export const en = {
       },
       'unauthorized': {
         'header': 'Linked work package unavailable',
-        'message': 'You do not have permission to see this'
+        'message': 'You do not have permission to see this',
+        'chip': 'Unavailable: No permission'
       },
       'error': {
         'header': 'Error',
-        'message': 'Could not load work package'
+        'message': 'Could not load work package',
+        'chip': 'Unavailable: error'
       }
     },
     'options': {

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -58,6 +58,8 @@ export async function insertBlockWorkPackageViaSlashMenu(searchTerm = 'Fix', res
   await userEvent.type(searchInput, searchTerm);
   await expect.element(page.getByText(resultTerm)).toBeVisible();
   await userEvent.click(page.getByText(resultTerm));
+
+  await expect.element(searchInput).not.toBeInTheDocument();
 }
 
 // Block card - popover & size menu

--- a/test/helpers/editorHelpers.ts
+++ b/test/helpers/editorHelpers.ts
@@ -58,8 +58,6 @@ export async function insertBlockWorkPackageViaSlashMenu(searchTerm = 'Fix', res
   await userEvent.type(searchInput, searchTerm);
   await expect.element(page.getByText(resultTerm)).toBeVisible();
   await userEvent.click(page.getByText(resultTerm));
-
-  await expect.element(page.getByTestId('block-card')).toBeVisible();
 }
 
 // Block card - popover & size menu

--- a/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
+++ b/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup } from 'vitest-browser-react';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { http, HttpResponse } from 'msw';
 import { InlineWorkPackageChip } from '../../../../lib/components/InlineWorkPackage/InlineWorkPackageChip';
 import { worker } from '../../../mocks/browser';
@@ -11,6 +11,26 @@ afterEach(() => {
   cleanup();
   worker.resetHandlers();
 });
+
+// Insert an inline work package whose detail fetch fails (the search list is
+// mocked separately, so the search flow still succeeds).
+async function insertUnavailableInlineWorkPackage() {
+  const editorEl = page.getByRole('textbox');
+  await expect.element(editorEl).toBeVisible();
+  await userEvent.click(editorEl);
+  await userEvent.type(editorEl, ' /');
+
+  await expect.element(page.getByText('Link existing work package').first()).toBeVisible();
+  await userEvent.click(page.getByText('Link existing work package').first());
+
+  const searchInput = page.getByPlaceholder('Search by work package ID or subject');
+  await expect.element(searchInput).toBeVisible();
+  await userEvent.type(searchInput, 'Fix');
+  await expect.element(page.getByText('Fix login bug')).toBeVisible();
+  await userEvent.click(page.getByText('Fix login bug'));
+
+  await expect.element(searchInput).not.toBeInTheDocument();
+}
 
 describe('Inline chip - unavailable work package', () => {
   it('shows eye-closed icon and "Unavailable: No permission" on 404', async () => {
@@ -28,7 +48,9 @@ describe('Inline chip - unavailable work package', () => {
     );
 
     await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    expect(document.querySelector('.octicon-eye-closed')).not.toBeNull();
+    expect(
+      page.getByText('Unavailable: No permission').element().closest('.op-bn-inline-wp')?.querySelector('.octicon-eye-closed')
+    ).not.toBeNull();
   });
 
   it('shows alert icon and "Unavailable: error" on server error', async () => {
@@ -46,7 +68,59 @@ describe('Inline chip - unavailable work package', () => {
     );
 
     await expect.element(page.getByText('Unavailable: error')).toBeVisible();
-    expect(document.querySelector('.octicon-alert')).not.toBeNull();
+    expect(
+      page.getByText('Unavailable: error').element().closest('.op-bn-inline-wp')?.querySelector('.octicon-alert')
+    ).not.toBeNull();
+  });
+
+  it('renders only the icon with a tooltip for size xxs', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/999', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    render(
+      <InlineWorkPackageChip
+        inlineContent={{ props: { wpid: '999', size: 'xxs', instanceId: 'test-xxs' } }}
+        contentRef={vi.fn()}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('.op-bn-inline-wp .octicon-eye-closed')).not.toBeNull();
+    });
+    const chip = document.querySelector('.op-bn-inline-wp');
+    expect(chip?.textContent).toBe('');
+    expect(chip?.getAttribute('title')).toBe('Unavailable: No permission');
+  });
+
+  it('gets the selection outline on click and can be copied and pasted', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/123', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    renderEditor();
+    await insertUnavailableInlineWorkPackage();
+
+    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
+    await userEvent.click(page.getByText('Unavailable: No permission'));
+
+    await expect.poll(() => {
+      const base = document.querySelector('.op-bn-inline-wp .op-bn-inline-wp-base');
+      return base ? getComputedStyle(base).boxShadow : '';
+    }).toContain('inset');
+
+    await userEvent.keyboard('{Control>}c{/Control}');
+    await userEvent.keyboard('{Control>}{End}{/Control}');
+    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard('{Control>}v{/Control}');
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('.op-bn-inline-wp').length).toBe(2);
+    });
   });
 });
 

--- a/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
+++ b/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from 'vitest-browser-react';
+import { page } from 'vitest/browser';
+import { http, HttpResponse } from 'msw';
+import { InlineWorkPackageChip } from '../../../../lib/components/InlineWorkPackage/InlineWorkPackageChip';
+import { worker } from '../../../mocks/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import { insertBlockWorkPackageViaSlashMenu } from '../../../helpers/editorHelpers';
+
+afterEach(() => {
+  cleanup();
+  worker.resetHandlers();
+});
+
+describe('Inline chip - unavailable work package', () => {
+  it('shows eye-closed icon and "Unavailable: No permission" on 404', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/999', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    render(
+      <InlineWorkPackageChip
+        inlineContent={{ props: { wpid: '999', size: 's', instanceId: 'test-unauth' } }}
+        contentRef={vi.fn()}
+      />
+    );
+
+    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
+    expect(document.querySelector('.octicon-eye-closed')).not.toBeNull();
+  });
+
+  it('shows alert icon and "Unavailable: error" on server error', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/999', () =>
+        HttpResponse.json({ message: 'Internal Server Error' }, { status: 500 })
+      )
+    );
+
+    render(
+      <InlineWorkPackageChip
+        inlineContent={{ props: { wpid: '999', size: 's', instanceId: 'test-err' } }}
+        contentRef={vi.fn()}
+      />
+    );
+
+    await expect.element(page.getByText('Unavailable: error')).toBeVisible();
+    expect(document.querySelector('.octicon-alert')).not.toBeNull();
+  });
+});
+
+describe('Block card - unavailable work package', () => {
+  it('shows eye-closed icon and "Linked work package unavailable" on 404', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/123', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    renderEditor();
+    await insertBlockWorkPackageViaSlashMenu();
+
+    await expect.element(page.getByText('Linked work package unavailable')).toBeVisible();
+    await expect.element(page.getByText('You do not have permission to see this')).toBeVisible();
+    expect(document.querySelector('.op-bn-unavailable-message--header .octicon-eye-closed')).not.toBeNull();
+  });
+
+  it('shows alert icon and "Error" on server error', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/123', () =>
+        HttpResponse.json({ message: 'Internal Server Error' }, { status: 500 })
+      )
+    );
+
+    renderEditor();
+    await insertBlockWorkPackageViaSlashMenu();
+
+    await expect.element(page.getByText('Error', { exact: true })).toBeVisible();
+    await expect.element(page.getByText('Could not load work package')).toBeVisible();
+    expect(document.querySelector('.op-bn-unavailable-message--header .octicon-alert')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-113

# What are you trying to accomplish?
Inline work package links that the user cannot access currently show only the raw identifier (e.g. #123) with no indication of why nothing else is visible. This is confusing — the user has no way to tell whether the work package failed to load, or whether they simply lack permission to see it.

The goal is to make both states explicit:

- No permission (HTTP 404): show an eye-closed icon and "Unavailable: No permission"
- Other error (e.g. HTTP 500): show an alert icon and "Unavailable: error"
The same icons are also added to the existing block work package unavailable card, which already had the text but was missing the visual indicator.

## Screenshots
<img width="555" height="231" alt="image" src="https://github.com/user-attachments/assets/73d1304d-9dfe-46eb-8831-59323d676746" />
<img width="792" height="141" alt="image" src="https://github.com/user-attachments/assets/43a0fe9b-22b7-4f66-be32-35fee868167a" />

# What approach did you choose and why?
The useWorkPackage hook already distinguishes between unauthorized (404) and error (other failures) - this logic was simply not surfaced in the inline chip component. The fix follows the same pattern already used in BlockWorkPackageComponent: destructure unauthorized and error from the hook and render the appropriate state.

To avoid duplicating the unauthorized/error chip markup, both states are rendered through a shared local unavailableWorkPackage helper that accepts an icon and a label - keeping the two one-liners easy to scan and extend. The UnavailableCard used by block cards received an optional icon prop so both surfaces share the same component without forking it.

Icons (EyeClosedIcon, AlertIcon) are from @primer/octicons-react, which is already a dependency of the project. Icon-text spacing in UnavailableCard uses CHIP_STYLES.gap instead of a hardcoded value to stay consistent with the rest of the chip system.

Four browser integration tests cover the new behavior end-to-end: inline 404, inline 500, block 404, block 500 - each asserting both the visible text and the presence of the correct icon in the DOM.

A follow-up fix was also applied to useWorkPackage itself: the unauthorized flag was never reset at the start of a new fetch, which meant a later non-404 failure could leave both unauthorized and error truthy simultaneously. Adding setUnauthorized(false) before each fetch makes the two states mutually exclusive.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
