### PR TITLE
Configure separate dependabot PRs for BlockNote

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,17 @@ updates:
     labels:
       - "dependencies"
     groups:
-      npm-minor-patch:
+      blocknote-minor-patch:
+        patterns:
+          - "@blocknote/*"
+        update-types:
+          - "minor"
+          - "patch"
+      other-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "@blocknote/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
# What are you trying to accomplish?
BlockNote needs to be updated separately, because we want to use the same version as OpenProject. Therefore it should be in separate dependabot PRs so we can just merge them.

# What approach did you choose and why?
Update dependabot config:
- Major version changes still get their own PRs
- Minor and patch version changes are not split between BlockNote and non-BlockNote updates

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
