### PR TITLE
[COMMS-806] Allow to delete characters after adding work package link

### DIFF
--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -2,8 +2,6 @@ import type { BlockNoteEditor } from '@blocknote/core';
 import type { InlineWpSize } from '../WorkPackage/types';
 import { makeInstanceId } from '../../utils/id.ts';
 import type { WorkPackage } from '../../openProjectTypes';
-import { placeCursorAfterInlineNode } from '../../utils/cursor.ts';
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyEditor = BlockNoteEditor<any, any, any>;
 
@@ -45,55 +43,59 @@ export function getSizeFromCurrentBlock(editor:AnyEditor):InlineWpSize {
 }
 
 /**
- * Inserts a chip at the cursor, removes the `#query` trigger before it,
- * then repositions the cursor right after the chip via its instanceId.
+ * Inserts a chip at the cursor and removes the `#query` trigger before it.
+ *
+ * The chip is inserted on its own (no trailing space): `insertInlineContent`
+ * leaves the cursor directly after the chip, which is exactly where we want it.
+ * We deliberately avoid placing the cursor with a separate selection
+ * transaction — under real-time collaboration (Yjs/Hocuspocus) any selection
+ * change dispatched after the menu insertion leaves the editor in a state where
+ * the following native keyboard input (e.g. Backspace) is silently dropped.
+ * Relying on the natural post-insertion cursor sidesteps that entirely.
  */
 export function insertWpChip(editor:AnyEditor, wp:WorkPackage, size:InlineWpSize):void {
   const instanceId = makeInstanceId();
 
   (editor.insertInlineContent as (content:unknown[]) => void)([
     { type: 'openProjectWorkPackageInline', props: { wpid: String(wp.id), instanceId, size, displayId: wp.displayId } },
-    { type: 'text', text: ' ', styles: {} },
   ]);
 
   removeTriggerBeforeChip(editor, instanceId);
   editor.focus();
-
-  requestAnimationFrame(() => {
-    placeCursorAfterInlineNode(editor, instanceId);
-  });
 }
 
 /**
- * Trims the trailing `#query` from the text node right before the chip.
- * Returns the block ID if the operation completed (with or without changes), or null if no block.
+ * Trims the trailing `#query` trigger from the text node directly before the chip.
+ *
+ * Implemented with a ProseMirror delete transaction rather than `editor.updateBlock`.
+ * updateBlock rebuilds the whole block and moves the cursor to the block end, which
+ * would leave the caret in the wrong place after insertion. A delete maps the existing
+ * selection through unchanged, so the caret stays directly after the chip — and we
+ * never dispatch a separate selection transaction, which under real-time collaboration
+ * (Yjs/Hocuspocus) would cause the following keyboard input to be silently dropped.
  */
-export function removeTriggerBeforeChip(editor:AnyEditor, instanceId:string):string | null {
-  const block = editor.getTextCursorPosition()?.block;
-  if (!block) return null;
+export function removeTriggerBeforeChip(editor:AnyEditor, instanceId:string):void {
+  const { doc } = editor.prosemirrorState;
 
-  const content = (block.content ?? []) as RawNode[];
-  const chipIndex = content.findIndex(
-    (n) => n.type === 'openProjectWorkPackageInline' && n.props?.instanceId === instanceId
-  );
-  if (chipIndex <= 0) return block.id;
+  let chipStart = -1;
+  doc.descendants((node, position) => {
+    if (chipStart !== -1) return false;
+    if ((node.attrs as Record<string, unknown>)?.instanceId === instanceId) {
+      chipStart = position;
+      return false;
+    }
+    return true;
+  });
+  if (chipStart === -1) return;
 
-  const prev = content[chipIndex - 1];
-  if (prev.type !== 'text') return block.id;
+  const nodeBeforeChip = doc.resolve(chipStart).nodeBefore;
+  if (!nodeBeforeChip?.isText || nodeBeforeChip.text == null) return;
 
-  const match = /#+\S*$/.exec(prev.text ?? '');
-  if (!match) return block.id;
+  const match = /#+\S*$/.exec(nodeBeforeChip.text);
+  if (!match) return;
 
-  const before = (prev.text ?? '').slice(0, match.index);
-  const newContent = [...content];
-
-  if (before.length > 0) {
-    newContent[chipIndex - 1] = { ...prev, text: before };
-  } else {
-    newContent.splice(chipIndex - 1, 1);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-  editor.updateBlock(block.id, { content: newContent } as any);
-  return block.id;
+  const triggerStart = chipStart - (nodeBeforeChip.text.length - match.index);
+  editor.transact((tr) => {
+    tr.delete(triggerStart, chipStart);
+  });
 }

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -43,8 +43,8 @@ export function getSizeFromCurrentBlock(editor:AnyEditor):InlineWpSize {
 }
 
 /**
- * Inserts a chip followed by a trailing space at the cursor and removes the
- * `#query` trigger before it.
+ * Inserts a chip followed by a trailing space at the cursor, then removes any
+ * leftover trigger hashes immediately before it.
  *
  * The chip and its trailing space are inserted together; `insertInlineContent`
  * leaves the cursor directly after the space, which is exactly where we want it.
@@ -67,14 +67,8 @@ export function insertWpChip(editor:AnyEditor, wp:WorkPackage, size:InlineWpSize
 }
 
 /**
- * Trims the trailing `#query` trigger from the text node directly before the chip.
- *
- * Implemented with a ProseMirror delete transaction rather than `editor.updateBlock`.
- * updateBlock rebuilds the whole block and moves the cursor to the block end, which
- * would leave the caret in the wrong place after insertion. A delete maps the existing
- * selection through unchanged, so the caret stays directly after the chip — and we
- * never dispatch a separate selection transaction, which under real-time collaboration
- * (Yjs/Hocuspocus) would cause the following keyboard input to be silently dropped.
+ * Removes the leftover trigger hashes (`#`/`##`) that BlockNote's suggestion menu
+ * leaves directly before the chip for `##`/`###` triggers.
  */
 export function removeTriggerBeforeChip(editor:AnyEditor, instanceId:string):void {
   const { doc } = editor.prosemirrorState;
@@ -93,7 +87,7 @@ export function removeTriggerBeforeChip(editor:AnyEditor, instanceId:string):voi
   const nodeBeforeChip = doc.resolve(chipStart).nodeBefore;
   if (!nodeBeforeChip?.isText || nodeBeforeChip.text == null) return;
 
-  const match = /#+\S*$/.exec(nodeBeforeChip.text);
+  const match = /#+$/.exec(nodeBeforeChip.text);
   if (!match) return;
 
   const triggerStart = chipStart - (nodeBeforeChip.text.length - match.index);

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -43,10 +43,11 @@ export function getSizeFromCurrentBlock(editor:AnyEditor):InlineWpSize {
 }
 
 /**
- * Inserts a chip at the cursor and removes the `#query` trigger before it.
+ * Inserts a chip followed by a trailing space at the cursor and removes the
+ * `#query` trigger before it.
  *
- * The chip is inserted on its own (no trailing space): `insertInlineContent`
- * leaves the cursor directly after the chip, which is exactly where we want it.
+ * The chip and its trailing space are inserted together; `insertInlineContent`
+ * leaves the cursor directly after the space, which is exactly where we want it.
  * We deliberately avoid placing the cursor with a separate selection
  * transaction — under real-time collaboration (Yjs/Hocuspocus) any selection
  * change dispatched after the menu insertion leaves the editor in a state where
@@ -58,6 +59,7 @@ export function insertWpChip(editor:AnyEditor, wp:WorkPackage, size:InlineWpSize
 
   (editor.insertInlineContent as (content:unknown[]) => void)([
     { type: 'openProjectWorkPackageInline', props: { wpid: String(wp.id), instanceId, size, displayId: wp.displayId } },
+    { type: 'text', text: ' ', styles: {} },
   ]);
 
   removeTriggerBeforeChip(editor, instanceId);

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -1,17 +1,16 @@
 import type { BlockNoteEditor, InlineContentFromConfig } from '@blocknote/core';
+import type { Node as ProsemirrorNode } from 'prosemirror-model';
 import { LinkIcon } from '@primer/octicons-react';
 import i18n from '../services/i18n.ts';
 import { getAliases } from '../services/slashMenuAliases';
 import { registerInlineWpCallbacks, clearInlineWpCallbacks, makePendingWpid } from './InlineWorkPackage/callbacks';
 import { makeInstanceId } from '../utils/id.ts';
-import { placeCursorAfterInlineNode } from '../utils/cursor.ts';
 import { pendingBlockRegistry } from './BlockWorkPackage/pendingBlockRegistry';
 import { isCurrentBlockEmpty } from '../utils/blockContent.ts';
 import type { AnyEditor } from './HashMenu/editorUtils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyInlineNode = InlineContentFromConfig<any, any>;
-interface TextNode { type:'text'; text:string; styles:Record<string, unknown> }
 
 function getBlockContent(
   editor:AnyEditor,
@@ -24,39 +23,39 @@ function getBlockContent(
 
 function buildOnSelect(
   editor:AnyEditor,
-  blockId:string,
-  pendingWpid:string,
   instanceId:string
 ):(wpid:number, displayId:string) => void {
   return (wpid:number, displayId:string) => {
-    const current = getBlockContent(editor, blockId);
-    if (!current) return;
-
-    const chipIndex = current.content.findIndex((node) => {
-      const n = node as { type:string; props?:{ wpid?:string } };
-      return n.type === 'openProjectWorkPackageInline' && n.props?.wpid === pendingWpid;
-    });
-
-    const updatedContent = current.content.map((node) => {
-      const n = node as { type:string; props?:{ wpid?:string; instanceId?:string } };
-      if (n.type === 'openProjectWorkPackageInline' && n.props?.wpid === pendingWpid) {
-        return { ...n, props: { ...n.props, wpid: String(wpid), instanceId, displayId } };
+    // Resolve the placeholder chip to its real work package by updating the node's
+    // props in place. We use a ProseMirror `setNodeMarkup` transaction rather than
+    // `editor.updateBlock` because updateBlock rebuilds the block and moves the
+    // cursor to the block end, whereas setNodeMarkup maps the existing selection
+    // through unchanged — leaving the cursor directly after the chip (where the
+    // placeholder insertion left it). Crucially we do NOT dispatch a separate
+    // selection transaction to reposition the cursor: under real-time
+    // collaboration (Yjs/Hocuspocus) a selection change issued after the menu
+    // insertion leaves the editor in a state where the next native keyboard input
+    // (e.g. Backspace) is silently dropped. Relying on the preserved selection
+    // avoids that entirely.
+    const view = editor.prosemirrorView;
+    let chipPosition:number | null = null;
+    let chipNode:ProsemirrorNode | null = null;
+    view.state.doc.descendants((node, position) => {
+      if (chipPosition !== null) return false;
+      if ((node.attrs as Record<string, unknown>)?.instanceId === instanceId) {
+        chipPosition = position;
+        chipNode = node;
+        return false;
       }
-      return node;
+      return true;
     });
+    if (chipPosition === null || chipNode === null) return;
 
-    const nodeAfter = updatedContent[chipIndex + 1] as TextNode | undefined;
-    const hasSpaceAfter = nodeAfter?.type === 'text' && nodeAfter?.text?.startsWith(' ');
-    if (!hasSpaceAfter) {
-      updatedContent.splice(chipIndex + 1, 0, { type: 'text', text: ' ', styles: {} } as AnyInlineNode);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-    editor.updateBlock(current.blockId, { content: updatedContent } as any);
-
-    requestAnimationFrame(() => {
-      editor.focus();
-      placeCursorAfterInlineNode(editor, instanceId);
+    const position:number = chipPosition;
+    const existingAttributes = (chipNode as ProsemirrorNode).attrs;
+    editor.focus();
+    editor.transact((tr) => {
+      tr.setNodeMarkup(position, undefined, { ...existingAttributes, wpid: String(wpid), displayId });
     });
   };
 }
@@ -105,7 +104,7 @@ function insertInlineWorkPackage(editor:AnyEditor):void {
   const blockId = editor.getTextCursorPosition()?.block?.id as string | undefined;
   if (!blockId) return;
 
-  const onSelect = buildOnSelect(editor, blockId, pendingWpid, instanceId);
+  const onSelect = buildOnSelect(editor, instanceId);
   const onCancel = buildOnCancel(editor, blockId, pendingWpid, instanceId);
 
   registerInlineWpCallbacks(instanceId, onSelect, onCancel);
@@ -113,7 +112,6 @@ function insertInlineWorkPackage(editor:AnyEditor):void {
   try {
     (editor.insertInlineContent as (content:unknown[]) => void)([
       { type: 'openProjectWorkPackageInline', props: { wpid: pendingWpid, instanceId, size: 's' } },
-      ' ',
     ]);
   } catch (error) {
     console.error('[inline-wp] insertInlineContent failed:', error);

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -30,8 +30,8 @@ function buildOnSelect(
     // props in place. We use a ProseMirror `setNodeMarkup` transaction rather than
     // `editor.updateBlock` because updateBlock rebuilds the block and moves the
     // cursor to the block end, whereas setNodeMarkup maps the existing selection
-    // through unchanged — leaving the cursor directly after the chip (where the
-    // placeholder insertion left it). Crucially we do NOT dispatch a separate
+    // through unchanged — leaving the cursor directly after the chip's trailing
+    // space (where the placeholder insertion left it). Crucially we do NOT dispatch a separate
     // selection transaction to reposition the cursor: under real-time
     // collaboration (Yjs/Hocuspocus) a selection change issued after the menu
     // insertion leaves the editor in a state where the next native keyboard input
@@ -112,6 +112,7 @@ function insertInlineWorkPackage(editor:AnyEditor):void {
   try {
     (editor.insertInlineContent as (content:unknown[]) => void)([
       { type: 'openProjectWorkPackageInline', props: { wpid: pendingWpid, instanceId, size: 's' } },
+      { type: 'text', text: ' ', styles: {} },
     ]);
   } catch (error) {
     console.error('[inline-wp] insertInlineContent failed:', error);

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -1,6 +1,6 @@
 import type { BlockNoteEditor } from '@blocknote/core';
 import type { Node as PmNode } from 'prosemirror-model';
-import { NodeSelection, TextSelection } from 'prosemirror-state';
+import { NodeSelection } from 'prosemirror-state';
 
 const isSafari =
   typeof navigator !== 'undefined' &&
@@ -65,10 +65,3 @@ export function selectInlineNode(editor:AnyEditor, instanceId:string):void {
   });
 }
 
-export function placeCursorAfterInlineNode(editor:AnyEditor, instanceId:string):void {
-  const range = findInlineNodeRange(editor.prosemirrorState.doc, instanceId);
-  if (!range) return;
-  editor.transact((tr) => {
-    tr.setSelection(TextSelection.create(tr.doc, range.to));
-  });
-}

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -177,7 +177,10 @@ describe('insertWpChip', () => {
     expect(chip.props.instanceId).toEqual(expect.any(String));
   });
 
-  it('inserts a trailing space after the chip', () => {
+  it('does not insert a trailing space after the chip', () => {
+    // The chip is inserted on its own so the caret lands directly after it.
+    // A trailing space would force the caret after the space (or require a
+    // separate selection transaction, which breaks Backspace under collaboration).
     const editor = createTestEditor('test ');
 
     insertWpChip(
@@ -192,9 +195,7 @@ describe('insertWpChip', () => {
     const chipIdx = content.findIndex(
       (n) => n.type === 'openProjectWorkPackageInline',
     );
-    const afterChip = content[chipIdx + 1];
 
-    expect(afterChip?.type).toBe('text');
-    expect(afterChip?.text).toBe(' ');
+    expect(content[chipIdx + 1]).toBeUndefined();
   });
 });

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -177,10 +177,7 @@ describe('insertWpChip', () => {
     expect(chip.props.instanceId).toEqual(expect.any(String));
   });
 
-  it('does not insert a trailing space after the chip', () => {
-    // The chip is inserted on its own so the caret lands directly after it.
-    // A trailing space would force the caret after the space (or require a
-    // separate selection transaction, which breaks Backspace under collaboration).
+  it('inserts a trailing space after the chip', () => {
     const editor = createTestEditor('test ');
 
     insertWpChip(
@@ -195,7 +192,9 @@ describe('insertWpChip', () => {
     const chipIdx = content.findIndex(
       (n) => n.type === 'openProjectWorkPackageInline',
     );
+    const afterChip = content[chipIdx + 1];
 
-    expect(content[chipIdx + 1]).toBeUndefined();
+    expect(afterChip?.type).toBe('text');
+    expect(afterChip?.text).toBe(' ');
   });
 });

--- a/test/lib/components/hashMenu.test.ts
+++ b/test/lib/components/hashMenu.test.ts
@@ -72,7 +72,10 @@ describe('getSizeFromCurrentBlock', () => {
 });
 
 describe('removeTriggerBeforeChip', () => {
-  it('removes the trailing # before the chip', () => {
+  // BlockNote's suggestion menu removes the active `#query`; this function only
+  // strips the leftover bare trigger hashes it leaves for `##`/`###`.
+
+  it('removes a single leftover # before the chip', () => {
     const editor = createEditorWithContent([
       { type: 'text', text: 'Hello #', styles: {} },
       {
@@ -87,7 +90,7 @@ describe('removeTriggerBeforeChip', () => {
     expect((block?.content as any)[0].text).toBe('Hello ');
   });
 
-  it('removes multiple trailing hashes (##, ###) before the chip', () => {
+  it('removes multiple leftover hashes (##, ###) before the chip', () => {
     const editor = createEditorWithContent([
       { type: 'text', text: 'Hello ###', styles: {} },
       {
@@ -102,7 +105,7 @@ describe('removeTriggerBeforeChip', () => {
     expect((block?.content as any)[0].text).toBe('Hello ');
   });
 
-  it('leaves earlier # in the line alone — removes only the trigger # nearest to the chip', () => {
+  it('leaves an earlier # in the line alone — removes only the trailing hashes', () => {
     const editor = createEditorWithContent([
       { type: 'text', text: 'Pre #one #two #', styles: {} },
       {
@@ -115,6 +118,24 @@ describe('removeTriggerBeforeChip', () => {
 
     const block = editor.getBlock(editor.document[0].id);
     expect((block?.content as any)[0].text).toBe('Pre #one #two ');
+  });
+
+  it('preserves a preceding #word — does not over-delete an existing hash like "#42"', () => {
+    // Regression: when the line already contains "#42" and a chip is inserted right
+    // after it (BlockNote has already removed the real "#query" trigger), the "#42"
+    // must survive — there are no leftover bare hashes to strip.
+    const editor = createEditorWithContent([
+      { type: 'text', text: 'See PR #42', styles: {} },
+      {
+        type: 'openProjectWorkPackageInline',
+        props: { wpid: '1', instanceId: 'test-iid', size: 'xxs' },
+      },
+    ]);
+
+    removeTriggerBeforeChip(editor as any, 'test-iid');
+
+    const block = editor.getBlock(editor.document[0].id);
+    expect((block?.content as any)[0].text).toBe('See PR #42');
   });
 
   it('removes the previous text node entirely when only # remains', () => {

--- a/test/lib/components/integration/inlineWorkPackageHashTrigger.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageHashTrigger.browser.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import { openEditorAndType } from '../../../helpers/editorHelpers';
+
+describe('Inline chip - # trigger with an existing hash in the line', () => {
+  it('preserves an earlier # in the line when inserting a chip via the # notation', async () => {
+    renderEditor();
+
+    // Pre-existing text that already contains a hash. Typing "#42" opens the hash
+    // menu; Escape dismisses it, leaving "#42" as plain text — as if it had been
+    // there from a saved document.
+    await openEditorAndType('See PR #42');
+    await userEvent.keyboard('{Escape}');
+
+    // Insert a work package via the # notation directly after the existing hash.
+    const editor = page.getByRole('textbox');
+    await userEvent.type(editor, '#Fix');
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await userEvent.click(page.getByText('Fix login bug'));
+
+    // The chip is inserted and the earlier "#42" must be preserved (only the
+    // "#Fix" trigger is removed — by BlockNote's suggestion menu).
+    await expect.element(page.getByText('#123')).toBeVisible();
+    await expect.element(editor).toHaveTextContent('See PR #42');
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-806

# What are you trying to accomplish?
Insert inline work packages and a slash afterwards without triggering a nasty ProseMirror / y / Hocuspocus bug that prevents deleting text typed after the insertion.

# What approach did you choose and why?
Do what needs to be done (removing the hashes the user wrote, inserting the inline work package link and then inserting the space) in a way that does not need manual cursor positioning (which triggered the bug in the first place).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
