### PR TITLE
[BNE-119] Bump typescript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "playwright": "^1.61.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "typescript": "~5.9.2",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.64.0",
         "vite": "^7.1.12",
         "vitest": "^4.1.10",
@@ -5852,9 +5852,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "playwright": "^1.61.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "typescript": "~5.9.2",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.64.0",
     "vite": "^7.1.12",
     "vitest": "^4.1.10",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/BNE-119

# What are you trying to accomplish?
Move off `typescript@5.9` as far as the toolchain currently allows. This replaces
dependabot's #198, which proposed `typescript@7.0.2` and cannot work

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
