### PR TITLE
[COMMS-904] Allow copying the link to an unavailable (unauthorized) work package for all inline/block sizes

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -141,6 +141,7 @@ export const BlockWorkPackageComponent = ({
   const optionsPopover = (
     <WpOptionsPopover
       wp={selectedWorkPackage ?? undefined}
+      displayId={displayId}
       currentSize={undefined}
       currentBlockSize={cardSize}
       // eslint-disable-next-line react-hooks/refs

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -205,6 +205,7 @@ export const BlockWorkPackageComponent = ({
                     headerKey="unavailableWorkPackage.unauthorized.header"
                     messageKey="unavailableWorkPackage.unauthorized.message"
                     displayId={displayId}
+                    linkHeader
                   />
                 )}
                 {isOptionsOpen && optionsPopover}

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -84,6 +84,9 @@ export const BlockWorkPackageComponent = ({
   }, [selectedWorkPackage?.displayId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const cardSize:BlockWpSize = block.props.size ?? 'm';
+  // The stored displayId may be '' (schema default), so ?? is not enough here.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const displayId = block.props.displayId || String(block.props.wpid);
 
   useEffect(() => {
     return () => { pendingBlockRegistry.delete(block.id); };
@@ -175,8 +178,8 @@ export const BlockWorkPackageComponent = ({
           <>
             {workPackageResult.loading && (
               <UnavailableCard
-                header={t('unavailableWorkPackage.loading.header')}
-                message={t('unavailableWorkPackage.loading.message')}
+                headerKey="unavailableWorkPackage.loading.header"
+                messageKey="unavailableWorkPackage.loading.message"
               />
             )}
             {!workPackageResult.loading && (workPackageResult.error ?? workPackageResult.unauthorized) && (
@@ -191,14 +194,16 @@ export const BlockWorkPackageComponent = ({
                 {workPackageResult.error ? (
                   <UnavailableCard
                     icon={<AlertIcon size={16} />}
-                    header={t('unavailableWorkPackage.error.header')}
-                    message={t('unavailableWorkPackage.error.message')}
+                    headerKey="unavailableWorkPackage.error.header"
+                    messageKey="unavailableWorkPackage.error.message"
+                    displayId={displayId}
                   />
                 ) : (
                   <UnavailableCard
                     icon={<EyeClosedIcon size={16} />}
-                    header={t('unavailableWorkPackage.unauthorized.header')}
-                    message={t('unavailableWorkPackage.unauthorized.message')}
+                    headerKey="unavailableWorkPackage.unauthorized.header"
+                    messageKey="unavailableWorkPackage.unauthorized.message"
+                    displayId={displayId}
                   />
                 )}
                 {isOptionsOpen && optionsPopover}

--- a/lib/components/InlineWorkPackage/InlineChips.tsx
+++ b/lib/components/InlineWorkPackage/InlineChips.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
 import type { WorkPackage } from '../../openProjectTypes';
-import { linkToWorkPackage } from '../../services/openProjectApi';
 import {
   typeColor,
   statusColor,
@@ -14,6 +12,7 @@ import {
   WorkPackageType,
   WorkPackageStatus,
   WorkPackageTitleLink,
+  workPackageLinkProps,
 } from '../WorkPackage/atoms';
 import { formatWorkPackageId } from '../../utils/id';
 
@@ -22,11 +21,8 @@ const WRAP_OPPORTUNITY = '\u200B'; /*zero-width space*/
 
 const titleLinkProps = (wp:WorkPackage) => ({
   as: 'a' as const,
-  href: linkToWorkPackage(resolvedDisplayId(wp)),
-  target: '_blank' as const,
-  rel: 'noopener noreferrer',
+  ...workPackageLinkProps(resolvedDisplayId(wp)),
   $compact: true,
-  onClick: (e:React.MouseEvent) => e.stopPropagation(),
 });
 
 // XXS — "#ID"

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -73,6 +73,7 @@ const InlineChip = styled.span.attrs({
 export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updateInlineContent }:InlineWorkPackageChipProps) => {
   const { t } = useTranslation();
   const rawWpid = inlineContent.props.wpid;
+  const displayId = inlineContent.props.displayId || rawWpid;
   const size = (inlineContent.props.size ?? 's') as InlineWpSize;
 
   const pendingCallbacks = getPendingCallbacks(rawWpid);
@@ -137,6 +138,7 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
   const optionsPopover = (
     <WpOptionsPopover
       wp={wp ?? undefined}
+      displayId={displayId}
       currentSize={size}
       // eslint-disable-next-line react-hooks/refs
       anchorEl={chipRef.current}
@@ -229,7 +231,6 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     const cardIcon = kind === 'unauthorized'
       ? <EyeClosedIcon size={16} />
       : <AlertIcon size={16} />;
-    const displayId = inlineContent.props.displayId || rawWpid;
     const shortMessageKey = `unavailableWorkPackage.${kind}.short_message`;
     const shortLabel = t(shortMessageKey).replace(/<\/?wplink>/g, '');
 

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -1,16 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
-import styled, { css } from 'styled-components';
 import { useWorkPackage } from '../../hooks/useWorkPackage';
 import { useWorkPackagePreview } from '../../hooks/useWorkPackagePreview';
 import { useColors } from '../../services/colors';
-import { CHIP_STYLES } from '../WorkPackage/tokens';
-import { ChipBase, ChipBaseXXS } from './chipLayouts';
-import { WorkPackageId, WorkPackageTitleLink, workPackageLinkProps } from '../WorkPackage/atoms';
+import { ChipBase, InlineChip } from './chipLayouts';
+import { WorkPackageId } from '../WorkPackage/atoms';
 import { WpChipXXS, WpChipXS, WpChipS } from './InlineChips';
+import { UnavailableChip } from './UnavailableChip';
 import { WorkPackageSearchPopover } from '../Search/WorkPackageSearchPopover';
 import { WpOptionsPopover } from '../WorkPackage/OptionsPopover';
 import { WpPreviewPopover } from '../WorkPackage/PreviewPopover';
-import { UnavailableCard } from '../WorkPackage/UnavailableCard';
 import { getPendingCallbacks, clearInlineWpCallbacks } from './callbacks';
 import type { InlineWpSize } from '../WorkPackage/types';
 import {
@@ -19,10 +17,8 @@ import {
   removeInlineChipAt,
   promoteInlineChipToBlockAt,
 } from '../../utils/inlineChipActions';
-import { EyeClosedIcon, AlertIcon } from '@primer/octicons-react';
 import { BlockCard } from '../BlockWorkPackage/BlockCard';
-import { Trans, useTranslation } from 'react-i18next';
-import { defaultWpVariables } from '../WorkPackage/atoms';
+import { useTranslation } from 'react-i18next';
 import { formatWorkPackageId } from '../../utils/id';
 import { useIsNodeInSelection } from '../../hooks/useIsNodeInSelection';
 import { useSuppressFormattingToolbar } from '../../hooks/useSuppressFormattingToolbar';
@@ -39,36 +35,6 @@ export interface InlineWorkPackageChipProps {
     props:{ wpid:string; size:string; displayId:string };
   }) => void;
 }
-
-const UnavailableLabel = styled.span`
-  color: var(--bn-colors-editor-text);
-`;
-
-const InlineChip = styled.span.attrs({
-  className: 'op-bn-inline-wp',
-  contentEditable: false,
-})<{ selected?:boolean }>`
-  ${defaultWpVariables}
-  display: inline;
-  cursor: pointer;
-  user-select: none;
-  -webkit-touch-callout: none;
-  border-radius: ${CHIP_STYLES.radius};
-  position: relative;
-  line-height: 1;
-
-  &:active {
-    cursor: grabbing;
-  }
-
-  ${({ selected }) =>
-    selected &&
-    css`
-      & > .op-bn-inline-wp-base {
-        box-shadow: ${CHIP_STYLES.inlineFocusShadow};
-      }
-    `}
-`;
 
 export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updateInlineContent }:InlineWorkPackageChipProps) => {
   const { t } = useTranslation();
@@ -92,8 +58,8 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
   const [isSelected, setIsSelected] = useState(false);
   const chipRef = useRef<HTMLElement | null>(null);
 
-  const { previewOpen, closePreview, wasLongPress, triggerProps, cardProps } =
-    useWorkPackagePreview({ enabled: size === 'xxs', suppressed: isSelected });
+  const preview = useWorkPackagePreview({ enabled: size === 'xxs', suppressed: isSelected });
+  const { previewOpen, closePreview, wasLongPress, triggerProps, cardProps } = preview;
 
   const isEditorSelected = useIsNodeInSelection(chipRef, editor);
 
@@ -224,69 +190,23 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     );
   }
 
-  const unavailableWorkPackage = (kind:'unauthorized' | 'error') => {
-    const inlineIcon = kind === 'unauthorized'
-      ? <EyeClosedIcon size={12} verticalAlign="middle" />
-      : <AlertIcon size={12} verticalAlign="middle" />;
-    const cardIcon = kind === 'unauthorized'
-      ? <EyeClosedIcon size={16} />
-      : <AlertIcon size={16} />;
-    const shortMessageKey = `unavailableWorkPackage.${kind}.short_message`;
-    const shortLabel = t(shortMessageKey).replace(/<\/?wplink>/g, '');
-
-    // xxs stays tiny (icon only); the full message lives in the hover/long-press preview.
-    const iconOnly = size === 'xxs';
-    const Base = iconOnly ? ChipBaseXXS : ChipBase;
-    const showPreview = iconOnly && previewOpen;
-
+  // Unavailable: the work package exists but this user cannot see it, or the fetch failed
+  if (wpid && (unauthorized || error)) {
     return (
-      <InlineChip
-        ref={setRef}
-        data-drag-handle
-        // icon-only xxs is a labelled state graphic; larger sizes carry visible text
-        role={iconOnly ? 'img' : undefined}
+      <UnavailableChip
+        kind={unauthorized ? 'unauthorized' : 'error'}
+        size={size}
+        displayId={displayId}
+        setRef={setRef}
+        // eslint-disable-next-line react-hooks/refs
+        anchorEl={chipRef.current}
         selected={isSelected || isEditorSelected}
-        aria-label={iconOnly ? shortLabel : undefined}
-        {...triggerProps}
+        preview={preview}
         onClick={handleWorkPackageClick}
-      >
-        <Base>
-          {inlineIcon}
-          {!iconOnly && <WorkPackageId as="span" $compact>{formatWorkPackageId(displayId)}</WorkPackageId>}
-          {!iconOnly && (
-            <UnavailableLabel>
-              <Trans
-                i18nKey={shortMessageKey}
-                components={{ wplink: <WorkPackageTitleLink {...workPackageLinkProps(displayId)} /> }}
-              />
-            </UnavailableLabel>
-          )}
-        </Base>
-
-        {showPreview && (
-          <WpPreviewPopover
-            anchorEl={chipRef.current}
-            onClose={closePreview}
-            {...cardProps}
-          >
-            <UnavailableCard
-              icon={cardIcon}
-              headerKey={`unavailableWorkPackage.${kind}.header`}
-              messageKey={`unavailableWorkPackage.${kind}.message`}
-              displayId={displayId}
-            />
-          </WpPreviewPopover>
-        )}
-
-        {isSelected && optionsPopover}
-      </InlineChip>
+        optionsPopover={isSelected && optionsPopover}
+      />
     );
-  };
-
-  // eslint-disable-next-line react-hooks/refs
-  if (wpid && unauthorized) return unavailableWorkPackage('unauthorized');
-  // eslint-disable-next-line react-hooks/refs
-  if (wpid && error) return unavailableWorkPackage('error');
+  }
 
   // Unknown / transitional
   if (wpid) {

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -5,7 +5,7 @@ import { useWorkPackagePreview } from '../../hooks/useWorkPackagePreview';
 import { useColors } from '../../services/colors';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
 import { ChipBase, ChipBaseXXS } from './chipLayouts';
-import { WorkPackageId } from '../WorkPackage/atoms';
+import { WorkPackageId, WorkPackageTitleLink, workPackageLinkProps } from '../WorkPackage/atoms';
 import { WpChipXXS, WpChipXS, WpChipS } from './InlineChips';
 import { WorkPackageSearchPopover } from '../Search/WorkPackageSearchPopover';
 import { WpOptionsPopover } from '../WorkPackage/OptionsPopover';
@@ -21,7 +21,7 @@ import {
 } from '../../utils/inlineChipActions';
 import { EyeClosedIcon, AlertIcon } from '@primer/octicons-react';
 import { BlockCard } from '../BlockWorkPackage/BlockCard';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { defaultWpVariables } from '../WorkPackage/atoms';
 import { formatWorkPackageId } from '../../utils/id';
 import { useIsNodeInSelection } from '../../hooks/useIsNodeInSelection';
@@ -229,7 +229,9 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
     const cardIcon = kind === 'unauthorized'
       ? <EyeClosedIcon size={16} />
       : <AlertIcon size={16} />;
-    const shortLabel = t(`unavailableWorkPackage.${kind}.short_message`);
+    const displayId = inlineContent.props.displayId || rawWpid;
+    const shortMessageKey = `unavailableWorkPackage.${kind}.short_message`;
+    const shortLabel = t(shortMessageKey).replace(/<\/?wplink>/g, '');
 
     // xxs stays tiny (icon only); the full message lives in the hover/long-press preview.
     const iconOnly = size === 'xxs';
@@ -249,7 +251,15 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
       >
         <Base>
           {inlineIcon}
-          {!iconOnly && <UnavailableLabel>{shortLabel}</UnavailableLabel>}
+          {!iconOnly && <WorkPackageId as="span" $compact>{formatWorkPackageId(displayId)}</WorkPackageId>}
+          {!iconOnly && (
+            <UnavailableLabel>
+              <Trans
+                i18nKey={shortMessageKey}
+                components={{ wplink: <WorkPackageTitleLink {...workPackageLinkProps(displayId)} /> }}
+              />
+            </UnavailableLabel>
+          )}
         </Base>
 
         {showPreview && (
@@ -260,8 +270,9 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
           >
             <UnavailableCard
               icon={cardIcon}
-              header={t(`unavailableWorkPackage.${kind}.header`)}
-              message={t(`unavailableWorkPackage.${kind}.message`)}
+              headerKey={`unavailableWorkPackage.${kind}.header`}
+              messageKey={`unavailableWorkPackage.${kind}.message`}
+              displayId={displayId}
             />
           </WpPreviewPopover>
         )}

--- a/lib/components/InlineWorkPackage/UnavailableChip.tsx
+++ b/lib/components/InlineWorkPackage/UnavailableChip.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { EyeClosedIcon, AlertIcon } from '@primer/octicons-react';
+import { ChipBase, ChipBaseXXS, InlineChip } from './chipLayouts';
+import { WorkPackageId, WorkPackageTitleLink, workPackageLinkProps } from '../WorkPackage/atoms';
+import { WpPreviewPopover } from '../WorkPackage/PreviewPopover';
+import { UnavailableCard } from '../WorkPackage/UnavailableCard';
+import { formatWorkPackageId } from '../../utils/id';
+import type { InlineWpSize } from '../WorkPackage/types';
+import type { WorkPackagePreview } from '../../hooks/useWorkPackagePreview';
+
+export interface UnavailableChipProps {
+  kind:'unauthorized' | 'error';
+  size:InlineWpSize;
+  displayId:string;
+  setRef:(node:HTMLElement | null) => void;
+  anchorEl:HTMLElement | null;
+  selected:boolean;
+  preview:WorkPackagePreview;
+  onClick:(e:React.MouseEvent) => void;
+  optionsPopover:ReactNode;
+}
+
+const UnavailableLabel = styled.span`
+  color: var(--bn-colors-editor-text);
+`;
+
+export const UnavailableChip = ({
+  kind,
+  size,
+  displayId,
+  setRef,
+  anchorEl,
+  selected,
+  preview,
+  onClick,
+  optionsPopover,
+}:UnavailableChipProps) => {
+  const { t } = useTranslation();
+  const { previewOpen, closePreview, triggerProps, cardProps } = preview;
+
+  const inlineIcon = kind === 'unauthorized'
+    ? <EyeClosedIcon size={12} verticalAlign="middle" />
+    : <AlertIcon size={12} verticalAlign="middle" />;
+  const cardIcon = kind === 'unauthorized'
+    ? <EyeClosedIcon size={16} />
+    : <AlertIcon size={16} />;
+  const shortLabel = t(`unavailableWorkPackage.${kind}.short_message`);
+
+  const linked = kind === 'unauthorized';
+
+  // xxs stays tiny (icon only); the full message lives in the hover/long-press preview.
+  const iconOnly = size === 'xxs';
+  const Base = iconOnly ? ChipBaseXXS : ChipBase;
+  const showPreview = iconOnly && previewOpen;
+
+  return (
+    <InlineChip
+      ref={setRef}
+      data-drag-handle
+      // icon-only xxs is a labelled state graphic; larger sizes carry visible text
+      role={iconOnly ? 'img' : undefined}
+      selected={selected}
+      aria-label={iconOnly ? shortLabel : undefined}
+      {...triggerProps}
+      onClick={onClick}
+    >
+      <Base>
+        {inlineIcon}
+        {!iconOnly && <WorkPackageId as="span" $compact>{formatWorkPackageId(displayId)}</WorkPackageId>}
+        {!iconOnly && (
+          <UnavailableLabel>
+            {linked
+              ? <WorkPackageTitleLink {...workPackageLinkProps(displayId)}>{shortLabel}</WorkPackageTitleLink>
+              : shortLabel}
+          </UnavailableLabel>
+        )}
+      </Base>
+
+      {showPreview && (
+        <WpPreviewPopover
+          anchorEl={anchorEl}
+          onClose={closePreview}
+          {...cardProps}
+        >
+          <UnavailableCard
+            icon={cardIcon}
+            headerKey={`unavailableWorkPackage.${kind}.header`}
+            messageKey={`unavailableWorkPackage.${kind}.message`}
+            displayId={displayId}
+            linkHeader={linked}
+          />
+        </WpPreviewPopover>
+      )}
+
+      {optionsPopover}
+    </InlineChip>
+  );
+};

--- a/lib/components/InlineWorkPackage/chipLayouts.tsx
+++ b/lib/components/InlineWorkPackage/chipLayouts.tsx
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 import styled from 'styled-components';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
+import { defaultWpVariables } from '../WorkPackage/atoms';
 
 const chipBaseStyles = css`
   display: inline;
@@ -46,3 +47,29 @@ export const ChipBaseS = styled.span.attrs({ className: 'op-bn-inline-wp-base' }
 `;
 
 export const ChipBase = ChipBaseS;
+
+export const InlineChip = styled.span.attrs({
+  className: 'op-bn-inline-wp',
+  contentEditable: false,
+})<{ selected?:boolean }>`
+  ${defaultWpVariables}
+  display: inline;
+  cursor: pointer;
+  user-select: none;
+  -webkit-touch-callout: none;
+  border-radius: ${CHIP_STYLES.radius};
+  position: relative;
+  line-height: 1;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  ${({ selected }) =>
+    selected &&
+    css`
+      & > .op-bn-inline-wp-base {
+        box-shadow: ${CHIP_STYLES.inlineFocusShadow};
+      }
+    `}
+`;

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -16,6 +16,7 @@ import { supportsHover } from '../../utils/device';
 
 export interface WpOptionsProps {
   wp?:WorkPackage;
+  displayId?:string;
   currentSize?:InlineWpSize;
   currentBlockSize?:BlockWpSize;
   anchorEl?:HTMLElement | null;
@@ -148,6 +149,7 @@ const IcChevron = () => <ChevronDownIcon size={10} />;
 
 export const WpOptionsPopover = ({
   wp,
+  displayId,
   currentSize,
   currentBlockSize,
   anchorEl,
@@ -172,6 +174,8 @@ export const WpOptionsPopover = ({
 
   const isBlock = currentSize === undefined;
 
+  const openId = wp?.displayId ?? displayId;
+
   const displayedSizeKey = isBlock ? (currentBlockSize ?? 'm') : currentSize;
   const displayedSize = t(`sizes.${displayedSizeKey}.label`);
 
@@ -185,14 +189,14 @@ export const WpOptionsPopover = ({
     // Do NOT add preventDefault: on iOS it suppresses the first tap's click, so
     // every button then needs a priming tap.
     <Popover ref={popoverRef} onMouseDown={(e) => e.stopPropagation()}>
-      {wp && (
+      {openId && (
         <>
           <PopBtn
             title={t('options.openInNewTab')}
-            aria-label={t('options.openAriaLabel', { id: formatWorkPackageId(wp.displayId) })}
+            aria-label={t('options.openAriaLabel', { id: formatWorkPackageId(openId) })}
             onClick={(e) => {
               e.stopPropagation();
-              window.open(linkToWorkPackage(wp.displayId), '_blank', 'noopener,noreferrer');
+              window.open(linkToWorkPackage(openId), '_blank', 'noopener,noreferrer');
             }}
           >
             <IcOpen /> {t('options.open')}

--- a/lib/components/WorkPackage/UnavailableCard.tsx
+++ b/lib/components/WorkPackage/UnavailableCard.tsx
@@ -1,12 +1,20 @@
 import type { ReactNode } from 'react';
 import styled from 'styled-components';
-import { defaultWpVariables } from './atoms';
+import { Trans, useTranslation } from 'react-i18next';
+import {
+  defaultWpVariables,
+  WorkPackageId,
+  WorkPackageTitleLink,
+  workPackageLinkProps,
+} from './atoms';
 import { CHIP_STYLES } from './tokens';
+import { formatWorkPackageId } from '../../utils/id';
 
 interface UnavailableCardProps {
-  header:string;
-  message:string;
+  headerKey:string;
+  messageKey:string;
   icon?:ReactNode;
+  displayId?:string;
 }
 
 const UnavailableWorkPackage = styled.div.attrs({
@@ -34,14 +42,24 @@ const UnavailableMessageHeader = styled.div.attrs({
   gap: ${CHIP_STYLES.gap};
 `;
 
-export const UnavailableCard = ({ header, message, icon }:UnavailableCardProps) => (
-  <UnavailableWorkPackage>
-    <UnavailableMessage>
-      <UnavailableMessageHeader>
-        {icon}
-        {header}
-      </UnavailableMessageHeader>
-      {message}
-    </UnavailableMessage>
-  </UnavailableWorkPackage>
-);
+export const UnavailableCard = ({ headerKey, messageKey, icon, displayId }:UnavailableCardProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <UnavailableWorkPackage>
+      <UnavailableMessage>
+        <UnavailableMessageHeader>
+          {icon}
+          {displayId && <WorkPackageId as="span" $compact>{formatWorkPackageId(displayId)}</WorkPackageId>}
+          <span>
+            <Trans
+              i18nKey={headerKey}
+              components={displayId ? { wplink: <WorkPackageTitleLink {...workPackageLinkProps(displayId)} /> } : undefined}
+            />
+          </span>
+        </UnavailableMessageHeader>
+        {t(messageKey)}
+      </UnavailableMessage>
+    </UnavailableWorkPackage>
+  );
+};

--- a/lib/components/WorkPackage/UnavailableCard.tsx
+++ b/lib/components/WorkPackage/UnavailableCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import styled from 'styled-components';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import {
   defaultWpVariables,
   WorkPackageId,
@@ -15,6 +15,7 @@ interface UnavailableCardProps {
   messageKey:string;
   icon?:ReactNode;
   displayId?:string;
+  linkHeader?:boolean;
 }
 
 const UnavailableWorkPackage = styled.div.attrs({
@@ -42,8 +43,10 @@ const UnavailableMessageHeader = styled.div.attrs({
   gap: ${CHIP_STYLES.gap};
 `;
 
-export const UnavailableCard = ({ headerKey, messageKey, icon, displayId }:UnavailableCardProps) => {
+export const UnavailableCard = ({ headerKey, messageKey, icon, displayId, linkHeader }:UnavailableCardProps) => {
   const { t } = useTranslation();
+
+  const header = t(headerKey);
 
   return (
     <UnavailableWorkPackage>
@@ -52,10 +55,9 @@ export const UnavailableCard = ({ headerKey, messageKey, icon, displayId }:Unava
           {icon}
           {displayId && <WorkPackageId as="span" $compact>{formatWorkPackageId(displayId)}</WorkPackageId>}
           <span>
-            <Trans
-              i18nKey={headerKey}
-              components={displayId ? { wplink: <WorkPackageTitleLink {...workPackageLinkProps(displayId)} /> } : undefined}
-            />
+            {linkHeader && displayId
+              ? <WorkPackageTitleLink {...workPackageLinkProps(displayId)}>{header}</WorkPackageTitleLink>
+              : header}
           </span>
         </UnavailableMessageHeader>
         {t(messageKey)}

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -1,9 +1,11 @@
+import type { MouseEvent } from 'react';
 import styled, { css } from 'styled-components';
 import {
   defaultColorStyles,
   metaTextColor,
   typeTextColor,
 } from '../../services/colors';
+import { linkToWorkPackage } from '../../services/openProjectApi';
 
 export const defaultWpVariables = css`
   --spacer-s: 4px;
@@ -95,6 +97,14 @@ export const WorkPackageTitle = styled.span.attrs({
   font-weight: 500;
   overflow-wrap: anywhere;
 `;
+
+export const workPackageLinkProps = (displayId:string) => ({
+  href: linkToWorkPackage(displayId),
+  target: '_blank' as const,
+  rel: 'noopener noreferrer',
+  /*  keep link clicks from toggling the surrounding chip/card popover  */
+  onClick: (e:MouseEvent) => e.stopPropagation(),
+});
 
 export const WorkPackageTitleLink = styled.a<{ $compact?:boolean }>`
   cursor: pointer;

--- a/lib/components/WorkPackage/index.ts
+++ b/lib/components/WorkPackage/index.ts
@@ -4,6 +4,7 @@ export {
   WorkPackageStatus,
   WorkPackageTitle,
   WorkPackageTitleLink,
+  workPackageLinkProps,
   defaultWpVariables,
 } from './atoms';
 export { WpOptionsPopover } from './OptionsPopover';

--- a/lib/hooks/useWorkPackagePreview.ts
+++ b/lib/hooks/useWorkPackagePreview.ts
@@ -36,7 +36,7 @@ interface ChipTriggerProps {
   style:{ touchAction:'none' };
 }
 
-interface WorkPackagePreview {
+export interface WorkPackagePreview {
   previewOpen:boolean;
   closePreview:() => void;
   // True at most once per press: the click that follows a long press, so the

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -15,22 +15,22 @@ export const en = {
       'placeholder': 'Search by work package ID or subject',
       'dropdownAriaLabel': 'Work package search results',
     },
-    // <wplink>...</wplink> wraps the words rendered as a link to the work package;
-    // every translation must keep the tag around the corresponding words.
+    // <wplink>...</wplink> wraps the text rendered as a link to the work package;
+    // every translation must keep the whole message wrapped so the entire line links.
     'unavailableWorkPackage': {
       'loading': {
         'header': 'Loading',
         'message': 'Please wait'
       },
       'unauthorized': {
-        'header': 'Linked <wplink>work package</wplink> unavailable',
+        'header': '<wplink>Linked work package unavailable</wplink>',
         'message': 'You do not have permission to see this',
-        'short_message': '<wplink>Unavailable</wplink>: No permission'
+        'short_message': '<wplink>Work package unavailable: no permission</wplink>'
       },
       'error': {
         'header': 'Error',
         'message': 'Could not load work package',
-        'short_message': '<wplink>Unavailable</wplink>: error'
+        'short_message': 'Unavailable: error'
       }
     },
     'options': {

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -15,20 +15,22 @@ export const en = {
       'placeholder': 'Search by work package ID or subject',
       'dropdownAriaLabel': 'Work package search results',
     },
+    // <wplink>...</wplink> wraps the words rendered as a link to the work package;
+    // every translation must keep the tag around the corresponding words.
     'unavailableWorkPackage': {
       'loading': {
         'header': 'Loading',
         'message': 'Please wait'
       },
       'unauthorized': {
-        'header': 'Linked work package unavailable',
+        'header': 'Linked <wplink>work package</wplink> unavailable',
         'message': 'You do not have permission to see this',
-        'short_message': 'Unavailable: No permission'
+        'short_message': '<wplink>Unavailable</wplink>: No permission'
       },
       'error': {
         'header': 'Error',
         'message': 'Could not load work package',
-        'short_message': 'Unavailable: error'
+        'short_message': '<wplink>Unavailable</wplink>: error'
       }
     },
     'options': {

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -15,17 +15,15 @@ export const en = {
       'placeholder': 'Search by work package ID or subject',
       'dropdownAriaLabel': 'Work package search results',
     },
-    // <wplink>...</wplink> wraps the text rendered as a link to the work package;
-    // every translation must keep the whole message wrapped so the entire line links.
     'unavailableWorkPackage': {
       'loading': {
         'header': 'Loading',
         'message': 'Please wait'
       },
       'unauthorized': {
-        'header': '<wplink>Linked work package unavailable</wplink>',
+        'header': 'Linked work package unavailable',
         'message': 'You do not have permission to see this',
-        'short_message': '<wplink>Work package unavailable: no permission</wplink>'
+        'short_message': 'Work package unavailable: no permission'
       },
       'error': {
         'header': 'Error',

--- a/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
+++ b/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
@@ -49,9 +49,13 @@ describe('Inline chip - unavailable work package', () => {
     );
 
     await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    expect(
-      page.getByText('Unavailable: No permission').element().closest('.op-bn-inline-wp')?.querySelector('.octicon-eye-closed')
-    ).not.toBeNull();
+    const chip = page.getByText('Unavailable: No permission').element().closest('.op-bn-inline-wp');
+    expect(chip?.querySelector('.octicon-eye-closed')).not.toBeNull();
+
+    expect(chip?.querySelector('.op-bn-work-package--id')?.textContent).toBe('#999');
+    const link = chip?.querySelector('a');
+    expect(link?.textContent).toBe('Unavailable');
+    expect(link?.getAttribute('href')).toBe('http://localhost:3000/wp/999');
   });
 
   it('shows alert icon and "Unavailable: error" on server error', async () => {
@@ -122,7 +126,13 @@ describe('Inline chip - unavailable work package', () => {
     await expect.element(page.getByText('Linked work package unavailable')).toBeVisible();
     await expect.element(page.getByText('You do not have permission to see this')).toBeVisible();
     // The known-format card icon is reused from the block card.
-    expect(document.querySelector('.op-bn-unavailable-message--header .octicon-eye-closed')).not.toBeNull();
+    const header = document.querySelector('.op-bn-unavailable-message--header');
+    expect(header?.querySelector('.octicon-eye-closed')).not.toBeNull();
+
+    expect(header?.querySelector('.op-bn-work-package--id')?.textContent).toBe('#999');
+    const link = header?.querySelector('a');
+    expect(link?.textContent).toBe('work package');
+    expect(link?.getAttribute('href')).toBe('http://localhost:3000/wp/999');
   });
 
   it('gets the selection outline on click and can be copied and pasted', async () => {
@@ -136,7 +146,8 @@ describe('Inline chip - unavailable work package', () => {
     await insertUnavailableInlineWorkPackage();
 
     await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    await userEvent.click(page.getByText('Unavailable: No permission'));
+    // click the identifier, not the label — its "Unavailable" word is a link
+    await userEvent.click(page.getByText('#123'));
 
     await expect.poll(() => {
       const base = document.querySelector('.op-bn-inline-wp .op-bn-inline-wp-base');
@@ -180,7 +191,8 @@ describe('Unavailable work package - options popover (BNE-112)', () => {
     render(<UnavailableChipWrapper initialSize="s" />);
 
     await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    await userEvent.click(page.getByText('Unavailable: No permission'));
+    // click the identifier, not the label — its "Unavailable" word is a link
+    await userEvent.click(page.getByText('#999'));
 
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
     await expect.element(page.getByTitle('Open in new tab')).not.toBeInTheDocument();
@@ -206,7 +218,8 @@ describe('Unavailable work package - options popover (BNE-112)', () => {
     await insertUnavailableInlineWorkPackage();
 
     await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    await userEvent.click(page.getByText('Unavailable: No permission'));
+    // click the identifier, not the label — its "Unavailable" word is a link
+    await userEvent.click(page.getByText('#123'));
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
 
     await userEvent.click(page.getByTitle('Remove'));
@@ -225,7 +238,8 @@ describe('Unavailable work package - options popover (BNE-112)', () => {
     await insertBlockWorkPackageViaSlashMenu();
 
     await expect.element(page.getByText('Linked work package unavailable')).toBeVisible();
-    await userEvent.click(page.getByText('Linked work package unavailable'));
+    // click the message, not the header — its "work package" words are a link
+    await userEvent.click(page.getByText('You do not have permission to see this'));
 
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
     await expect.element(page.getByTitle('Open in new tab')).not.toBeInTheDocument();
@@ -249,7 +263,13 @@ describe('Block card - unavailable work package', () => {
 
     await expect.element(page.getByText('Linked work package unavailable')).toBeVisible();
     await expect.element(page.getByText('You do not have permission to see this')).toBeVisible();
-    expect(document.querySelector('.op-bn-unavailable-message--header .octicon-eye-closed')).not.toBeNull();
+    const header = document.querySelector('.op-bn-unavailable-message--header');
+    expect(header?.querySelector('.octicon-eye-closed')).not.toBeNull();
+
+    expect(header?.querySelector('.op-bn-work-package--id')?.textContent).toBe('#123');
+    const link = header?.querySelector('a');
+    expect(link?.textContent).toBe('work package');
+    expect(link?.getAttribute('href')).toBe('http://localhost:3000/wp/123');
   });
 
   it('shows alert icon and "Error" on server error', async () => {

--- a/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
+++ b/test/lib/components/integration/workPackageUnavailable.browser.test.tsx
@@ -34,7 +34,7 @@ async function insertUnavailableInlineWorkPackage() {
 }
 
 describe('Inline chip - unavailable work package', () => {
-  it('shows eye-closed icon and "Unavailable: No permission" on 404', async () => {
+  it('shows eye-closed icon and "Work package unavailable: no permission" on 404', async () => {
     worker.use(
       http.get('http://localhost:3000/api/v3/work_packages/999', () =>
         HttpResponse.json({ message: 'Not found' }, { status: 404 })
@@ -48,13 +48,13 @@ describe('Inline chip - unavailable work package', () => {
       />
     );
 
-    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    const chip = page.getByText('Unavailable: No permission').element().closest('.op-bn-inline-wp');
+    await expect.element(page.getByText('Work package unavailable: no permission')).toBeVisible();
+    const chip = page.getByText('Work package unavailable: no permission').element().closest('.op-bn-inline-wp');
     expect(chip?.querySelector('.octicon-eye-closed')).not.toBeNull();
 
     expect(chip?.querySelector('.op-bn-work-package--id')?.textContent).toBe('#999');
     const link = chip?.querySelector('a');
-    expect(link?.textContent).toBe('Unavailable');
+    expect(link?.textContent).toBe('Work package unavailable: no permission');
     expect(link?.getAttribute('href')).toBe('http://localhost:3000/wp/999');
   });
 
@@ -99,7 +99,7 @@ describe('Inline chip - unavailable work package', () => {
     expect(chip?.textContent).toBe('');
     // The full message now lives in the hover/long-press preview, not a native tooltip.
     expect(chip?.getAttribute('title')).toBeNull();
-    expect(chip?.getAttribute('aria-label')).toBe('Unavailable: No permission');
+    expect(chip?.getAttribute('aria-label')).toBe('Work package unavailable: no permission');
   });
 
   it('shows the unavailable card in the preview on hover for size xxs', async () => {
@@ -131,7 +131,7 @@ describe('Inline chip - unavailable work package', () => {
 
     expect(header?.querySelector('.op-bn-work-package--id')?.textContent).toBe('#999');
     const link = header?.querySelector('a');
-    expect(link?.textContent).toBe('work package');
+    expect(link?.textContent).toBe('Linked work package unavailable');
     expect(link?.getAttribute('href')).toBe('http://localhost:3000/wp/999');
   });
 
@@ -145,8 +145,8 @@ describe('Inline chip - unavailable work package', () => {
     renderEditor();
     await insertUnavailableInlineWorkPackage();
 
-    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    // click the identifier, not the label — its "Unavailable" word is a link
+    await expect.element(page.getByText('Work package unavailable: no permission')).toBeVisible();
+    // click the identifier, not the label — the whole label is a link
     await userEvent.click(page.getByText('#123'));
 
     await expect.poll(() => {
@@ -181,7 +181,7 @@ function UnavailableChipWrapper({ initialSize }:{ initialSize:string }) {
 }
 
 describe('Unavailable work package - options popover (BNE-112)', () => {
-  it('inline chip: opens the popover without the Open button and resizes', async () => {
+  it('inline chip: opens the popover with the Open button and resizes', async () => {
     worker.use(
       http.get('http://localhost:3000/api/v3/work_packages/999', () =>
         HttpResponse.json({ message: 'Not found' }, { status: 404 })
@@ -190,12 +190,12 @@ describe('Unavailable work package - options popover (BNE-112)', () => {
 
     render(<UnavailableChipWrapper initialSize="s" />);
 
-    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    // click the identifier, not the label — its "Unavailable" word is a link
+    await expect.element(page.getByText('Work package unavailable: no permission')).toBeVisible();
+    // click the identifier, not the label — the whole label is a link
     await userEvent.click(page.getByText('#999'));
 
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
-    await expect.element(page.getByTitle('Open in new tab')).not.toBeInTheDocument();
+    await expect.element(page.getByTitle('Open in new tab')).toBeVisible();
 
     await userEvent.click(page.getByTitle('Change size'));
     await expect.element(page.getByTestId('size-menu')).toBeVisible();
@@ -203,7 +203,7 @@ describe('Unavailable work package - options popover (BNE-112)', () => {
 
     // xxs renders icon-only with the message exposed to assistive tech via aria-label
     await vi.waitFor(() => {
-      expect(document.querySelector('.op-bn-inline-wp')?.getAttribute('aria-label')).toBe('Unavailable: No permission');
+      expect(document.querySelector('.op-bn-inline-wp')?.getAttribute('aria-label')).toBe('Work package unavailable: no permission');
     });
   });
 
@@ -217,17 +217,17 @@ describe('Unavailable work package - options popover (BNE-112)', () => {
     renderEditor();
     await insertUnavailableInlineWorkPackage();
 
-    await expect.element(page.getByText('Unavailable: No permission')).toBeVisible();
-    // click the identifier, not the label — its "Unavailable" word is a link
+    await expect.element(page.getByText('Work package unavailable: no permission')).toBeVisible();
+    // click the identifier, not the label — the whole label is a link
     await userEvent.click(page.getByText('#123'));
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
 
     await userEvent.click(page.getByTitle('Remove'));
 
-    await expect.element(page.getByText('Unavailable: No permission')).not.toBeInTheDocument();
+    await expect.element(page.getByText('Work package unavailable: no permission')).not.toBeInTheDocument();
   });
 
-  it('block card: opens the popover without the Open button and removes the block', async () => {
+  it('block card: opens the popover with the Open button and removes the block', async () => {
     worker.use(
       http.get('http://localhost:3000/api/v3/work_packages/123', () =>
         HttpResponse.json({ message: 'Not found' }, { status: 404 })
@@ -238,11 +238,11 @@ describe('Unavailable work package - options popover (BNE-112)', () => {
     await insertBlockWorkPackageViaSlashMenu();
 
     await expect.element(page.getByText('Linked work package unavailable')).toBeVisible();
-    // click the message, not the header — its "work package" words are a link
+    // click the message, not the header — the whole header is a link
     await userEvent.click(page.getByText('You do not have permission to see this'));
 
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
-    await expect.element(page.getByTitle('Open in new tab')).not.toBeInTheDocument();
+    await expect.element(page.getByTitle('Open in new tab')).toBeVisible();
 
     await userEvent.click(page.getByTitle('Remove'));
 
@@ -268,7 +268,7 @@ describe('Block card - unavailable work package', () => {
 
     expect(header?.querySelector('.op-bn-work-package--id')?.textContent).toBe('#123');
     const link = header?.querySelector('a');
-    expect(link?.textContent).toBe('work package');
+    expect(link?.textContent).toBe('Linked work package unavailable');
     expect(link?.getAttribute('href')).toBe('http://localhost:3000/wp/123');
   });
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-904

# What are you trying to accomplish?
Expose the identifier and a clickable link for unavailable (unauthorized) work package references across every inline and block size, and make the linking consistent at every size.

Previously, when a document referenced a work package the user has no permission to access, the "Unavailable" placeholder gave no way to get the work package's URL - the identifier was shown inconsistently across sizes and no part of the text was a link. This made it impossible to copy the link or share it with someone who does have access.

Now every unavailable reference shows the identifier plus a standard blue, hoverable link, and **the whole message is the link** (instead of highlighting a different fragment per size, which looked restless):

- **Tiny (xxs):** icon only; the full message lives in the hover/long-press preview, where the identifier is shown after the eye-closed icon and the whole "Linked work package unavailable" line is a link.
- **Compact / Regular (xs / s):** identifier shown, and the whole "Work package unavailable: no permission" line is a link.
- **Compact card (m) and larger:** identifier shown after the eye-closed icon, and the whole "Linked work package unavailable" line is a link.

The link is a real `<a href>` pointing at the work package, so it is copyable and navigable even though the work package itself is not accessible. The identifier (`#123` / `PROJ-42`) stays a non-linked prefix, mirroring how available references keep the id separate from the linked subject.

The **"Open in new tab" action is restored in the options popover** for unavailable references (it had been dropped when there was no link target).

**Load errors (non-404)** are treated distinctly from permission denials (404): the placeholder text stays plain (an error is transient/infra, not a stable "share this" state, so a persistent blue "Error" link would mislead), but the popover still offers "Open in new tab" as a valid recovery action since the page itself may load fine.

## Screenshots
<img width="566" height="366" alt="image" src="https://github.com/user-attachments/assets/b67c39aa-7aae-4840-9c09-ca80f3ba5774" />

# What approach did you choose and why?
Maximised reuse of existing building blocks to keep the change DRY:

- Added a single `workPackageLinkProps(displayId)` helper in `WorkPackage/atoms` (href via the existing `linkToWorkPackage`, `target=_blank`, `rel`, and `stopPropagation` so a link click does not toggle the surrounding chip/card popover). It now backs the existing inline title links as well as the new unavailable links.
- Reused the existing `WorkPackageId` and `WorkPackageTitleLink` atoms for the identifier and link rendering, so styling matches the rest of the extension.
- Changed `UnavailableCard` to take i18n keys (`headerKey`/`messageKey`) plus an optional `displayId` and a `linkHeader` flag, and own its own `t()` rendering, instead of receiving pre-resolved strings from three separate call sites. One component now covers the tiny preview, the block cards, and the loading state. It stays in the `WorkPackage` namespace because both namespaces use it: the block card renders it directly, and the inline chip renders the same card inside the xxs hover/long-press preview.
- Extracted the inline unavailable state out of `InlineWorkPackageChip` into its own `InlineWorkPackage/UnavailableChip.tsx`, and moved the shared `InlineChip` styled wrapper to `chipLayouts` since both files need it now.
- Kept a **single `WpOptionsPopover`** for both available and unavailable references: the "Open in new tab" button is driven by `openId = wp?.displayId ?? displayId`, so it works whether or not the full work package resource loaded.

Because the whole message is the link, no translation has to be split into fragments and none has to carry markup: the translated string is fetched with plain `t()` and passed as children to `WorkPackageTitleLink`. Locale files stay ordinary sentences that an external translator can read, and nothing coming from a translation is ever parsed as HTML or interpolated into markup. (An earlier iteration wrapped the linked part in a `<wplink>` tag inside the translation and rendered it with `<Trans>`; that was dropped in favour of the above.)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
