### PR TITLE
[BNE-111] Preview for tiny work package links in documents

### DIFF
--- a/lib/components/BlockWorkPackage/BlockCard.tsx
+++ b/lib/components/BlockWorkPackage/BlockCard.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, memo } from 'react';
 import type { WorkPackage } from '../../openProjectTypes';
 import type { BlockWpSize } from '../WorkPackage/types';
 import { BlockCardM, BlockCardL, BlockCardXL } from './BlockCards';
@@ -11,14 +11,18 @@ export interface BlockCardProps {
   onClick?:(e:React.MouseEvent<HTMLDivElement>) => void;
 }
 
-export const BlockCard = forwardRef<HTMLDivElement, BlockCardProps>(
-  ({ workPackage, size = 'm', inDropdown, linkTitle, onClick }, ref) => {
-    const shared = { workPackage, inDropdown, linkTitle, onClick, cardRef: ref };
+// Memoized: rendered inside popovers that re-render on hover/selection, while
+// the work package reference stays stable (cached by useWorkPackage).
+export const BlockCard = memo(
+  forwardRef<HTMLDivElement, BlockCardProps>(
+    ({ workPackage, size = 'm', inDropdown, linkTitle, onClick }, ref) => {
+      const shared = { workPackage, inDropdown, linkTitle, onClick, cardRef: ref };
 
-    if (size === 'xl') return <BlockCardXL {...shared} />;
-    if (size === 'l')  return <BlockCardL  {...shared} />;
-    return <BlockCardM {...shared} />;
-  }
+      if (size === 'xl') return <BlockCardXL {...shared} />;
+      if (size === 'l')  return <BlockCardL  {...shared} />;
+      return <BlockCardM {...shared} />;
+    }
+  )
 );
 
 BlockCard.displayName = 'BlockCard';

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useWorkPackage } from '../../hooks/useWorkPackage';
+import { useWorkPackagePreview } from '../../hooks/useWorkPackagePreview';
 import { useColors } from '../../services/colors';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
 import { ChipBase, ChipBaseXXS } from './chipLayouts';
@@ -8,6 +9,8 @@ import { WorkPackageId } from '../WorkPackage/atoms';
 import { WpChipXXS, WpChipXS, WpChipS } from './InlineChips';
 import { WorkPackageSearchPopover } from '../Search/WorkPackageSearchPopover';
 import { WpOptionsPopover } from '../WorkPackage/OptionsPopover';
+import { WpPreviewPopover } from '../WorkPackage/PreviewPopover';
+import { UnavailableCard } from '../WorkPackage/UnavailableCard';
 import { getPendingCallbacks, clearInlineWpCallbacks } from './callbacks';
 import type { InlineWpSize } from '../WorkPackage/types';
 import {
@@ -48,6 +51,7 @@ const InlineChip = styled.span.attrs({
   display: inline;
   cursor: pointer;
   user-select: none;
+  -webkit-touch-callout: none;
   border-radius: ${CHIP_STYLES.radius};
   position: relative;
   line-height: 1;
@@ -86,6 +90,11 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
   const [isSelected, setIsSelected] = useState(false);
   const chipRef = useRef<HTMLElement | null>(null);
 
+  const { previewOpen, closePreview, wasLongPress, triggerProps, cardProps } =
+    useWorkPackagePreview({ enabled: size === 'xxs', suppressed: isSelected });
+
+  const closeOptions = useCallback(() => setIsSelected(false), []);
+
   const isEditorSelected = useIsNodeInSelection(chipRef, editor);
 
   const setRef = (node:HTMLElement | null) => {
@@ -100,17 +109,18 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     editor.getExtension('formattingToolbar')?.store?.setState(false);
   };
 
-  // Close the options popover when the user clicks outside the chip
+  // Close the options popover and long-press preview when the user taps outside the chip
   useEffect(() => {
-    if (!isSelected) return;
+    if (!isSelected && !previewOpen) return;
     const onClickOutside = (e:MouseEvent) => {
       if (chipRef.current && !chipRef.current.contains(e.target as Node)) {
         setIsSelected(false);
+        closePreview();
       }
     };
     document.addEventListener('mousedown', onClickOutside);
     return () => document.removeEventListener('mousedown', onClickOutside);
-  }, [isSelected]);
+  }, [isSelected, previewOpen, closePreview]);
 
   // Pending: waiting for user to pick a WP via search
   if (pendingCallbacks) {
@@ -144,6 +154,9 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
 
   // Resolved
   if (wpid && wp) {
+    // Hidden while the options menu is open so the two popovers never stack.
+    const showPreview = size === 'xxs' && previewOpen && !isSelected;
+
     return (
       <InlineChip
         data-drag-handle
@@ -151,9 +164,14 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
         aria-label={t('options.chipAriaLabel', { id: formatWorkPackageId(wp.displayId) })}
         ref={setRef}
         selected={isSelected || isEditorSelected}
+        {...triggerProps}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
+
+          // A long press already opened the preview; swallow the trailing click.
+          if (wasLongPress()) return;
+          closePreview();
           setIsSelected((prev) => !prev);
           selectWorkPackageNode();
         }}
@@ -162,13 +180,24 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
         {size === 'xs' && <WpChipXS wp={wp} />}
         {size === 's' && <WpChipS wp={wp} />}
 
+        {showPreview && (
+          <WpPreviewPopover
+            // eslint-disable-next-line react-hooks/refs
+            anchorEl={chipRef.current}
+            onClose={closePreview}
+            {...cardProps}
+          >
+            <BlockCard workPackage={wp} size="m" linkTitle />
+          </WpPreviewPopover>
+        )}
+
         {isSelected && (
           <WpOptionsPopover
             wp={wp}
             currentSize={size}
             // eslint-disable-next-line react-hooks/refs
             anchorEl={chipRef.current}
-            onClose={() => setIsSelected(false)}
+            onClose={closeOptions}
             onResize={(newSize) => {
               updateInlineContent?.({ type: 'openProjectWorkPackageInline', props: { ...inlineContent.props, size: newSize } });
             }}
@@ -188,34 +217,65 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     );
   }
 
-  const unavailableWorkPackage = (icon:ReactNode, label:string) => {
-    // xxs stays tiny: icon only, with the label as a tooltip instead
+  const unavailableWorkPackage = (kind:'unauthorized' | 'error') => {
+    const inlineIcon = kind === 'unauthorized'
+      ? <EyeClosedIcon size={12} verticalAlign="middle" />
+      : <AlertIcon size={12} verticalAlign="middle" />;
+    const cardIcon = kind === 'unauthorized'
+      ? <EyeClosedIcon size={16} />
+      : <AlertIcon size={16} />;
+    const shortLabel = t(`unavailableWorkPackage.${kind}.short_message`);
+
+    // xxs stays tiny (icon only); the full message lives in the hover/long-press preview.
     const iconOnly = size === 'xxs';
     const Base = iconOnly ? ChipBaseXXS : ChipBase;
+    const showPreview = iconOnly && previewOpen;
+
     return (
       <InlineChip
         ref={setRef}
         data-drag-handle
+        // icon-only xxs is a labelled state graphic; larger sizes carry visible text
+        role={iconOnly ? 'img' : undefined}
         selected={isEditorSelected}
-        // xxs shows no text, so expose the message to the tooltip and to assistive tech
-        title={iconOnly ? label : undefined}
-        aria-label={iconOnly ? label : undefined}
+        aria-label={iconOnly ? shortLabel : undefined}
+        {...triggerProps}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
+
+          // A long press already opened the preview; swallow the trailing click.
+          if (wasLongPress()) return;
+          closePreview();
           selectWorkPackageNode();
         }}
       >
         <Base>
-          {icon}
-          {!iconOnly && <UnavailableLabel>{label}</UnavailableLabel>}
+          {inlineIcon}
+          {!iconOnly && <UnavailableLabel>{shortLabel}</UnavailableLabel>}
         </Base>
+
+        {showPreview && (
+          <WpPreviewPopover
+            anchorEl={chipRef.current}
+            onClose={closePreview}
+            {...cardProps}
+          >
+            <UnavailableCard
+              icon={cardIcon}
+              header={t(`unavailableWorkPackage.${kind}.header`)}
+              message={t(`unavailableWorkPackage.${kind}.message`)}
+            />
+          </WpPreviewPopover>
+        )}
       </InlineChip>
     );
   };
 
-  if (wpid && unauthorized) return unavailableWorkPackage(<EyeClosedIcon size={12} verticalAlign="middle" />, t('unavailableWorkPackage.unauthorized.short_message'));
-  if (wpid && error) return unavailableWorkPackage(<AlertIcon size={12} verticalAlign="middle" />, t('unavailableWorkPackage.error.short_message'));
+  // eslint-disable-next-line react-hooks/refs
+  if (wpid && unauthorized) return unavailableWorkPackage('unauthorized');
+  // eslint-disable-next-line react-hooks/refs
+  if (wpid && error) return unavailableWorkPackage('error');
 
   // Unknown / transitional
   if (wpid) {

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useLayoutEffect, useRef, type CSSProperties } from 'react';
-import { createPortal } from 'react-dom';
+import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { WorkPackage } from '../../openProjectTypes';
 import { linkToWorkPackage } from '../../services/openProjectApi';
 import type { InlineWpSize, BlockWpSize } from './types';
 import styled from 'styled-components';
 import { defaultWpVariables } from './atoms';
+import { useAnchoredPopover, PopoverPortal } from './anchoredPopover';
 import {
   LinkExternalIcon,
   TrashIcon,
@@ -141,17 +141,6 @@ const SizeBtnDesc = styled.span`
   opacity: 0.6;
 `;
 
-// For a chip wrapped across lines, getBoundingClientRect() returns the union
-// of its line fragments (left edge = start of line). The first fragment is
-// where the link actually starts, so anchor to it.
-const getAnchorRect = (el:HTMLElement):DOMRect =>
-  el.getClientRects()[0] ?? el.getBoundingClientRect();
-
-const VIEWPORT_MARGIN = 8;
-
-const clampLeft = (left:number, width:number):number =>
-  Math.max(VIEWPORT_MARGIN, Math.min(left, window.innerWidth - width - VIEWPORT_MARGIN));
-
 const IcOpen = () => <LinkExternalIcon size={13} />;
 const IcDelete = () => <TrashIcon size={13} />;
 const IcChevron = () => <ChevronDownIcon size={10} />;
@@ -171,39 +160,13 @@ export const WpOptionsPopover = ({
   const { t } = useTranslation();
   const [showSizes, setShowSizes] = useState(false);
 
-  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(
-    () => (anchorEl ? getAnchorRect(anchorEl) : null)
-  );
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const [popoverWidth, setPopoverWidth] = useState<number | null>(null);
-
-  // Measure before paint so the clamped position is applied without a flash.
-  useLayoutEffect(() => {
-    if (popoverRef.current) setPopoverWidth(popoverRef.current.offsetWidth);
-  }, []);
-
-  useEffect(() => {
-    if (!anchorEl) return;
-    const update = () => setAnchorRect(getAnchorRect(anchorEl));
-    const handleScroll = () => onClose();
-
-    update();
-    window.addEventListener('scroll', handleScroll, true);
-    window.addEventListener('resize', update);
-    return () => {
-      window.removeEventListener('scroll', handleScroll, true);
-      window.removeEventListener('resize', update);
-    };
-  }, [anchorEl, onClose]);
-
-  const fixedStyle:CSSProperties | undefined = anchorRect
-    ? {
-        position: 'fixed',
-        bottom: window.innerHeight - anchorRect.top + 6,
-        left: clampLeft(anchorRect.left, popoverWidth ?? 0),
-        visibility: popoverWidth === null ? 'hidden' : undefined,
-      }
-    : undefined;
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  useAnchoredPopover({
+    anchorEl,
+    popoverRef,
+    placement: 'above',
+    onClose,
+  });
 
   const isBlock = currentSize === undefined;
 
@@ -217,7 +180,7 @@ export const WpOptionsPopover = ({
 
   const content = (
     // Prevent editor/parent handlers from stealing focus or closing the popover
-    <Popover ref={popoverRef} style={fixedStyle} onMouseDown={(e) => e.stopPropagation()}>
+    <Popover ref={popoverRef} onMouseDown={(e) => e.stopPropagation()}>
       <PopBtn
         title={t('options.openInNewTab')}
         aria-label={t('options.openAriaLabel', { id: formatWorkPackageId(wp.displayId) })}
@@ -317,9 +280,5 @@ export const WpOptionsPopover = ({
     </Popover>
   );
 
-  if (anchorEl) {
-    const portalTarget = (anchorEl.closest('.bn-container')) ?? document.body;
-    return createPortal(content, portalTarget);
-  }
-  return content;
+  return <PopoverPortal anchorEl={anchorEl}>{content}</PopoverPortal>;
 };

--- a/lib/components/WorkPackage/PreviewPopover.tsx
+++ b/lib/components/WorkPackage/PreviewPopover.tsx
@@ -1,0 +1,62 @@
+import { useRef, type ReactNode } from 'react';
+import styled from 'styled-components';
+import { defaultWpVariables } from './atoms';
+import { useAnchoredPopover, PopoverPortal } from './anchoredPopover';
+
+const PreviewContainer = styled.div.attrs({
+  className: 'op-bn-wp-preview',
+  'data-testid': 'wp-preview',
+})`
+  ${defaultWpVariables}
+  position: absolute;
+  z-index: 9999;
+  top: calc(100% + 6px);
+  left: 0;
+  width: max-content;
+  max-width: min(420px, calc(100vw - 24px));
+  background-color: var(--bn-colors-menu-background, #fff);
+  box-shadow: var(--bn-shadow-medium);
+  border-radius: var(--bn-border-radius-large);
+  padding: var(--spacer-s);
+  cursor: default;
+`;
+
+export interface WpPreviewPopoverProps {
+  anchorEl?:HTMLElement | null;
+  onClose:() => void;
+  onMouseEnter?:() => void;
+  onMouseLeave?:() => void;
+  children:ReactNode;
+}
+
+// Hover/long-press preview for tiny (xxs) inline chips.
+export const WpPreviewPopover = ({
+  anchorEl,
+  onClose,
+  onMouseEnter,
+  onMouseLeave,
+  children,
+}:WpPreviewPopoverProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useAnchoredPopover({
+    anchorEl,
+    popoverRef: containerRef,
+    placement: 'below',
+    onClose,
+  });
+
+  return (
+    <PopoverPortal anchorEl={anchorEl}>
+      {/* Prevent editor/parent handlers from stealing focus while interacting with the preview */}
+      <PreviewContainer
+        ref={containerRef}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        {children}
+      </PreviewContainer>
+    </PopoverPortal>
+  );
+};

--- a/lib/components/WorkPackage/anchoredPopover.tsx
+++ b/lib/components/WorkPackage/anchoredPopover.tsx
@@ -1,0 +1,88 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+const DEFAULT_ANCHOR_OFFSET = 6;
+const VIEWPORT_MARGIN = 8;
+
+// For a chip wrapped across lines, getBoundingClientRect() returns the union of
+// its line fragments (left edge = start of line). The first fragment is where
+// the link actually starts, so anchor to it.
+const getAnchorRect = (el:HTMLElement):DOMRect =>
+  el.getClientRects()[0] ?? el.getBoundingClientRect();
+
+export interface AnchoredPopoverOptions {
+  anchorEl?:HTMLElement | null;
+  popoverRef:RefObject<HTMLElement | null>;
+  placement:'above' | 'below';
+  offset?:number;
+  onClose:() => void;
+}
+
+export const useAnchoredPopover = ({
+  anchorEl,
+  popoverRef,
+  placement,
+  offset = DEFAULT_ANCHOR_OFFSET,
+  onClose,
+}:AnchoredPopoverOptions) => {
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(
+    () => (anchorEl ? getAnchorRect(anchorEl) : null)
+  );
+
+  useEffect(() => {
+    if (!anchorEl) return;
+    const update = () => setAnchorRect(getAnchorRect(anchorEl));
+    const handleScroll = () => onClose();
+
+    update();
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [anchorEl, onClose]);
+
+  // Position before paint so the popover never flashes at its CSS fallback spot.
+  useLayoutEffect(() => {
+    const popover = popoverRef.current;
+    if (!anchorRect || !popover) return;
+
+    const { offsetWidth: width, offsetHeight: height } = popover;
+    const spaceAbove = anchorRect.top - offset - VIEWPORT_MARGIN;
+    const spaceBelow = window.innerHeight - anchorRect.bottom - offset - VIEWPORT_MARGIN;
+    const fitsPreferred = height <= (placement === 'above' ? spaceAbove : spaceBelow);
+    const resolved = fitsPreferred
+      ? placement
+      : (spaceAbove >= spaceBelow ? 'above' : 'below');
+
+    const left = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(anchorRect.left, window.innerWidth - width - VIEWPORT_MARGIN)
+    );
+
+    popover.style.position = 'fixed';
+    popover.style.left = `${left}px`;
+    if (resolved === 'above') {
+      popover.style.bottom = `${window.innerHeight - anchorRect.top + offset}px`;
+      popover.style.top = 'auto';
+    } else {
+      popover.style.top = `${anchorRect.bottom + offset}px`;
+      popover.style.bottom = 'auto';
+    }
+  }, [anchorRect, placement, offset, popoverRef]);
+};
+
+export const PopoverPortal = ({
+  anchorEl,
+  children,
+}:{ anchorEl?:HTMLElement | null; children:ReactNode }) => {
+  if (!anchorEl) return <>{children}</>;
+  return createPortal(children, anchorEl.closest('.bn-container') ?? document.body);
+};

--- a/lib/components/WorkPackage/index.ts
+++ b/lib/components/WorkPackage/index.ts
@@ -7,6 +7,8 @@ export {
   defaultWpVariables,
 } from './atoms';
 export { WpOptionsPopover } from './OptionsPopover';
+export { WpPreviewPopover } from './PreviewPopover';
 export { UnavailableCard } from './UnavailableCard';
 export type { WpOptionsProps } from './OptionsPopover';
+export type { WpPreviewPopoverProps } from './PreviewPopover';
 export type { InlineWpSize, BlockWpSize, WpSize } from './types';

--- a/lib/hooks/useWorkPackagePreview.ts
+++ b/lib/hooks/useWorkPackagePreview.ts
@@ -1,0 +1,149 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+
+const PREVIEW_OPEN_DELAY = 300;
+const PREVIEW_CLOSE_DELAY = 150;
+
+// Touch devices open the preview with a long press instead of a hover.
+const LONG_PRESS_DELAY = 500;
+const LONG_PRESS_MOVE_TOLERANCE = 10;
+
+interface UseWorkPackagePreviewOptions {
+  // Only tiny (xxs) chips show just the ID, so only they get a preview trigger.
+  enabled:boolean;
+  // Suppress opening while another popover (the options menu) owns the chip.
+  suppressed:boolean;
+}
+
+interface ChipTriggerProps {
+  onMouseEnter:() => void;
+  onMouseLeave:() => void;
+  onPointerDown:(e:ReactPointerEvent) => void;
+  onPointerUp:() => void;
+  onPointerMove:(e:ReactPointerEvent) => void;
+  onPointerCancel:() => void;
+  onContextMenu:((e:ReactMouseEvent) => void) | undefined;
+  // Claim the touch gesture so the browser doesn't start panning and fire
+  // pointercancel mid-press, which used to make the long press fire only sometimes.
+  style:{ touchAction:'none' };
+}
+
+interface WorkPackagePreview {
+  previewOpen:boolean;
+  closePreview:() => void;
+  // True at most once per press: the click that follows a long press, so the
+  // caller can swallow it instead of treating it as a tap.
+  wasLongPress:() => boolean;
+  triggerProps:ChipTriggerProps | undefined;
+  cardProps:{ onMouseEnter:() => void; onMouseLeave:() => void };
+}
+
+// Encapsulates the hover (desktop) / long-press (touch) preview trigger for an
+// inline work package chip: open/close timing, touch long-press detection, and
+// the props to wire onto the chip and the preview card.
+export function useWorkPackagePreview({ enabled, suppressed }:UseWorkPackagePreviewOptions):WorkPackagePreview {
+  const canHover = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(hover: hover)').matches,
+    []
+  );
+
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const openTimer = useRef<number | undefined>(undefined);
+  const closeTimer = useRef<number | undefined>(undefined);
+
+  const longPressTimer = useRef<number | undefined>(undefined);
+  const longPressFired = useRef(false);
+  const longPressStart = useRef<{ x:number; y:number } | null>(null);
+
+  const clearTimers = useCallback(() => {
+    window.clearTimeout(openTimer.current);
+    window.clearTimeout(closeTimer.current);
+  }, []);
+
+  useEffect(
+    () => () => {
+      clearTimers();
+      window.clearTimeout(longPressTimer.current);
+    },
+    [clearTimers]
+  );
+
+  // Stable identity: the popover's positioning effect subscribes scroll/resize
+  // listeners keyed on onClose, so it must not change every render.
+  const closePreview = useCallback(() => {
+    clearTimers();
+    setPreviewOpen(false);
+  }, [clearTimers]);
+
+  const handlePreviewEnter = () => {
+    if (!canHover || suppressed) return;
+    clearTimers();
+    openTimer.current = window.setTimeout(() => setPreviewOpen(true), PREVIEW_OPEN_DELAY);
+  };
+
+  // On touch the preview stays until an outside tap, so only hover closes on pointer-out.
+  const handlePreviewLeave = () => {
+    if (!canHover) return;
+    clearTimers();
+    closeTimer.current = window.setTimeout(() => setPreviewOpen(false), PREVIEW_CLOSE_DELAY);
+  };
+
+  const handleLongPressStart = (e:ReactPointerEvent) => {
+    if (canHover) return;
+    // Clear any in-flight timer so a second pointer (multi-touch) can't orphan it
+    // and fire a spurious open after both fingers have lifted.
+    window.clearTimeout(longPressTimer.current);
+    longPressStart.current = { x: e.clientX, y: e.clientY };
+    longPressFired.current = false;
+    longPressTimer.current = window.setTimeout(() => {
+      longPressFired.current = true;
+      setPreviewOpen(true);
+    }, LONG_PRESS_DELAY);
+  };
+
+  const cancelLongPress = () => window.clearTimeout(longPressTimer.current);
+
+  const handleLongPressMove = (e:ReactPointerEvent) => {
+    const start = longPressStart.current;
+    if (!start) return;
+    if (Math.hypot(e.clientX - start.x, e.clientY - start.y) > LONG_PRESS_MOVE_TOLERANCE)
+      cancelLongPress();
+  };
+
+  const wasLongPress = () => {
+    if (!longPressFired.current) return false;
+    longPressFired.current = false;
+    return true;
+  };
+
+  const triggerProps = enabled
+    ? {
+        onMouseEnter: handlePreviewEnter,
+        onMouseLeave: handlePreviewLeave,
+        onPointerDown: handleLongPressStart,
+        onPointerUp: cancelLongPress,
+        onPointerMove: handleLongPressMove,
+        onPointerCancel: cancelLongPress,
+        onContextMenu: canHover ? undefined : (e:ReactMouseEvent) => e.preventDefault(),
+        style: { touchAction: 'none' as const },
+      }
+    : undefined;
+
+  return {
+    previewOpen,
+    closePreview,
+    wasLongPress,
+    triggerProps,
+    cardProps: { onMouseEnter: clearTimers, onMouseLeave: handlePreviewLeave },
+  };
+}

--- a/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { useState } from 'react';
+import { renderEditor } from '../../../helpers/renderEditor';
+import {
+  insertInlineWorkPackageViaSlashMenu,
+  insertInlineWorkPackageViaHash,
+  openInlineWorkPackagePopover,
+} from '../../../helpers/editorHelpers';
+import { WpPreviewPopover } from '../../../../lib/components/WorkPackage/PreviewPopover';
+import { BlockCard } from '../../../../lib/components/BlockWorkPackage/BlockCard';
+import type { WorkPackage } from '../../../../lib/openProjectTypes';
+
+const previewWp:WorkPackage = {
+  id: 123,
+  displayId: '123',
+  subject: 'Fix login bug',
+  _links: {
+    self: { href: '/api/v3/work_packages/123' },
+    type: { title: 'Bug', href: '/api/v3/types/1' },
+    status: { title: 'In Progress', href: '/api/v3/statuses/1' },
+    assignee: null,
+  },
+};
+
+// Renders the preview against a fixed anchor so the flip behaviour can be
+// asserted for anchors near the viewport edges.
+function FlipHarness({ anchorTop }:{ anchorTop:number }) {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  return (
+    <div>
+      <span
+        ref={setAnchor}
+        data-testid="flip-anchor"
+        style={{ position: 'fixed', top: anchorTop, left: 40 }}
+      >
+        #123
+      </span>
+      {anchor && (
+        <WpPreviewPopover anchorEl={anchor} onClose={() => {}}>
+          <BlockCard workPackage={previewWp} size="m" linkTitle />
+        </WpPreviewPopover>
+      )}
+    </div>
+  );
+}
+
+describe('Inline chip - XXS hover preview', () => {
+  it('shows no preview before hovering', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+  });
+
+  it('hovering an XXS chip shows a card preview with type, status and subject', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await userEvent.hover(page.getByText('#123').first());
+
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+    await expect.element(page.getByTestId('op-bn-work-package--type')).toBeVisible();
+    await expect.element(page.getByText('In Progress')).toBeVisible();
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+  });
+
+  it('moving the pointer away hides the preview', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await userEvent.hover(page.getByText('#123').first());
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+
+    await userEvent.unhover(page.getByText('#123').first());
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+  });
+
+  it('clicking the chip opens the options popover and hides the hover preview', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await userEvent.hover(page.getByText('#123').first());
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+
+    await openInlineWorkPackagePopover();
+
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+  });
+
+  it('does not re-show the preview when hovering the chip while the options menu is open', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    await openInlineWorkPackagePopover();
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await userEvent.hover(page.getByText('#123').first());
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+  });
+
+  it('does not show a preview when hovering an S chip', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaSlashMenu();
+
+    await userEvent.hover(page.getByText('#123').first());
+
+    // Give the open delay a chance to elapse before asserting absence
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+  });
+});
+
+describe('Inline chip - XXS long-press preview (touch)', () => {
+  function forceTouch() {
+    const original = window.matchMedia;
+    window.matchMedia = ((query:string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+    return () => { window.matchMedia = original; };
+  }
+
+  it('opens the preview on a long press and not on a quick tap', async () => {
+    const restore = forceTouch();
+    try {
+      renderEditor();
+      await insertInlineWorkPackageViaHash('#');
+      // let the fetch settle so the chip's remount doesn't clear the long-press timer
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+
+      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+
+      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      await expect.element(page.getByTestId('wp-preview'), { timeout: 2000 }).toBeVisible();
+      await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+      // stays open after the finger lifts; only an outside tap closes it on touch
+      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+    }
+    finally {
+      restore();
+    }
+  });
+
+  it('closes the preview when the user taps outside', async () => {
+    const restore = forceTouch();
+    try {
+      renderEditor();
+      await insertInlineWorkPackageViaHash('#');
+      // let the fetch settle so the chip's remount doesn't clear the long-press timer
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+
+      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      await expect.element(page.getByTestId('wp-preview'), { timeout: 2000 }).toBeVisible();
+
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+    }
+    finally {
+      restore();
+    }
+  });
+
+  it('cancels the long press when the finger moves past the tolerance', async () => {
+    const restore = forceTouch();
+    try {
+      renderEditor();
+      await insertInlineWorkPackageViaHash('#');
+      // let the fetch settle so the chip's remount doesn't clear the long-press timer
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+
+      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 100, clientY: 100 }));
+      chip.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: 100, clientY: 140 }));
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+    }
+    finally {
+      restore();
+    }
+  });
+
+  it('does not open a spurious preview after a two-finger tap', async () => {
+    const restore = forceTouch();
+    try {
+      renderEditor();
+      await insertInlineWorkPackageViaHash('#');
+      // let the fetch settle so the chip's remount doesn't clear the long-press timer
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+
+      // both fingers lift before the delay: the first timer must not be orphaned
+      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
+      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 2 }));
+      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 2 }));
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+    }
+    finally {
+      restore();
+    }
+  });
+});
+
+describe('Preview popover - placement', () => {
+  it('opens below the anchor when there is space', async () => {
+    render(<FlipHarness anchorTop={50} />);
+
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+
+    const anchorRect = page.getByTestId('flip-anchor').element().getBoundingClientRect();
+    const previewRect = page.getByTestId('wp-preview').element().getBoundingClientRect();
+    expect(previewRect.top).toBeGreaterThanOrEqual(anchorRect.bottom);
+  });
+
+  it('flips above the anchor near the bottom of the viewport', async () => {
+    render(<FlipHarness anchorTop={window.innerHeight - 30} />);
+
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+
+    const anchorRect = page.getByTestId('flip-anchor').element().getBoundingClientRect();
+    const previewRect = page.getByTestId('wp-preview').element().getBoundingClientRect();
+    expect(previewRect.bottom).toBeLessThanOrEqual(anchorRect.top);
+    expect(previewRect.top).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
+++ b/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
@@ -73,7 +73,7 @@ describe('Inline chip - unavailable work package', () => {
     ).not.toBeNull();
   });
 
-  it('renders only the icon with a tooltip for size xxs', async () => {
+  it('renders only the icon with an aria-label and no native tooltip for size xxs', async () => {
     worker.use(
       http.get('http://localhost:3000/api/v3/work_packages/999', () =>
         HttpResponse.json({ message: 'Not found' }, { status: 404 })
@@ -92,7 +92,36 @@ describe('Inline chip - unavailable work package', () => {
     });
     const chip = document.querySelector('.op-bn-inline-wp');
     expect(chip?.textContent).toBe('');
-    expect(chip?.getAttribute('title')).toBe('Unavailable: No permission');
+    // The full message now lives in the hover/long-press preview, not a native tooltip.
+    expect(chip?.getAttribute('title')).toBeNull();
+    expect(chip?.getAttribute('aria-label')).toBe('Unavailable: No permission');
+  });
+
+  it('shows the unavailable card in the preview on hover for size xxs', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/999', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    render(
+      <InlineWorkPackageChip
+        inlineContent={{ props: { wpid: '999', size: 'xxs', instanceId: 'test-xxs-preview' } }}
+        contentRef={vi.fn()}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('.op-bn-inline-wp .octicon-eye-closed')).not.toBeNull();
+    });
+
+    await userEvent.hover(page.getByRole('img'));
+
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+    await expect.element(page.getByText('Linked work package unavailable')).toBeVisible();
+    await expect.element(page.getByText('You do not have permission to see this')).toBeVisible();
+    // The known-format card icon is reused from the block card.
+    expect(document.querySelector('.op-bn-unavailable-message--header .octicon-eye-closed')).not.toBeNull();
   });
 
   it('gets the selection outline on click and can be copied and pasted', async () => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/BNE-111

# What are you trying to accomplish?
Preview for tiny work package links in documents.

Tiny (`xxs`) inline work package links only render the identifier (e.g. `#81`),
so a reader can't tell what the linked work package is about without opening it.
This PR adds an on-demand preview so users get that context in place:

- **Desktop:** hovering a tiny chip shows a preview card after a short delay.
- **Touch:** the preview opens on a **long press** (per Judith's request to try
  long-tap on mobile). A normal tap still opens the options menu; long-press is
  the dedicated "peek" gesture.
- **Missing permission / load error:** tiny chips the reader can't access no
  longer show just an icon - the same preview shows the "unavailable" card in
  the known format, so the state reads consistently (Judith's suggestion to
  reuse the preview for this case).
- The preview is suppressed while the options menu is open (editing size /
  removing), so the two popovers never stack.

The preview intentionally looks like the existing work package link card
(type, identifier, status, subject) for resolved links, and the existing
unavailable card for links that can't be loaded.


## Screenshots
<img width="555" height="261" alt="image" src="https://github.com/user-attachments/assets/9791d6f1-1ab8-4a8d-96fa-7c487b2eb04d" />
<img width="555" height="261" alt="image" src="https://github.com/user-attachments/assets/0a52037d-fe4b-4182-9ad9-b7e10331eb43" />
<img width="555" height="261" alt="image" src="https://github.com/user-attachments/assets/f6fe09a7-0d20-45e3-9a2a-5d4b28a2dfb5" />
<img width="527" height="294" alt="image" src="https://github.com/user-attachments/assets/ed10497d-ea64-4988-80a7-aa97d5a76b1f" />

# What approach did you choose and why?
**Reuse over new UI.** The preview renders the existing `BlockCard` (`m` size)
for resolved links and the existing `UnavailableCard` for missing/errored links,
rather than any new card markup or styles. It matches the work package link card
(and the block-level unavailable card) by construction and stays in sync with
them automatically - as the ticket's technical note asked. `PreviewPopover` was
generalised to take `children` so both card types flow through the same popover.

**Shared anchored positioning.** The options popover already had bespoke
anchored-positioning logic (track anchor rect, reposition on resize, close on
scroll, portal into the editor container). Rather than copy it for the preview,
it's a shared `useAnchoredPopover` hook + `PopoverPortal` that both popovers
consume, giving a single implementation of:
- **viewport-aware flipping** - flips to the opposite side when the preferred
  side doesn't fit and clamps horizontally so it never hangs off-screen
  (positioned before paint via `useLayoutEffect`, so it never flashes at the
  wrong spot);
- **portaling into `.bn-container`** so it inherits BlockNote's theme variables.

**Preview trigger extracted into `useWorkPackagePreview`.** All of the
hover/long-press behaviour lives in one hook: open/close timing, touch
long-press detection, and the props to wire onto the chip and the card. This
keeps the chip component lean and makes the interaction testable in isolation.

**Touch reliability.** Long-press on a tiny inline target is easily hijacked by
the browser's own gestures, which used to make it fire only intermittently.
Fixes: `touch-action: none` + `-webkit-touch-callout: none` on the chip so the
browser doesn't claim the gesture, a move tolerance so a scroll/drag cancels the
press, and clearing any in-flight timer on a fresh press so a multi-touch tap
can't leave an orphaned timer that opens the preview unprompted. On touch the
preview stays open until the user taps outside it.

**Accessibility.** The icon-only tiny unavailable chip uses `role="img"` +
`aria-label` so the "no permission / error" state has an accessible name without
implying an interactive control.

**Hover UX tuned for real pointer movement.** Open/close delays plus a small
"bridge" so moving the pointer from the chip onto the preview card doesn't close
it; the preview is scoped to `xxs` only (larger sizes already show enough
inline). Touch vs. hover is detected once via `matchMedia('(hover: hover)')`.

**Targeted memoization** where it removes real work: a stable `closePreview`
callback so the shared positioning effect doesn't re-subscribe scroll/resize
listeners on every chip re-render, a memoized hover-capability value, and
`memo(BlockCard)` (safe because `useWorkPackage` returns a cached, stable
reference).

### Testing
Browser integration tests cover the real user behaviour:
- **Hover (desktop):** preview shows with the expected card content, hides on
  pointer-out, hides when the options menu opens, does not re-appear while the
  menu is open, and is absent for larger chip sizes.
- **Long press (touch):** opens on a long press and not on a quick tap, stays
  open after the finger lifts, closes on an outside tap, cancels when the finger
  moves past the tolerance, and does not open spuriously after a two-finger tap.
- **Unavailable:** the no-permission card shows in the preview on hover for a
  tiny chip.
- **Placement:** flip/clamp logic near the viewport edges.

# Merge checklist
- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
