### PR TITLE
[BNE-120] Reduce likelihood for npm toolchain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 5

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+min-release-age=5
+allow-git=root
+ignore-scripts=true


### PR DESCRIPTION
https://community.openproject.org/wp/BNE-120

- Wait 5 days before newly released dependencies can be installed (so security issues can be detected by the community in the meantime)
- Only allow installing from git for the root package, not dependencies of packages (often a way how malicious code is sneaked in, because it would only show in the package-lock.json, which is not really readable)
- Don't run e.g. post-install scripts (so far we don't seem to have packages which need that)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
