### PR TITLE
[BNE-117] Low contrast text in documents inline work package links that makes it hard to read

### DIFF
--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import {
   defaultColorStyles,
+  metaTextColor,
   typeTextColor,
 } from '../../services/colors';
 
@@ -18,18 +19,13 @@ export const defaultWpVariables = css`
 
   --op-chip-bg: var(--bn-colors-highlights-gray-background);
   --op-item-hover-bg: var(--bn-colors-highlights-gray-background, #f0f0f0);
-  --op-wp-meta-color: var(--bn-colors-highlights-gray-text);
+  --op-wp-meta-color: ${metaTextColor};
 
   [data-color-scheme="dark"] & {
     --lightness-threshold: 0.6;
     --background-alpha: 0.10;
     --op-chip-bg: var(--bn-colors-disabled-text);
     --op-item-hover-bg: rgba(255, 255, 255, 0.12);
-    --op-wp-meta-color: var(--bn-colors-highlights-gray-text);
-  }
-
-  [data-color-scheme="dark"][data-high-contrast] & {
-    --op-wp-meta-color: var(--bn-colors-editor-text);
   }
 `;
 

--- a/lib/services/colors.ts
+++ b/lib/services/colors.ts
@@ -149,6 +149,12 @@ export function typeTextColor() {
     : 'hsla(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - (var(--color-l) * 0.22)) * 1%), 1)';
 }
 
+export function metaTextColor() {
+  return wantsHighContrast()
+    ? 'var(--bn-colors-editor-text)'
+    : 'color-mix(in srgb, var(--bn-colors-editor-text) 60%, var(--bn-colors-highlights-gray-text))';
+}
+
 function hexToHSL(hexColor:string):{ h:number; s:number; l:number } {
   const color = cleanColorString(hexColor);
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-117

# What are you trying to accomplish?
Fixes low-contrast text in inline work package chips (e.g. `###KSTP-1`). The chip's ID text used a static gray token (`--bn-colors-highlights-gray-text`) regardless of contrast settings, which is grey-on-grey and hard to read - even under OpenProject's "Light High Contrast" color mode.

The existing dark-mode high-contrast override (`[data-color-scheme="dark"][data-high-contrast] &`) never actually applied: nothing in the app sets a `data-high-contrast` attribute. OpenProject exposes contrast state via `data-light-theme="light_high_contrast"` / `data-dark-theme="dark_high_contrast"` on `<body>` instead, so this selector never matched. As a result, light-mode high contrast was completely unhandled, and even the intended dark-mode fix was dead code.

## Screenshots
<img width="1214" height="706" alt="image" src="https://github.com/user-attachments/assets/33a85a22-a4e1-4576-bfff-42bf6da7f15b" />

# What approach did you choose and why?
Added `metaTextColor()` in `lib/services/colors.ts`, following the exact same pattern already used by `typeTextColor()` / `statusTextColor()` in the same file — a pure function driven by the existing `wantsHighContrast()` detector, which already correctly reads both the OS `prefers-contrast: more` media query and OpenProject's per-mode contrast attributes on `<body>`.

Wired it into `--op-wp-meta-color` inside `defaultWpVariables` (`atoms.tsx`), replacing the static gray token and removing the dead `[data-color-scheme="dark"][data-high-contrast]` selector block.

This keeps the change minimal and DRY — no new detection mechanism, no new CSS/data attributes, just reuse of the module's existing, already-relied-upon contrast pattern. Since `--op-wp-meta-color` is consumed through the shared `defaultWpVariables` mixin, this also improves contrast for `MetaItem` in `BlockCards.tsx` (parent/project links on block-style work package cards) at no extra cost.

**Alternatives considered:**
- A pure `@media (prefers-contrast: more)` CSS rule would react live to OS-level changes (unlike the memoized `wantsHighContrast()`), but wouldn't cover OpenProject's own manually-set Light/Dark High Contrast setting (exposed via `data-*-theme` body attributes, not a media query). Combining both was judged out of scope for a minimal fix.
- A graduated contrast boost (like `typeTextColor()` does for hue-based type badges) was considered, but the meta/ID color is a flat gray token, not hue-based — a direct swap to the existing full-contrast `--bn-colors-editor-text` (already used elsewhere, e.g. `WorkPackageTitle`) was simpler and confirmed to read clearly.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
