### PR TITLE
[BNE-131] Give feedback when waiting for work package search

### DIFF
--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -3,8 +3,9 @@ import type { SuggestionMenuProps } from '@blocknote/react';
 import styled from 'styled-components';
 import { BlockCard } from '../BlockWorkPackage/BlockCard';
 import { defaultWpVariables } from '../WorkPackage/atoms';
-import type { WorkPackage } from '../../openProjectTypes';
-import type { HashMenuItem } from './types';
+import { SearchMessage } from '../Search/SearchContainer';
+import { Spinner } from '../Spinner';
+import type { HashMenuItem, HashSearchState } from './types';
 import { useTranslation } from 'react-i18next';
 
 /*
@@ -45,38 +46,44 @@ const MenuItem = styled.div<{ $selected:boolean }>`
   }
 `;
 
-const EmptyState = styled.div`
-  padding: var(--spacer-m) var(--spacer-l);
-  font-size: 0.85em;
-  color: var(--bn-colors-highlights-gray-text, #888);
-`;
-
 const MAX_RESULTS = 5;
 
 export function createHashWpMenuComponent(
-  resultsRef:RefObject<WorkPackage[]>,
+  searchStateRef:RefObject<HashSearchState>,
 ):FC<SuggestionMenuProps<HashMenuItem>> {
   const HashWpMenuComponent:FC<SuggestionMenuProps<HashMenuItem>> = ({
     items,
+    loadingState,
     selectedIndex,
     onItemClick,
   }) => {
     const { t } = useTranslation();
-    const searchQuery = items[0]?.title ?? '';
-    const visibleResults = (resultsRef.current ?? []).slice(0, MAX_RESULTS);
+    const { query, results, error } = searchStateRef.current;
+    const visibleResults = results.slice(0, MAX_RESULTS);
 
-    if (!searchQuery) {
+    if (loadingState !== 'loaded') {
       return (
         <Menu>
-          <EmptyState>{t('hashMenu.typeToSearch')}</EmptyState>
+          <SearchMessage>
+            {t('hashMenu.typeToSearch')}
+            <Spinner />
+          </SearchMessage>
         </Menu>
       );
     }
 
-    if (visibleResults.length === 0) {
+    if (!query) {
       return (
         <Menu>
-          <EmptyState>{t('hashMenu.noResults', { query: searchQuery })}</EmptyState>
+          <SearchMessage>{t('hashMenu.typeToSearch')}</SearchMessage>
+        </Menu>
+      );
+    }
+
+    if (error || visibleResults.length === 0) {
+      return (
+        <Menu>
+          <SearchMessage>{error ? t('search.error') : t('search.noResults')}</SearchMessage>
         </Menu>
       );
     }

--- a/lib/components/HashMenu/index.ts
+++ b/lib/components/HashMenu/index.ts
@@ -1,4 +1,4 @@
 export { createHashWpMenuComponent } from './HashWpMenu';
 export { useHashWpMenu } from './useHashWpMenu';
 export { isHashWpQuery } from './types';
-export type { HashMenuItem } from './types';
+export type { HashMenuItem, HashSearchState } from './types';

--- a/lib/components/HashMenu/types.ts
+++ b/lib/components/HashMenu/types.ts
@@ -1,6 +1,14 @@
+import type { WorkPackage } from '../../openProjectTypes';
+
 export interface HashMenuItem {
   title:string;
   onItemClick:() => void;
+}
+
+export interface HashSearchState {
+  query:string;
+  results:WorkPackage[];
+  error:string | null;
 }
 
 export function isHashWpQuery(query:string):boolean {

--- a/lib/components/HashMenu/useHashWpMenu.ts
+++ b/lib/components/HashMenu/useHashWpMenu.ts
@@ -3,38 +3,57 @@ import { useWorkPackageSearch } from '../../hooks/useWorkPackageSearch';
 import { createHashWpMenuComponent } from './HashWpMenu';
 import { isHashWpQuery } from './types';
 import { getSizeFromCurrentBlock, insertWpChip } from './editorUtils';
-import type { HashMenuItem } from './types';
+import type { HashMenuItem, HashSearchState } from './types';
 import type { AnyEditor } from './editorUtils';
-import type { WorkPackage } from '../../openProjectTypes';
 import { cacheColors } from '../../services/colors';
 
 export function useHashWpMenu(editor:AnyEditor) {
   const { search } = useWorkPackageSearch();
-  const searchResultsRef = useRef<WorkPackage[]>([]);
+  const searchStateRef = useRef<HashSearchState>({ query: '', results: [], error: null });
+  const latestQueryRef = useRef('');
 
   const getHashItems = useCallback(
     async (query:string):Promise<HashMenuItem[]> => {
-      if (!isHashWpQuery(query)) return [];
+      latestQueryRef.current = query;
+
+      if (!isHashWpQuery(query)) {
+        searchStateRef.current = { query, results: [], error: null };
+        return [];
+      }
 
       await cacheColors();
 
-      const results = await search(query);
-      searchResultsRef.current = results;
+      try {
+        const results = await search(query);
 
-      const size = getSizeFromCurrentBlock(editor);
-      return results.map((wp) => ({
-        title: query,
-        onItemClick: () => {
-          insertWpChip(editor, wp, size);
-        },
-      }));
+        if (latestQueryRef.current !== query) return [];
+        searchStateRef.current = { query, results, error: null };
+
+        const size = getSizeFromCurrentBlock(editor);
+        return results.map((wp) => ({
+          title: query,
+          onItemClick: () => {
+            insertWpChip(editor, wp, size);
+          },
+        }));
+      } catch (error) {
+        console.error('[work package search] Failed to load work packages from OpenProject:', error);
+        if (latestQueryRef.current === query) {
+          searchStateRef.current = {
+            query,
+            results: [],
+            error: error instanceof Error ? error.message : 'Unknown error',
+          };
+        }
+        return [];
+      }
     },
     [editor, search]
   );
 
   /* eslint-disable react-hooks/refs */
   const HashWpMenu = useMemo(
-    () => createHashWpMenuComponent(searchResultsRef),
+    () => createHashWpMenuComponent(searchStateRef),
     []
   );
   /* eslint-enable react-hooks/refs */

--- a/lib/components/Search/SearchContainer.tsx
+++ b/lib/components/Search/SearchContainer.tsx
@@ -64,6 +64,19 @@ export const SearchInput = styled.input.attrs({
   box-sizing: border-box;
 `;
 
+export const SearchMessage = styled.div.attrs({
+  className: 'op-bn-search--message',
+  role: 'status',
+})`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacer-m);
+  padding: var(--spacer-m) var(--spacer-l);
+  font-size: 0.85em;
+  color: var(--bn-colors-highlights-gray-text, #888);
+`;
+
 export const DropdownList = styled.div`
   overflow: hidden;
   padding-top: var(--spacer-m);

--- a/lib/components/Search/SearchDropdown.tsx
+++ b/lib/components/Search/SearchDropdown.tsx
@@ -7,9 +7,11 @@ import { useWorkPackageSearchDropdown } from '../../hooks/useWorkPackageSearchDr
 import {
   SearchIconWrapper,
   SearchInput,
+  SearchMessage,
   DropdownList,
   DropdownItem,
 } from './SearchContainer';
+import { Spinner } from '../Spinner';
 
 const MAX_RESULTS = 5;
 
@@ -69,6 +71,8 @@ export const SearchDropdown = ({ onSelect, onCancel, autoFocus, renderItem }:Sea
     searchQuery,
     setSearchQuery,
     searchResults,
+    loading,
+    error,
     focusedIndex,
     setFocusedIndex,
     isDropdownOpen,
@@ -114,7 +118,17 @@ export const SearchDropdown = ({ onSelect, onCancel, autoFocus, renderItem }:Sea
             }, 150);
           }}
         />
+
+        {loading && (
+          <SearchIconWrapper>
+            <Spinner />
+          </SearchIconWrapper>
+        )}
       </SearchInputWrapper>
+
+      {isDropdownOpen && !loading && searchResults.length === 0 && (
+        <SearchMessage>{error ? t('search.error') : t('search.noResults')}</SearchMessage>
+      )}
 
       {isDropdownOpen && searchResults.length > 0 && (
         <DropdownList role="listbox" aria-label={t('search.dropdownAriaLabel')}>

--- a/lib/components/Spinner.tsx
+++ b/lib/components/Spinner.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next';
+import styled, { keyframes } from 'styled-components';
+
+const rotate = keyframes`
+  to { transform: rotate(360deg); }
+`;
+
+const SpinnerSvg = styled.svg.attrs({ className: 'op-bn-spinner' })`
+  flex-shrink: 0;
+  animation: ${rotate} 1s linear infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation-duration: 2s;
+  }
+`;
+
+export const Spinner = ({ size = 16 }:{ size?:number }) => {
+  const { t } = useTranslation();
+
+  return (
+    <SpinnerSvg
+      role="img"
+      aria-label={t('spinner.ariaLabel')}
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="7"
+        stroke="currentColor"
+        strokeOpacity="0.25"
+        strokeWidth="2"
+        vectorEffect="non-scaling-stroke"
+      />
+      <path
+        d="M15 8a7.002 7.002 0 0 0-7-7"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </SpinnerSvg>
+  );
+};

--- a/lib/hooks/useWorkPackageSearch.ts
+++ b/lib/hooks/useWorkPackageSearch.ts
@@ -18,6 +18,7 @@ export function useWorkPackageSearch(
 
   // Used to cancel debounce in imperative search()
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingResolveRef = useRef<((results:WorkPackage[]) => void) | null>(null);
 
   // Reactive search (used by SearchDropdown)
   useEffect(() => {
@@ -63,26 +64,31 @@ export function useWorkPackageSearch(
   // Imperative search (used by BlockNote getItems — must return results immediately)
   const search = useCallback(
     (query:string):Promise<WorkPackage[]> => {
+      // A superseded call must still settle, otherwise its caller awaits forever
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      pendingResolveRef.current?.([]);
+      pendingResolveRef.current = null;
+
       if (!query.trim()) {
         setSearchResults([]);
         return Promise.resolve([]);
       }
 
-      if (debounceTimerRef.current !== null) {
-        clearTimeout(debounceTimerRef.current);
-      }
-
       return new Promise<WorkPackage[]>((resolve, reject) => {
+        pendingResolveRef.current = resolve;
         debounceTimerRef.current = setTimeout(async () => {
           debounceTimerRef.current = null;
+          pendingResolveRef.current = null;
           try {
             const results = await searchWorkPackages(query);
             setSearchResults(results);
             resolve(results);
           } catch (error) {
             setSearchResults([]);
-            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-            reject(error);
+            reject(error instanceof Error ? error : new Error(String(error)));
           }
         }, debounce);
       });

--- a/lib/hooks/useWorkPackageSearch.ts
+++ b/lib/hooks/useWorkPackageSearch.ts
@@ -72,16 +72,17 @@ export function useWorkPackageSearch(
         clearTimeout(debounceTimerRef.current);
       }
 
-      return new Promise<WorkPackage[]>((resolve) => {
+      return new Promise<WorkPackage[]>((resolve, reject) => {
         debounceTimerRef.current = setTimeout(async () => {
           debounceTimerRef.current = null;
           try {
             const results = await searchWorkPackages(query);
             setSearchResults(results);
             resolve(results);
-          } catch {
+          } catch (error) {
             setSearchResults([]);
-            resolve([]);
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            reject(error);
           }
         }, debounce);
       });

--- a/lib/hooks/useWorkPackageSearchDropdown.ts
+++ b/lib/hooks/useWorkPackageSearchDropdown.ts
@@ -12,6 +12,8 @@ interface UseWorkPackageSearchDropdownResult {
   searchQuery:string;
   setSearchQuery:(q:string) => void;
   searchResults:WorkPackage[];
+  loading:boolean;
+  error:string | null;
   focusedIndex:number;
   setFocusedIndex:(i:number) => void;
   isDropdownOpen:boolean;
@@ -26,7 +28,7 @@ export function useWorkPackageSearchDropdown({
   onSelect,
   onEscape,
 }:UseWorkPackageSearchDropdownOptions):UseWorkPackageSearchDropdownResult {
-  const { searchQuery, setSearchQuery, searchResults } = useWorkPackageSearch();
+  const { searchQuery, setSearchQuery, searchResults, loading, error } = useWorkPackageSearch();
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -67,6 +69,8 @@ export function useWorkPackageSearchDropdown({
     searchQuery,
     setSearchQuery,
     searchResults,
+    loading,
+    error,
     focusedIndex,
     setFocusedIndex,
     isDropdownOpen,

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -14,6 +14,8 @@ export const en = {
       'label': 'Link existing work package',
       'placeholder': 'Search by work package ID or subject',
       'dropdownAriaLabel': 'Work package search results',
+      'noResults': 'No results',
+      'error': 'Error. Unable to load content.',
     },
     'unavailableWorkPackage': {
       'loading': {
@@ -51,8 +53,10 @@ export const en = {
       'xl': { 'label': 'Full card', 'desc': 'Identifier, Subject, Type, Status, Parent, Project, Description' }
     },
     'hashMenu': {
-      'typeToSearch': 'Type to search work packages…',
-      'noResults': 'No results for "{{query}}"'
+      'typeToSearch': 'Type to search work packages…'
+    },
+    'spinner': {
+      'ariaLabel': 'Loading'
     },
   }
 };

--- a/test/lib/components/integration/hashMenuFeedback.browser.test.tsx
+++ b/test/lib/components/integration/hashMenuFeedback.browser.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { http, HttpResponse, delay } from 'msw';
+import { renderEditor } from '../../../helpers/renderEditor';
+import { openEditorAndType } from '../../../helpers/editorHelpers';
+import { mockWorkPackage } from '../../../mocks/handlers';
+import { worker } from '../../../mocks/browser';
+
+const WORK_PACKAGES_ENDPOINT = 'http://localhost:3000/api/v3/work_packages';
+
+describe('Hash menu - search feedback', () => {
+  afterEach(() => {
+    worker.resetHandlers();
+  });
+
+  it('shows a spinner in the hint box while the search is running', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, async () => {
+        await delay(300);
+        return HttpResponse.json({ _embedded: { elements: [mockWorkPackage] } });
+      })
+    );
+
+    renderEditor();
+    await openEditorAndType('#Fix');
+
+    const spinner = page.getByRole('img', { name: 'Loading' });
+    await expect.element(page.getByText('Type to search work packages…')).toBeVisible();
+    await expect.element(spinner).toBeVisible();
+
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await expect.element(spinner).not.toBeInTheDocument();
+  });
+
+  it('shows "No results" when the search returns nothing', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, () =>
+        HttpResponse.json({ _embedded: { elements: [] } })
+      )
+    );
+
+    renderEditor();
+    await openEditorAndType('#zzz');
+
+    await expect.element(page.getByText('No results')).toBeVisible();
+  });
+
+  it('shows an error message when the search request fails', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, () => HttpResponse.error())
+    );
+
+    renderEditor();
+    await openEditorAndType('#zzz');
+
+    await expect.element(page.getByText('Error. Unable to load content.')).toBeVisible();
+  });
+});

--- a/test/lib/components/integration/searchDropdown.browser.test.tsx
+++ b/test/lib/components/integration/searchDropdown.browser.test.tsx
@@ -1,12 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
+import { http, HttpResponse, delay } from 'msw';
 import { SearchDropdown } from '../../../../lib/components/Search/SearchDropdown';
 import { BlockCard } from '../../../../lib/components/BlockWorkPackage/BlockCard';
 import { mockWorkPackage, mockWorkPackage2 } from '../../../mocks/handlers';
+import { worker } from '../../../mocks/browser';
 import type { WorkPackage } from '../../../../lib/openProjectTypes';
 
 const renderItem = (wp:WorkPackage) => <BlockCard workPackage={wp} inDropdown />;
+
+const WORK_PACKAGES_ENDPOINT = 'http://localhost:3000/api/v3/work_packages';
+
+afterEach(() => {
+  worker.resetHandlers();
+});
 
 describe('SearchDropdown', () => {
   it('shows results after typing', async () => {
@@ -81,6 +89,57 @@ describe('SearchDropdown', () => {
         expect.objectContaining({ id: mockWorkPackage2.id })
     );
     });
+
+  it('shows a spinner while the search is running', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, async () => {
+        await delay(300);
+        return HttpResponse.json({ _embedded: { elements: [mockWorkPackage] } });
+      })
+    );
+
+    render(
+      <SearchDropdown onSelect={vi.fn()} onCancel={vi.fn()} renderItem={renderItem} />
+    );
+
+    await userEvent.type(page.getByRole('searchbox'), 'Fix');
+
+    const spinner = page.getByRole('img', { name: 'Loading' });
+    await expect.element(spinner).toBeVisible();
+
+    await expect.element(page.getByText('Fix login bug')).toBeVisible();
+    await expect.element(spinner).not.toBeInTheDocument();
+  });
+
+  it('shows "No results" when the search returns nothing', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, () =>
+        HttpResponse.json({ _embedded: { elements: [] } })
+      )
+    );
+
+    render(
+      <SearchDropdown onSelect={vi.fn()} onCancel={vi.fn()} renderItem={renderItem} />
+    );
+
+    await userEvent.type(page.getByRole('searchbox'), 'nothing');
+
+    await expect.element(page.getByText('No results')).toBeVisible();
+  });
+
+  it('shows an error message when the search request fails', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, () => HttpResponse.error())
+    );
+
+    render(
+      <SearchDropdown onSelect={vi.fn()} onCancel={vi.fn()} renderItem={renderItem} />
+    );
+
+    await userEvent.type(page.getByRole('searchbox'), 'Fix');
+
+    await expect.element(page.getByText('Error. Unable to load content.')).toBeVisible();
+  });
 
   it('limits results to 5 items maximum', async () => {
     render(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-131

# What are you trying to accomplish?
Work package search gave the user no feedback while a request was in flight, and no way to tell a failed request from an empty result set.

Both search surfaces were affected:

- **`#` hash menu** - showed `No results for "<query>"` the moment you started typing, before the request had even returned. If the API call failed, the same message appeared, so a backend outage looked exactly like a work package that does not exist.
- **Search dropdown** ("Link existing work package") - rendered nothing at all: no spinner while loading, no message when the search came back empty, no message when it failed.

Both now show a spinner while the search runs, `No results` when it returns empty, and `Error. Unable to load content.` when the request fails.

## Screenshots
<img width="452" height="130" alt="image" src="https://github.com/user-attachments/assets/75e6776d-7889-46ca-a075-9bcafbb0f5be" />
<img width="525" height="144" alt="image" src="https://github.com/user-attachments/assets/33c191fa-2442-4f07-a381-37d5ff8d844c" />
<img width="525" height="144" alt="image" src="https://github.com/user-attachments/assets/b7069806-12e3-4f30-b12f-9535a57e1d5d" />
<img width="525" height="144" alt="image" src="https://github.com/user-attachments/assets/91ca13ae-45b6-4200-b40d-798ee061ac55" />
<img width="374" height="83" alt="image" src="https://github.com/user-attachments/assets/e1a47436-3a72-4905-84f6-cb77b927bd8f" />
<img width="460" height="155" alt="image" src="https://github.com/user-attachments/assets/31d34611-fcfe-47a6-b5ea-d2caf891307d" />

# What approach did you choose and why?

**Surfacing state that was already there.** `useWorkPackageSearch` already tracked `loading` and `error`, but no consumer read them. `useWorkPackageSearchDropdown` now passes both through, so the dropdown needed no new state handling.

**The imperative `search()` swallowed failures.** It caught every error and resolved with `[]`, which is the root cause of the hash menu being unable to distinguish "nothing found" from "request failed". It now rejects, normalised to an `Error`, and lets the caller decide what to render.

**The same `search()` could also leave a caller hanging.** Cancelling the debounce for a superseded call cleared its timer without ever settling the promise that call had returned, so `getHashItems` could await a result that would never arrive. The cancellation path now settles the superseded promise with `[]` before starting the new one, and it runs before the empty-query branch as well, so a request can no longer land after the input was cleared. Pre-existing, but it sits directly under the error handling this ticket touches.

**The spinner is Primer's, inlined.** The technical note asks for the same spinner Primer uses. Rather than adding `@primer/react` to a library that consumers embed, `Spinner.tsx` inlines Primer's spinner markup - same `16x16` viewBox, same track circle at 25% opacity, same arc, same `1s linear` rotation - so it is visually the Primer spinner without the dependency weight and without another package version to track. It draws with `currentColor`, so it adapts to the surrounding theme without extra styling.

**One shared look for both surfaces.** The hash menu had its own `EmptyState` while the dropdown had nothing. Both now use a single `SearchMessage` from `SearchContainer` and the same `Spinner`, so the two menus stay visually consistent instead of drifting apart.

**Hash menu state moved into one object.** `createHashWpMenuComponent` used to receive a bare results ref and derive the query from `items[0].title`, which only worked as long as results existed. It now receives a `HashSearchState` ref (`query`, `results`, `error`), typed the same way the hook types its own error, so the empty and error cases are distinguishable and the two paths cannot describe a failure differently. The loading case comes from BlockNote's own `loadingState` prop rather than from state we track ourselves.

**Guarding against out-of-order responses.** `getHashItems` keeps a `latestQueryRef` and drops a response whose query is no longer the current one, so a slow reply to an earlier keystroke cannot overwrite the state of what the user is typing now.

**Copy.** `hashMenu.noResults` was removed - it duplicated the dropdown's message and interpolated the query into it. Both surfaces now share `search.noResults` and `search.error`.

**Accessibility.** The message container is `role="status"` so the outcome is announced, and the spinner carries an `aria-label` from `spinner.ariaLabel` and slows its animation under `prefers-reduced-motion`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

Six new browser tests: spinner while loading, `No results` on an empty response, and the error message on a failed request - for the hash menu and for the search dropdown each.
