### PR TITLE
[BNE-112] Work package link with missing permissions is not resizable

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -34,6 +34,11 @@ const BlockCardWrapper = styled.div`
   display: inline-block;
 `;
 
+const UnavailableCardWrapper = styled(BlockCardWrapper)`
+  display: block;
+  cursor: pointer;
+`;
+
 type SideMenuInstance = NonNullable<ReturnType<ReturnType<typeof SideMenuExtension>>>;
 
 interface BlockProps {
@@ -110,8 +115,8 @@ export const BlockWorkPackageComponent = ({
   }, [isOptionsOpen]);
 
   const handleConvertToInline = (size:InlineWpSize) => {
-    if (!selectedWorkPackage) return;
-    convertBlockToInlineChip(editor, block.id, selectedWorkPackage.id, size);
+    if (!block.props.wpid) return;
+    convertBlockToInlineChip(editor, block.id, block.props.wpid, size);
   };
 
   const handleResizeBlock = (size:BlockWpSize) => {
@@ -125,6 +130,21 @@ export const BlockWorkPackageComponent = ({
   };
 
   const isPending = pendingBlockRegistry.has(block.id);
+
+  const optionsPopover = (
+    <WpOptionsPopover
+      wp={selectedWorkPackage ?? undefined}
+      currentSize={undefined}
+      currentBlockSize={cardSize}
+      // eslint-disable-next-line react-hooks/refs
+      anchorEl={cardRef.current}
+      onClose={() => setIsOptionsOpen(false)}
+      onConvertToInline={handleConvertToInline}
+      onConvertToBlock={handleResizeBlock}
+      onResizeBlock={handleResizeBlock}
+      onRemove={handleRemove}
+    />
+  );
 
   return (
     <Block $pending={isPending} $selected={isBlockSelected} data-selected={isBlockSelected || undefined} draggable="true" onDragStart={handleBlockDragStart}>
@@ -155,19 +175,29 @@ export const BlockWorkPackageComponent = ({
                 message={t('unavailableWorkPackage.loading.message')}
               />
             )}
-            {!workPackageResult.loading && workPackageResult.error && (
-              <UnavailableCard
-                icon={<AlertIcon size={16} />}
-                header={t('unavailableWorkPackage.error.header')}
-                message={t('unavailableWorkPackage.error.message')}
-              />
-            )}
-            {!workPackageResult.loading && !workPackageResult.error && workPackageResult.unauthorized && (
-              <UnavailableCard
-                icon={<EyeClosedIcon size={16} />}
-                header={t('unavailableWorkPackage.unauthorized.header')}
-                message={t('unavailableWorkPackage.unauthorized.message')}
-              />
+            {!workPackageResult.loading && (workPackageResult.error ?? workPackageResult.unauthorized) && (
+              <UnavailableCardWrapper
+                ref={cardRef}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setIsOptionsOpen((prev) => !prev);
+                }}
+              >
+                {workPackageResult.error ? (
+                  <UnavailableCard
+                    icon={<AlertIcon size={16} />}
+                    header={t('unavailableWorkPackage.error.header')}
+                    message={t('unavailableWorkPackage.error.message')}
+                  />
+                ) : (
+                  <UnavailableCard
+                    icon={<EyeClosedIcon size={16} />}
+                    header={t('unavailableWorkPackage.unauthorized.header')}
+                    message={t('unavailableWorkPackage.unauthorized.message')}
+                  />
+                )}
+                {isOptionsOpen && optionsPopover}
+              </UnavailableCardWrapper>
             )}
             {!workPackageResult.loading &&
               !workPackageResult.error &&
@@ -184,20 +214,7 @@ export const BlockWorkPackageComponent = ({
                       setIsOptionsOpen((prev) => !prev);
                     }}
                   />
-                  {isOptionsOpen && (
-                    <WpOptionsPopover
-                      wp={selectedWorkPackage}
-                      currentSize={undefined}
-                      currentBlockSize={cardSize}
-                      // eslint-disable-next-line react-hooks/refs
-                      anchorEl={cardRef.current}
-                      onClose={() => setIsOptionsOpen(false)}
-                      onConvertToInline={handleConvertToInline}
-                      onConvertToBlock={handleResizeBlock}
-                      onResizeBlock={handleResizeBlock}
-                      onRemove={handleRemove}
-                    />
-                  )}
+                  {isOptionsOpen && optionsPopover}
                 </BlockCardWrapper>
               )}
           </>

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useWorkPackage } from '../../hooks/useWorkPackage';
 import { useWorkPackagePreview } from '../../hooks/useWorkPackagePreview';
@@ -93,8 +93,6 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
   const { previewOpen, closePreview, wasLongPress, triggerProps, cardProps } =
     useWorkPackagePreview({ enabled: size === 'xxs', suppressed: isSelected });
 
-  const closeOptions = useCallback(() => setIsSelected(false), []);
-
   const isEditorSelected = useIsNodeInSelection(chipRef, editor);
 
   const setRef = (node:HTMLElement | null) => {
@@ -109,6 +107,17 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     editor.getExtension('formattingToolbar')?.store?.setState(false);
   };
 
+  const handleWorkPackageClick = (e:React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // A long press already opened the preview; swallow the trailing click.
+    if (wasLongPress()) return;
+    closePreview();
+    setIsSelected((prev) => !prev);
+    selectWorkPackageNode();
+  };
+
   // Close the options popover and long-press preview when the user taps outside the chip
   useEffect(() => {
     if (!isSelected && !previewOpen) return;
@@ -121,6 +130,29 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     document.addEventListener('mousedown', onClickOutside);
     return () => document.removeEventListener('mousedown', onClickOutside);
   }, [isSelected, previewOpen, closePreview]);
+
+  const optionsPopover = (
+    <WpOptionsPopover
+      wp={wp ?? undefined}
+      currentSize={size}
+      // eslint-disable-next-line react-hooks/refs
+      anchorEl={chipRef.current}
+      onClose={() => setIsSelected(false)}
+      onResize={(newSize) => {
+        updateInlineContent?.({ type: 'openProjectWorkPackageInline', props: { ...inlineContent.props, size: newSize } });
+      }}
+      onConvertToBlock={(blockSize) => {
+        if (!editor || !chipRef.current) return;
+        const chip = findInlineChipAtDOM(editor, chipRef.current);
+        if (chip) promoteInlineChipToBlockAt(editor, chip.position, blockSize);
+      }}
+      onRemove={() => {
+        if (!editor || !chipRef.current) return;
+        const chip = findInlineChipAtDOM(editor, chipRef.current);
+        if (chip) removeInlineChipAt(editor, chip.position);
+      }}
+    />
+  );
 
   // Pending: waiting for user to pick a WP via search
   if (pendingCallbacks) {
@@ -165,16 +197,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
         ref={setRef}
         selected={isSelected || isEditorSelected}
         {...triggerProps}
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-
-          // A long press already opened the preview; swallow the trailing click.
-          if (wasLongPress()) return;
-          closePreview();
-          setIsSelected((prev) => !prev);
-          selectWorkPackageNode();
-        }}
+        onClick={handleWorkPackageClick}
       >
         {size === 'xxs' && <WpChipXXS wp={wp} />}
         {size === 'xs' && <WpChipXS wp={wp} />}
@@ -191,28 +214,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
           </WpPreviewPopover>
         )}
 
-        {isSelected && (
-          <WpOptionsPopover
-            wp={wp}
-            currentSize={size}
-            // eslint-disable-next-line react-hooks/refs
-            anchorEl={chipRef.current}
-            onClose={closeOptions}
-            onResize={(newSize) => {
-              updateInlineContent?.({ type: 'openProjectWorkPackageInline', props: { ...inlineContent.props, size: newSize } });
-            }}
-            onConvertToBlock={(blockSize) => {
-              if (!editor || !chipRef.current) return;
-              const chip = findInlineChipAtDOM(editor, chipRef.current);
-              if (chip) promoteInlineChipToBlockAt(editor, chip.position, blockSize);
-            }}
-            onRemove={() => {
-              if (!editor || !chipRef.current) return;
-              const chip = findInlineChipAtDOM(editor, chipRef.current);
-              if (chip) removeInlineChipAt(editor, chip.position);
-            }}
-          />
-        )}
+        {isSelected && optionsPopover}
       </InlineChip>
     );
   }
@@ -237,18 +239,10 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
         data-drag-handle
         // icon-only xxs is a labelled state graphic; larger sizes carry visible text
         role={iconOnly ? 'img' : undefined}
-        selected={isEditorSelected}
+        selected={isSelected || isEditorSelected}
         aria-label={iconOnly ? shortLabel : undefined}
         {...triggerProps}
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-
-          // A long press already opened the preview; swallow the trailing click.
-          if (wasLongPress()) return;
-          closePreview();
-          selectWorkPackageNode();
-        }}
+        onClick={handleWorkPackageClick}
       >
         <Base>
           {inlineIcon}
@@ -268,6 +262,8 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
             />
           </WpPreviewPopover>
         )}
+
+        {isSelected && optionsPopover}
       </InlineChip>
     );
   };

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -14,7 +14,7 @@ import {
 import {formatWorkPackageId} from '../../utils/id';
 
 export interface WpOptionsProps {
-  wp:WorkPackage;
+  wp?:WorkPackage;
   currentSize?:InlineWpSize;
   currentBlockSize?:BlockWpSize;
   anchorEl?:HTMLElement | null;
@@ -181,18 +181,22 @@ export const WpOptionsPopover = ({
   const content = (
     // Prevent editor/parent handlers from stealing focus or closing the popover
     <Popover ref={popoverRef} onMouseDown={(e) => e.stopPropagation()}>
-      <PopBtn
-        title={t('options.openInNewTab')}
-        aria-label={t('options.openAriaLabel', { id: formatWorkPackageId(wp.displayId) })}
-        onClick={(e) => {
-          e.stopPropagation();
-          window.open(linkToWorkPackage(wp.displayId), '_blank', 'noopener,noreferrer');
-        }}
-      >
-        <IcOpen /> {t('options.open')}
-      </PopBtn>
+      {wp && (
+        <>
+          <PopBtn
+            title={t('options.openInNewTab')}
+            aria-label={t('options.openAriaLabel', { id: formatWorkPackageId(wp.displayId) })}
+            onClick={(e) => {
+              e.stopPropagation();
+              window.open(linkToWorkPackage(wp.displayId), '_blank', 'noopener,noreferrer');
+            }}
+          >
+            <IcOpen /> {t('options.open')}
+          </PopBtn>
 
-      <Divider />
+          <Divider />
+        </>
+      )}
 
       <SizeButtonWrapper>
         <PopBtn

--- a/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
+++ b/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
 import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
 import { InlineWorkPackageChip } from '../../../../lib/components/InlineWorkPackage/InlineWorkPackageChip';
 import { worker } from '../../../mocks/browser';
 import { renderEditor } from '../../../helpers/renderEditor';
@@ -42,7 +43,7 @@ describe('Inline chip - unavailable work package', () => {
 
     render(
       <InlineWorkPackageChip
-        inlineContent={{ props: { wpid: '999', size: 's', instanceId: 'test-unauth' } }}
+        inlineContent={{ props: { wpid: '999', size: 's', displayId: '999' } }}
         contentRef={vi.fn()}
       />
     );
@@ -62,7 +63,7 @@ describe('Inline chip - unavailable work package', () => {
 
     render(
       <InlineWorkPackageChip
-        inlineContent={{ props: { wpid: '999', size: 's', instanceId: 'test-err' } }}
+        inlineContent={{ props: { wpid: '999', size: 's', displayId: '999' } }}
         contentRef={vi.fn()}
       />
     );
@@ -82,7 +83,7 @@ describe('Inline chip - unavailable work package', () => {
 
     render(
       <InlineWorkPackageChip
-        inlineContent={{ props: { wpid: '999', size: 'xxs', instanceId: 'test-xxs' } }}
+        inlineContent={{ props: { wpid: '999', size: 'xxs', displayId: '999' } }}
         contentRef={vi.fn()}
       />
     );
@@ -150,6 +151,88 @@ describe('Inline chip - unavailable work package', () => {
     await vi.waitFor(() => {
       expect(document.querySelectorAll('.op-bn-inline-wp').length).toBe(2);
     });
+  });
+});
+
+// Unauthorized chip whose size is held in state, so resizing re-renders
+function UnavailableChipWrapper({ initialSize }:{ initialSize:string }) {
+  const [size, setSize] = useState(initialSize);
+
+  return (
+    <div style={{ paddingTop: '200px', paddingLeft: '20px' }}>
+      <InlineWorkPackageChip
+        inlineContent={{ props: { wpid: '999', size, displayId: '999' } }}
+        contentRef={vi.fn()}
+        updateInlineContent={(update) => setSize(update.props.size)}
+      />
+    </div>
+  );
+}
+
+describe('Unavailable work package - options popover (BNE-112)', () => {
+  it('inline chip: opens the popover without the Open button and resizes', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/999', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    render(<UnavailableChipWrapper initialSize="s" />);
+
+    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
+    await userEvent.click(page.getByText('Unavailable: No permission'));
+
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+    await expect.element(page.getByTitle('Open in new tab')).not.toBeInTheDocument();
+
+    await userEvent.click(page.getByTitle('Change size'));
+    await expect.element(page.getByTestId('size-menu')).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Tiny', exact: true }));
+
+    // xxs renders icon-only with the message exposed to assistive tech via aria-label
+    await vi.waitFor(() => {
+      expect(document.querySelector('.op-bn-inline-wp')?.getAttribute('aria-label')).toBe('Unavailable: No permission');
+    });
+  });
+
+  it('inline chip: removes the chip from the document', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/123', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    renderEditor();
+    await insertUnavailableInlineWorkPackage();
+
+    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
+    await userEvent.click(page.getByText('Unavailable: No permission'));
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+
+    await userEvent.click(page.getByTitle('Remove'));
+
+    await expect.element(page.getByText('Unavailable: No permission')).not.toBeInTheDocument();
+  });
+
+  it('block card: opens the popover without the Open button and removes the block', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/123', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    );
+
+    renderEditor();
+    await insertBlockWorkPackageViaSlashMenu();
+
+    await expect.element(page.getByText('Linked work package unavailable')).toBeVisible();
+    await userEvent.click(page.getByText('Linked work package unavailable'));
+
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+    await expect.element(page.getByTitle('Open in new tab')).not.toBeInTheDocument();
+
+    await userEvent.click(page.getByTitle('Remove'));
+
+    await expect.element(page.getByTestId('block-wp-wrapper')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-112

# What are you trying to accomplish?
A work package link (inline chip or block card) that the current user isn't allowed to access showed no context menu on click, so such links could neither be resized nor removed - the options popover was only wired into the fully-resolved state.

After this change, permission-restricted (and errored) WP links open the same options popover as normal ones, with resize / convert / remove all working. The only difference is that the Open action is hidden, since there's nothing the user is allowed to open.


## Screenshots
<img width="486" height="258" alt="image" src="https://github.com/user-attachments/assets/e9e1053f-8a56-44a9-8e4e-34c9d424ac13" />
<img width="486" height="258" alt="image" src="https://github.com/user-attachments/assets/f46e9240-9b2f-42b6-a3d5-d06036f8dc63" />

# What approach did you choose and why?
I reused the existing WpOptionsPopover instead of building a parallel component, because every popover action except Open already operates on the node's wpid / displayId props rather than the fetched work package - so the restricted state needs no new logic, just access to the menu.

- WpOptionsPopover: made the wp prop optional and render the Open button (and its divider) only when a resolved work package is present. Everything else is unchanged.
- InlineWorkPackageChip and BlockWorkPackage: extracted the popover JSX into a single local optionsPopover element per component (removing the duplication that previously existed between the resolved and unavailable branches) and wired it into the unavailable branch. The block card's unavailable state now uses a clickable UnavailableCardWrapper; handleConvertToInline reads block.props.wpid instead of the resolved WP so conversion works without loaded details.
- This also fixes a Safari issue where unavailable inline chips didn't get the blue selection outline: the unavailable branch now drives selection via its own isSelected state, like the resolved chip.


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
