### PR TITLE
[BNE-119] Bump react-i18next to 17 and @testing-library/user-event to…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^26.3.5",
-        "react-i18next": "^16.3.5",
+        "react-i18next": "^17.0.11",
         "styled-components": "^6.4.3"
       },
       "devDependencies": {
@@ -23,7 +23,7 @@
         "@mantine/utils": "^6.0.22",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
+        "@testing-library/user-event": "^14.6.3",
         "@types/node": "^26.1.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2233,9 +2233,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4146,12 +4146,12 @@
       "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
       "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
+      "funding": {
+        "url": "https://locize.com"
       }
     },
     "node_modules/i18next": {
@@ -5223,19 +5223,19 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.3.5",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.3.5.tgz",
-      "integrity": "sha512-F7Kglc+T0aE6W2rO5eCAFBEuWRpNb5IFmXOYEgztjZEuiuSLTe/xBIEG6Q3S0fbl8GXMNo+Q7gF8bpokFNWJww==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "html-parse-stringify": "^3.0.1",
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 25.6.2",
+        "i18next": ">= 26.2.0",
         "react": ">= 16.8.0",
-        "typescript": "^5"
+        "typescript": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -6217,15 +6217,6 @@
         "@types/react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@mantine/utils": "^6.0.22",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@testing-library/react": "^16.3.2",
-    "@testing-library/user-event": "^14.6.1",
+    "@testing-library/user-event": "^14.6.3",
     "@types/node": "^26.1.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -77,7 +77,7 @@
   "dependencies": {
     "@primer/octicons-react": "^19.20.0",
     "i18next": "^26.3.5",
-    "react-i18next": "^16.3.5",
+    "react-i18next": "^17.0.11",
     "styled-components": "^6.4.3"
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/COMMS/work_packages/BNE-119

# What are you trying to accomplish?
Two remaining updates that dependabot did not deliver:
| package | from | to | 
| --- | --- | --- | 
| `react-i18next` | 16.3.5 | ^17.0.11 |
| `@testing-library/user-event` | 14.6.1 | ^14.6.3 |
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
