### PR TITLE
[COMMS-927] Use new exactMatch order when searching work packages

### DIFF
--- a/lib/services/openProjectApi.ts
+++ b/lib/services/openProjectApi.ts
@@ -98,7 +98,7 @@ export function fetchTypes():Promise<TypeCollection> {
 
 export async function searchWorkPackages(query:string):Promise<WorkPackage[]> {
   const filters = encodeURIComponent(`[{"typeahead":{"operator":"**","values":["${query}"]}}]`);
-  const sortBy = encodeURIComponent('[["updatedAt","desc"]]');
+  const sortBy = encodeURIComponent('[["exactMatch","desc"],["updatedAt","desc"]]');
 
   const endpoint = `/api/v3/work_packages?filters=${filters}&sortBy=${sortBy}`;
   const data = await get<OpenProjectResponse>(endpoint);

--- a/test/lib/services/openProjectApi.test.ts
+++ b/test/lib/services/openProjectApi.test.ts
@@ -41,7 +41,7 @@ describe('openProjectApi', () => {
         searchWorkPackages('test query');
 
         const url = calledUrl(fetchSpy.mock.calls);
-        expect(url).toContain('sortBy=%5B%5B%22updatedAt%22%2C%22desc%22%5D%5D');
+        expect(url).toContain('&sortBy=%5B%5B%22exactMatch%22%2C%22desc%22%5D%2C%5B%22updatedAt%22%2C%22desc%22%5D%5D');
       } finally {
         fetchSpy.mockRestore();
       }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-927

# What are you trying to accomplish?
This will make search results with a exact match appear at the top of the list.

## Screenshots

<img width="816" height="533" alt="image" src="https://github.com/user-attachments/assets/cbdb957f-dbe5-4df4-96ba-13ac4a505033" />

# What approach did you choose and why?
Use the new exact_match search order which was recently implemented in OpenProject (maybe you need to pull to be able to use it)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
