### PR TITLE
[BNE-123] Documents: cursor misplaced after block is created on work package url copy-paste

### DIFF
--- a/lib/plugins/pasteWorkPackageLinkPlugin.ts
+++ b/lib/plugins/pasteWorkPackageLinkPlugin.ts
@@ -2,8 +2,10 @@ import { Plugin, PluginKey } from 'prosemirror-state';
 import type { Fragment, Node } from 'prosemirror-model';
 import { contentNodeToInlineContent, isLinkInlineContent, isStyledTextInlineContent } from '@blocknote/core';
 import type { BlockNoteEditor, InlineContent, StyleSchema, StyledText } from '@blocknote/core';
+import type { WorkPackageBlockProps } from '../components/BlockWorkPackage/externalHtml';
 import { fetchWorkPackage, parseWorkPackageUrl } from '../services/openProjectApi';
 import { isCurrentBlockEmpty } from '../utils/blockContent';
+import { moveCursorAfterBlock } from '../utils/cursor';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyEditor = BlockNoteEditor<any, any, any>;
@@ -38,6 +40,13 @@ export function pasteWorkPackageLinkPlugin(editor:AnyEditor):Plugin {
 
     props: {
       handlePaste(_view, _event, slice) {
+        const card = solePastedCard(slice.content);
+        if (card) {
+          const target = editor.getTextCursorPosition()?.block;
+          if (!target || target.type === 'codeBlock') return false;
+          return insertPastedCard(editor, card, target.id);
+        }
+
         const pasted = singlePastedTextblock(slice.content);
         if (!pasted) return false;
 
@@ -60,6 +69,31 @@ export function pasteWorkPackageLinkPlugin(editor:AnyEditor):Plugin {
       },
     },
   });
+}
+
+function solePastedCard(fragment:Fragment):Node | null {
+  if (fragment.childCount !== 1) return null;
+  const child = fragment.child(0);
+  if (child.type.name === 'openProjectWorkPackageBlock') return child;
+  if (child.isText || child.isTextblock) return null;
+  return solePastedCard(child.content);
+}
+
+/**
+ * The default paste nests the card inside the block it is dropped into and selects it as
+ * a node, leaving no caret; hence the sibling insert and the explicit cursor move.
+ */
+function insertPastedCard(editor:AnyEditor, card:Node, blockId:string):boolean {
+  const props = card.attrs as WorkPackageBlockProps;
+  if (!props.wpid) return false;
+
+  const node = { type: 'openProjectWorkPackageBlock', props } as Parameters<typeof editor.insertBlocks>[0][number];
+  const [inserted] = isCurrentBlockEmpty(editor)
+    ? editor.replaceBlocks([blockId], [node]).insertedBlocks
+    : editor.insertBlocks([node], blockId, 'after');
+
+  moveCursorAfterBlock(editor, inserted.id);
+  return true;
 }
 
 /**
@@ -171,10 +205,12 @@ async function insertBlockWorkPackage(editor:AnyEditor, reference:Reference, blo
     editor.replaceBlocks([blockId], fallback as Parameters<typeof editor.replaceBlocks>[1]);
     return;
   }
-  editor.replaceBlocks([blockId], [{
+  const { insertedBlocks } = editor.replaceBlocks([blockId], [{
     type: 'openProjectWorkPackageBlock',
     props: { wpid: resolved.wpid, displayId: resolved.displayId },
   } as Parameters<typeof editor.replaceBlocks>[1][number]]);
+
+  moveCursorAfterBlock(editor, insertedBlocks[0].id);
 }
 
 function canInsertInlineWorkPackage(editor:AnyEditor):boolean {

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -8,7 +8,14 @@ export function moveCursorAfterBlock(editor:AnyEditor, blockId:string):void {
   editor.setTextCursorPosition(blockId, 'end');
 
   const cursor = editor.getTextCursorPosition();
-  if (!cursor?.nextBlock && cursor?.block) {
+  const blockSchema = editor.schema.blockSchema as Record<string, { content?:string } | undefined>;
+  const nextType = cursor?.nextBlock?.type as string | undefined;
+
+  // A block without content of its own — another card, an image — takes a NodeSelection
+  // instead of a caret, which renders nothing and swallows what is typed next.
+  const nextTakesCursor = nextType !== undefined && blockSchema[nextType]?.content !== 'none';
+
+  if (cursor?.block && !nextTakesCursor) {
     editor.insertBlocks([{ type: 'paragraph', content: [] }], cursor.block.id, 'after');
   }
 

--- a/test/lib/components/integration/blockWorkPackageCopyPaste.browser.test.tsx
+++ b/test/lib/components/integration/blockWorkPackageCopyPaste.browser.test.tsx
@@ -10,8 +10,8 @@ import {
 // Paste the serialised external HTML of a block card into the editor.
 // Dispatch directly on the contenteditable so we can test paste independence
 // without relying on browser clipboard permissions.
-function pasteBlockCardHtml(wpid:number) {
-  const data = computeWorkPackageBlockExternalData({ wpid, size: 'm' })!;
+function pasteBlockCardHtml(wpid:number, size = 'm') {
+  const data = computeWorkPackageBlockExternalData({ wpid, size })!;
   const el = document.querySelector('[contenteditable]');
   if (!(el instanceof HTMLElement)) {
     throw new Error('Could not find a [contenteditable] element to dispatch paste on');
@@ -21,6 +21,57 @@ function pasteBlockCardHtml(wpid:number) {
   dt.setData('text/plain', `#${wpid}`);
   el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
 }
+
+describe('Block card - paste placement', () => {
+  // Left to the default paste, the card ends up indented under the line it was pasted
+  // into, with no caret: the next keystroke is swallowed.
+  it('pastes below a line with text and leaves the cursor after the card', async () => {
+    let editor!:{ document:{ type:string; children:unknown[] }[] };
+    renderEditor({ onEditor: (e) => { editor = e; } });
+    const textbox = page.getByRole('textbox');
+    await userEvent.click(textbox);
+    await userEvent.keyboard('before');
+
+    pasteBlockCardHtml(123);
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    await userEvent.keyboard('HERE');
+
+    await expect.element(textbox).toHaveTextContent(/before[\s\S]*#123[\s\S]*HERE/);
+    expect(editor.document.map((block) => block.type)).toEqual([
+      'paragraph',
+      'openProjectWorkPackageBlock',
+      'paragraph',
+    ]);
+    // Not nested under the line it was pasted into.
+    expect(editor.document[0].children).toEqual([]);
+  });
+
+  it('pastes into an empty line and leaves the cursor after the card', async () => {
+    renderEditor();
+    const textbox = page.getByRole('textbox');
+    await userEvent.click(textbox);
+    await userEvent.keyboard('before{Enter}');
+
+    pasteBlockCardHtml(123);
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    await userEvent.keyboard('HERE');
+
+    await expect.element(textbox).toHaveTextContent(/before[\s\S]*#123[\s\S]*HERE/);
+  });
+
+  it('keeps the size of the copied card', async () => {
+    renderEditor();
+    await userEvent.click(page.getByRole('textbox'));
+
+    pasteBlockCardHtml(123, 'xl');
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+    expect(document.querySelector('[data-testid="block-card"]')?.className)
+      .toContain('op-bn-work-package--xl');
+  });
+});
 
 describe('Block card - copy/paste independence', () => {
   it('removing the pasted copy does not remove the original', async () => {

--- a/test/lib/components/integration/pasteWorkPackageUrl.browser.test.tsx
+++ b/test/lib/components/integration/pasteWorkPackageUrl.browser.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { page, userEvent } from 'vitest/browser';
 import { BlockNoteSchema, defaultInlineContentSpecs } from '@blocknote/core';
 import { openProjectWorkPackageBlockSpec } from '../../../../lib';
 import { renderEditor } from '../../../helpers/renderEditor';
+import { worker } from '../../../mocks/browser';
 
 // Simulate pasting a plain text URL by dispatching a ClipboardEvent carrying
 // only text/plain data, as a browser does when copying from the address bar.
@@ -17,6 +19,8 @@ function pastePlainText(plain:string) {
 }
 
 describe('Paste work package URL', () => {
+  afterEach(() => worker.resetHandlers());
+
   it('creates a block card when pasting into an empty paragraph', async () => {
     renderEditor();
     await userEvent.click(page.getByRole('textbox'));
@@ -111,6 +115,68 @@ describe('Paste work package URL', () => {
 
     await expect.element(page.getByText('#456')).toBeVisible();
     expect(document.body.textContent).not.toContain('custom label');
+  });
+
+  // What the user notices about the cursor is where the next keystroke lands, so these
+  // assert the reading order of the document rather than the selection.
+  it('leaves the cursor after the created block card, not in the line above', async () => {
+    renderEditor();
+    const textbox = page.getByRole('textbox');
+    await userEvent.click(textbox);
+    await userEvent.keyboard('before{Enter}');
+
+    pastePlainText('http://localhost:3000/wp/123');
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    await userEvent.keyboard('HERE');
+
+    await expect.element(textbox).toHaveTextContent(/before[\s\S]*#123[\s\S]*HERE/);
+  });
+
+  it('leaves the cursor between the created card and a card right below it', async () => {
+    let editor!:{
+      document:{ id:string }[];
+      replaceBlocks:(remove:unknown, insert:unknown) => void;
+      setTextCursorPosition:(block:string, placement:string) => void;
+    };
+    renderEditor({ onEditor: (e) => { editor = e; } });
+    const textbox = page.getByRole('textbox');
+    await expect.element(textbox).toBeVisible();
+
+    editor.replaceBlocks(editor.document, [
+      { type: 'paragraph', content: [] },
+      { type: 'openProjectWorkPackageBlock', props: { wpid: 456, displayId: '456', size: 'm' } },
+    ]);
+    await expect.element(page.getByText('Add dark mode')).toBeVisible();
+    editor.setTextCursorPosition(editor.document[0].id, 'start');
+
+    pastePlainText('http://localhost:3000/wp/123');
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+
+    await userEvent.keyboard('HERE');
+
+    await expect.element(textbox).toHaveTextContent(/#123[\s\S]*HERE[\s\S]*#456/);
+  });
+
+  it('leaves the cursor after the link when the work package cannot be reached', async () => {
+    worker.use(
+      http.get('http://localhost:3000/api/v3/work_packages/GONE-1', () =>
+        HttpResponse.json({ message: 'not found' }, { status: 404 })
+      )
+    );
+    renderEditor();
+    const textbox = page.getByRole('textbox');
+    await userEvent.click(textbox);
+
+    pastePlainText('http://localhost:3000/wp/GONE-1');
+    await expect.element(page.getByText('http://localhost:3000/wp/GONE-1')).toBeVisible();
+
+    await userEvent.keyboard('HERE');
+
+    await expect.element(textbox).toHaveTextContent('http://localhost:3000/wp/GONE-1HERE');
+    // Typing must not extend the link itself.
+    expect(document.querySelector('[contenteditable] a')?.textContent)
+      .toBe('http://localhost:3000/wp/GONE-1');
   });
 
   it('keeps markdown links to foreign URLs untouched', async () => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-123

# What are you trying to accomplish?
After a work package card is created by pasting, the cursor stayed where it was instead of
moving after the card, so the next keystroke landed in the wrong line — or was swallowed
entirely.

Two separate paste paths were affected:

1. **Pasting a work package URL** into an empty line: the plugin created the card but never
   moved the cursor, because handling the paste ourselves means no transaction of the
   editor's own carries the selection past the inserted content.
2. **Pasting a copied card**: the plugin did not recognise this slice at all, so BlockNote's
   default paste took over - it nested the card inside the block it was pasted into and left
   a NodeSelection on it. The card appeared indented under the line, no caret was rendered
   and typing was swallowed. This is why the report was hard to reproduce: a URL and a
   copied card look identical to the user but take different code paths.

A third defect surfaced while fixing the above: `moveCursorAfterBlock` parked the cursor in
the next block even when that block cannot hold a caret (another card, an image), producing
the same swallowed-typing symptom. It is reachable from `/wp` and from the chip -> card
conversion as well, since they share the helper.

The cursor now lands in a caret position after the card in all of these cases, matching
`/wp` and inline link paste.

# What approach did you choose and why?
- **Everything routes through `moveCursorAfterBlock`.** One place decides where the cursor
  goes after a card, which is why repairing the helper fixed all four of its call sites at
  once (URL paste, card paste, `/wp`, chip -> card).
- **The single-copied-card slice is now handled in the plugin** instead of falling through to
  the default paste, and the card is inserted as a **sibling** rather than nested. A nested
  card has no sensible "after" position, so the cursor could not be fixed without this;
  sibling placement also matches what `convertInlineChipToBlock` already does.
- **The helper now only parks the cursor in a next block whose content is not `none`.**
  Deliberately `!== 'none'` and not `=== 'inline'`: BlockNote's `setTextCursorPosition`
  supports table content too, so a table below the card still takes the caret in its first
  cell instead of gaining a stray empty paragraph.
- **The pasted card's props pass through unchanged**, so `size` and `displayId` survive the
  copy without re-deriving them.

**Alternatives considered and discarded**

- *Only calling `moveCursorAfterBlock` from the URL path* - the obvious minimal fix. Measured
  against the new tests: it fails 3 of 6. It does nothing for a copied card (the code never
  runs) and nothing for the adjacent-card case (the helper itself was broken).
- *Explicitly placing the cursor in the unresolvable-link fallback branch* - a test showed the
  selection already maps correctly into that paragraph, since it is ordinary inline content.
  The code was unnecessary and was removed again.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
