### PR TITLE
[BNE-118] Wrong placement of context menu if inline work package link spans multiple lines

### DIFF
--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type CSSProperties } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { WorkPackage } from '../../openProjectTypes';
@@ -142,6 +142,17 @@ const SizeBtnDesc = styled.span`
   opacity: 0.6;
 `;
 
+// For a chip wrapped across lines, getBoundingClientRect() returns the union
+// of its line fragments (left edge = start of line). The first fragment is
+// where the link actually starts, so anchor to it.
+const getAnchorRect = (el:HTMLElement):DOMRect =>
+  el.getClientRects()[0] ?? el.getBoundingClientRect();
+
+const VIEWPORT_MARGIN = 8;
+
+const clampLeft = (left:number, width:number):number =>
+  Math.max(VIEWPORT_MARGIN, Math.min(left, window.innerWidth - width - VIEWPORT_MARGIN));
+
 const IcOpen = () => <LinkExternalIcon size={13} />;
 const IcDelete = () => <TrashIcon size={13} />;
 const IcChevron = () => <ChevronDownIcon size={10} />;
@@ -163,12 +174,19 @@ export const WpOptionsPopover = ({
   const [showSizes, setShowSizes] = useState(false);
 
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(
-    () => anchorEl?.getBoundingClientRect() ?? null
+    () => (anchorEl ? getAnchorRect(anchorEl) : null)
   );
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [popoverWidth, setPopoverWidth] = useState<number | null>(null);
+
+  // Measure before paint so the clamped position is applied without a flash.
+  useLayoutEffect(() => {
+    if (popoverRef.current) setPopoverWidth(popoverRef.current.offsetWidth);
+  }, []);
 
   useEffect(() => {
     if (!anchorEl) return;
-    const update = () => setAnchorRect(anchorEl.getBoundingClientRect());
+    const update = () => setAnchorRect(getAnchorRect(anchorEl));
     const handleScroll = () => onClose();
 
     update();
@@ -184,7 +202,8 @@ export const WpOptionsPopover = ({
     ? {
         position: 'fixed',
         bottom: window.innerHeight - anchorRect.top + 6,
-        left: anchorRect.left,
+        left: clampLeft(anchorRect.left, popoverWidth ?? 0),
+        visibility: popoverWidth === null ? 'hidden' : undefined,
       }
     : undefined;
 
@@ -200,7 +219,7 @@ export const WpOptionsPopover = ({
 
   const content = (
     // Prevent editor/parent handlers from stealing focus or closing the popover
-    <Popover style={fixedStyle} onMouseDown={(e) => e.stopPropagation()}>
+    <Popover ref={popoverRef} style={fixedStyle} onMouseDown={(e) => e.stopPropagation()}>
       <PopBtn
         title={t('options.openInNewTab')}
         aria-label={t('options.openAriaLabel', { id: formatWorkPackageId(wp.displayId) })}

--- a/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
+++ b/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
@@ -153,6 +153,58 @@ describe('Options popover portal', () => {
   });
 });
 
+describe('Options popover positioning', () => {
+  it('opens at the start of a chip that wraps across multiple lines', async () => {
+    render(
+      <div style={{ width: '140px', paddingTop: '200px' }}>
+        <span style={{ display: 'inline-block', width: '90px' }} />
+        <InlineWorkPackageChip
+          inlineContent={{ props: { wpid: '123', size: 's', instanceId: 'iid-wrap' } }}
+          contentRef={vi.fn()}
+        />
+      </div>,
+    );
+
+    await waitForResolvedChip();
+
+    const chip = document.querySelector('.op-bn-inline-wp')!;
+    const fragments = chip.getClientRects();
+    expect(fragments.length).toBeGreaterThan(1);
+    expect(fragments[0].left).toBeGreaterThan(chip.getBoundingClientRect().left);
+
+    await openPopover();
+
+    const popover = document.querySelector('[data-testid="popover-content"]')!;
+    const popoverRect = popover.getBoundingClientRect();
+    expect(popoverRect.left).toBeCloseTo(fragments[0].left, 0);
+    expect(popoverRect.bottom).toBeLessThanOrEqual(fragments[0].top);
+  });
+
+  it('stays inside the viewport when the chip starts near the right edge', async () => {
+    render(
+      <div style={{ paddingTop: '200px' }}>
+        <span style={{ display: 'inline-block', width: 'calc(100vw - 80px)' }} />
+        <InlineWorkPackageChip
+          inlineContent={{ props: { wpid: '123', size: 's', instanceId: 'iid-clamp' } }}
+          contentRef={vi.fn()}
+        />
+      </div>,
+    );
+
+    await waitForResolvedChip();
+
+    const chip = document.querySelector('.op-bn-inline-wp')!;
+    expect(chip.getClientRects()[0].left).toBeGreaterThan(window.innerWidth - 120);
+
+    await openPopover();
+
+    const popover = document.querySelector('[data-testid="popover-content"]')!;
+    const popoverRect = popover.getBoundingClientRect();
+    expect(popoverRect.right).toBeLessThanOrEqual(window.innerWidth);
+    expect(popoverRect.left).toBeGreaterThanOrEqual(0);
+  });
+});
+
 describe('Inline chip popover UX', () => {
   it('popover is not visible before clicking the chip', async () => {
     render(<ChipWrapper initialSize="s" />);


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-118

# What are you trying to accomplish?
When an inline work package link has a subject long enough to wrap across multiple lines, clicking it opened the options context menu at an "unrelated" position (the start of the line) instead of over the link.

Root cause: the popover anchored to anchorEl.getBoundingClientRect(). For an inline element wrapped across lines, that returns the union of all its line fragments, whose left edge is the start of the line - not where the link actually begins.

## Screenshots
<img width="1076" height="239" alt="image" src="https://github.com/user-attachments/assets/c6f9ba09-acd6-40ae-8d9a-672c03ae3a43" />

# What approach did you choose and why?
1. Anchor to the first line fragment. Introduced a small `getAnchorRect` helper that uses `el.getClientRects()[0]` (the first fragment = where the link starts) and falls back to `getBoundingClientRect()`:
```jsx
const getAnchorRect = (el:HTMLElement):DOMRect =>
  el.getClientRects()[0] ?? el.getBoundingClientRect();
```
Since it lives in the shared WpOptionsPopover, both inline chips and block cards benefit with no duplication. For single-rect elements (block cards, non-wrapped chips) `getClientRects()[0]` equals the bounding rect, so their behavior is unchanged.

2. Keep the popover inside the viewport. Anchoring to the real link start means a wrapped chip's start sits near the end of a line - i.e. close to the right edge - so the menu could overflow off-screen and its buttons become unclickable. Added horizontal clamping with an 8px margin (clampLeft), measuring the popover width once via useLayoutEffect (before paint, no flash).

Chose a minimal, self-contained fix over pulling in @floating-ui - the latter is only a transitive dependency of BlockNote/Mantine, so relying on it directly would be a larger, riskier change for this scope.

**Tests**: added two regression tests in wpOptionsPopover.browser.test.tsx - one asserting the menu opens at the wrapped chip's first fragment, one asserting it stays within the viewport when the chip starts near the right edge. Verified the first fails against the old code.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
