### PR TITLE
[COMMS-882] Add proxy URL for work package links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ First, initialize the library configuration:
 initializeOpBlockNoteExtensions({ baseUrl: 'https://my.openproject.url', locale: 'en' });
 ```
 
+`baseUrl` is the address of your OpenProject instance. It is used to build links
+to work packages and to recognize pasted work package URLs.
+
+Optionally, you can pass a `proxyUrl`. The authorized API requests are then sent
+to that address instead of `baseUrl`, which is useful if the API traffic has to
+be routed through a proxy, for example to inject authorization. Links to work
+packages and the recognition of pasted work package URLs keep using `baseUrl`.
+
+```js
+initializeOpBlockNoteExtensions({
+  baseUrl: 'https://my.openproject.url',
+  proxyUrl: 'https://my.proxy.url',
+  locale: 'en',
+});
+```
+
 Then set up a BlockNote schema extending it with the block and inline specs:
 
 ```tsx

--- a/lib/initialize.ts
+++ b/lib/initialize.ts
@@ -1,7 +1,7 @@
 import { initOpenProjectApi } from './services/openProjectApi.ts';
 import { initLanguage } from './services/i18n.ts';
 
-export function initializeOpBlockNoteExtensions(config:{ baseUrl:string, locale:string }) {
-  initOpenProjectApi({ baseUrl: config.baseUrl });
+export function initializeOpBlockNoteExtensions(config:{ baseUrl:string, proxyUrl?:string, locale:string }) {
+  initOpenProjectApi({ baseUrl: config.baseUrl, proxyUrl: config.proxyUrl });
   initLanguage(config.locale);
 }

--- a/lib/services/openProjectApi.ts
+++ b/lib/services/openProjectApi.ts
@@ -2,6 +2,7 @@
 import type {OpenProjectResponse, StatusCollection, TypeCollection, WorkPackage} from '../openProjectTypes';
 
 let baseUrl = 'https://openproject.local';
+let proxyUrl = 'https://openproject.local';
 
 
 export class OpenProjectApiError extends Error {
@@ -14,15 +15,26 @@ export class OpenProjectApiError extends Error {
   }
 }
 
-export function initOpenProjectApi(config:{ baseUrl:string }) {
-  baseUrl = config.baseUrl;
-  if (baseUrl.endsWith('/')) {
-    baseUrl = baseUrl.slice(0, -1);
-  }
+function stripTrailingSlash(url:string):string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+/**
+ * Initializes the API configuration.
+ *
+ * `baseUrl` is the address of the OpenProject instance. It is used for links
+ * pointing to work packages and for recognizing pasted work package URLs.
+ * `proxyUrl` is the address the authorized API requests are sent to. It
+ * defaults to `baseUrl` and only needs to be given if the API traffic has to
+ * be routed through a proxy, for example to inject authorization.
+ */
+export function initOpenProjectApi(config:{ baseUrl:string, proxyUrl?:string }) {
+  baseUrl = stripTrailingSlash(config.baseUrl);
+  proxyUrl = stripTrailingSlash(config.proxyUrl ?? config.baseUrl);
 }
 
 async function get<T>(endpoint:string):Promise<T> {
-  const response = await fetch(`${baseUrl}${endpoint}`, {
+  const response = await fetch(`${proxyUrl}${endpoint}`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
   });

--- a/test/lib/services/openProjectApi.test.ts
+++ b/test/lib/services/openProjectApi.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchStatuses,
   fetchTypes,
@@ -10,10 +10,12 @@ import {
   searchWorkPackages
 } from '../../../lib/services/openProjectApi';
 
-// fetch resolves to a full Response, but the API layer only reads ok, status,
-// statusText and json(), so the stubs cover just those.
 function mockResponse(props:Partial<Response>):Response {
   return props as Response;
+}
+
+function calledUrl(calls:unknown[][], index = 0):string {
+  return calls[index][0] as string;
 }
 
 describe('openProjectApi', () => {
@@ -38,8 +40,8 @@ describe('openProjectApi', () => {
       try {
         searchWorkPackages('test query');
 
-        const calledUrl = fetchSpy.mock.calls[0][0] as string;
-        expect(calledUrl).toContain('sortBy=%5B%5B%22updatedAt%22%2C%22desc%22%5D%5D');
+        const url = calledUrl(fetchSpy.mock.calls);
+        expect(url).toContain('sortBy=%5B%5B%22updatedAt%22%2C%22desc%22%5D%5D');
       } finally {
         fetchSpy.mockRestore();
       }
@@ -102,6 +104,74 @@ describe('openProjectApi', () => {
       expect(parseWorkPackageUrl('http://localhost:3000/wp/abc')).toBeNull();
       expect(parseWorkPackageUrl('http://localhost:3000/wp/0')).toBeNull();
       expect(parseWorkPackageUrl('not a url')).toBeNull();
+    });
+  });
+
+  describe('proxyUrl', () => {
+    const baseUrl = 'https://openproject.example.com';
+    const proxyUrl = 'https://proxy.example.com';
+
+    let fetchSpy = vi.spyOn(global, 'fetch');
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse({
+        ok: true,
+        json: async () => ({ _embedded: { elements: [] } }),
+      }));
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('sends the authorized API requests to the proxyUrl', async () => {
+      initOpenProjectApi({ baseUrl, proxyUrl });
+
+      await fetchStatuses();
+      expect(calledUrl(fetchSpy.mock.calls)).toBe(`${proxyUrl}/api/v3/statuses`);
+
+      await fetchTypes();
+      expect(calledUrl(fetchSpy.mock.calls, 1)).toBe(`${proxyUrl}/api/v3/types`);
+
+      await fetchWorkPackage('DWPS-2');
+      expect(calledUrl(fetchSpy.mock.calls, 2)).toBe(`${proxyUrl}/api/v3/work_packages/DWPS-2`);
+
+      await searchWorkPackages('test query');
+      expect(calledUrl(fetchSpy.mock.calls, 3)).toContain(`${proxyUrl}/api/v3/work_packages?`);
+    });
+
+    it('keeps building work package links from the baseUrl', () => {
+      initOpenProjectApi({ baseUrl, proxyUrl });
+      expect(linkToWorkPackage('42')).toBe(`${baseUrl}/wp/42`);
+    });
+
+    it('only recognizes pasted work package URLs of the baseUrl', () => {
+      initOpenProjectApi({ baseUrl, proxyUrl });
+      expect(parseWorkPackageUrl(`${baseUrl}/wp/123`)).toBe('123');
+      expect(parseWorkPackageUrl(`${proxyUrl}/wp/123`)).toBeNull();
+    });
+
+    it('falls back to the baseUrl for the API requests if no proxyUrl is given', async () => {
+      initOpenProjectApi({ baseUrl, proxyUrl });
+      initOpenProjectApi({ baseUrl });
+
+      await fetchStatuses();
+      expect(calledUrl(fetchSpy.mock.calls)).toBe(`${baseUrl}/api/v3/statuses`);
+    });
+
+    it('works with a proxyUrl with trailing slash', async () => {
+      initOpenProjectApi({ baseUrl: `${baseUrl}/`, proxyUrl: `${proxyUrl}/` });
+
+      await fetchStatuses();
+      expect(calledUrl(fetchSpy.mock.calls)).toBe(`${proxyUrl}/api/v3/statuses`);
+      expect(linkToWorkPackage('42')).toBe(`${baseUrl}/wp/42`);
+    });
+
+    it('strips the trailing slash of the baseUrl it falls back to', async () => {
+      initOpenProjectApi({ baseUrl: `${baseUrl}/` });
+
+      await fetchStatuses();
+      expect(calledUrl(fetchSpy.mock.calls)).toBe(`${baseUrl}/api/v3/statuses`);
     });
   });
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-882

# What are you trying to accomplish?
Routes that need authorization can be routed through a proxy.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
