### PR TITLE
[BNE-125] Clickling / selecting a work package link block sometimes looks weird on Safari

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Don't try to use prettier!
 
 ## Coding guidelines
 - Always add tests for all changes. For new features, also always add an integration (browser) test. For bugs it can be sufficient to only add a unit test (depending on the bug).
+- Whenever a test needs an editor, always use the shared test editor setup (`test/helpers/renderEditor.tsx`) and the shared helpers in `test/helpers/editorHelpers.ts`. Never add another editor setup, and never hand-roll a fake editor object. Only if a test really, really needs a different setup, use one and document the reason in a comment.
 - Avoid to use abbreviations for variable names unless it's beneficial because the line gets too long otherwise
 - Write code like a senior developer would
 - Always try to solve the requirements by using BlockNote's built-in features / API first. Always check the [BlockNote documentation](https://www.blocknotejs.org/docs) or [source code](https://github.com/TypeCellOS/BlockNote/) before using Prosemirror or Tiptap. Only use Prosemirror or Tiptap if the requirements can not be achieved with BlockNote directly.

--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -18,6 +18,7 @@ import { SearchDropdown } from '../Search/SearchDropdown';
 import { defaultWpVariables } from '../WorkPackage/atoms';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
 import { moveCursorAfterBlock } from '../../utils/cursor';
+import { hideSafariPhantomSelection } from '../../utils/selection';
 import { pendingBlockRegistry } from './pendingBlockRegistry';
 import { useSuppressFormattingToolbar } from '../../hooks/useSuppressFormattingToolbar';
 
@@ -69,6 +70,12 @@ export const BlockWorkPackageComponent = ({
   const selectedBlocks = useSelectedBlocks(editor);
   const isBlockSelected = selectedBlocks.some((b) => b.id === block.id);
   const [isOptionsOpen, setIsOptionsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isBlockSelected) return;
+    hideSafariPhantomSelection(editor);
+    return editor.onSelectionChange(() => hideSafariPhantomSelection(editor));
+  }, [isBlockSelected, editor]);
 
   useSuppressFormattingToolbar(editor, isOptionsOpen);
 

--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -1,8 +1,6 @@
-import type { BlockNoteEditor } from '@blocknote/core';
+import type { AnyEditor } from '../../editorTypes';
 import type { InlineWpSize } from '../WorkPackage/types';
 import type { WorkPackage } from '../../openProjectTypes';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyEditor = BlockNoteEditor<any, any, any>;
 
 interface RawNode {
   type:string;

--- a/lib/components/HashMenu/useHashWpMenu.ts
+++ b/lib/components/HashMenu/useHashWpMenu.ts
@@ -4,7 +4,7 @@ import { createHashWpMenuComponent } from './HashWpMenu';
 import { isHashWpQuery } from './types';
 import { getSizeFromCurrentBlock, insertWpChip } from './editorUtils';
 import type { HashMenuItem, HashSearchState } from './types';
-import type { AnyEditor } from './editorUtils';
+import type { AnyEditor } from '../../editorTypes';
 import { cacheColors } from '../../services/colors';
 
 export function useHashWpMenu(editor:AnyEditor) {

--- a/lib/components/SlashMenu.tsx
+++ b/lib/components/SlashMenu.tsx
@@ -6,7 +6,7 @@ import { registerInlineWpCallbacks, clearInlineWpCallbacks, makePendingWpid } fr
 import { findPendingInlineChip } from '../utils/inlineChipActions';
 import { pendingBlockRegistry } from './BlockWorkPackage/pendingBlockRegistry';
 import { isCurrentBlockEmpty } from '../utils/blockContent.ts';
-import type { AnyEditor } from './HashMenu/editorUtils';
+import type { AnyEditor } from '../editorTypes';
 
 function buildOnSelect(
   editor:AnyEditor,

--- a/lib/editorTypes.ts
+++ b/lib/editorTypes.ts
@@ -1,0 +1,6 @@
+import type { BlockNoteEditor } from '@blocknote/core';
+
+// The schema generics differ per call site and none of our helpers depend on
+// them, so they stay open rather than being threaded through every signature.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyEditor = BlockNoteEditor<any, any, any>;

--- a/lib/plugins/pasteWorkPackageLinkExtension.ts
+++ b/lib/plugins/pasteWorkPackageLinkExtension.ts
@@ -1,9 +1,6 @@
 import { createExtension } from '@blocknote/core';
-import type { BlockNoteEditor } from '@blocknote/core';
+import type { AnyEditor } from '../editorTypes';
 import { pasteWorkPackageLinkPlugin } from './pasteWorkPackageLinkPlugin';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyEditor = BlockNoteEditor<any, any, any>;
 
 /**
  * Registers pasteWorkPackageLinkPlugin at editor construction time. Bundled

--- a/lib/plugins/pasteWorkPackageLinkPlugin.ts
+++ b/lib/plugins/pasteWorkPackageLinkPlugin.ts
@@ -1,14 +1,13 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
 import type { Fragment, Node } from 'prosemirror-model';
 import { contentNodeToInlineContent, isLinkInlineContent, isStyledTextInlineContent } from '@blocknote/core';
-import type { BlockNoteEditor, InlineContent, StyleSchema, StyledText } from '@blocknote/core';
+import type { InlineContent, StyleSchema, StyledText } from '@blocknote/core';
+import type { AnyEditor } from '../editorTypes';
 import type { WorkPackageBlockProps } from '../components/BlockWorkPackage/externalHtml';
 import { fetchWorkPackage, parseWorkPackageUrl } from '../services/openProjectApi';
 import { isCurrentBlockEmpty } from '../utils/blockContent';
 import { moveCursorAfterBlock } from '../utils/cursor';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyEditor = BlockNoteEditor<any, any, any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyInline = InlineContent<any, StyleSchema>;
 

--- a/lib/utils/blockContent.ts
+++ b/lib/utils/blockContent.ts
@@ -1,7 +1,4 @@
-import type { BlockNoteEditor } from '@blocknote/core';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyEditor = BlockNoteEditor<any, any, any>;
+import type { AnyEditor } from '../editorTypes';
 
 export function isCurrentBlockEmpty(editor:AnyEditor):boolean {
   const block = editor.getTextCursorPosition()?.block;

--- a/lib/utils/cursor.ts
+++ b/lib/utils/cursor.ts
@@ -1,7 +1,4 @@
-import type { BlockNoteEditor } from '@blocknote/core';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyEditor = BlockNoteEditor<any, any, any>;
+import type { AnyEditor } from '../editorTypes';
 
 export function moveCursorAfterBlock(editor:AnyEditor, blockId:string):void {
   editor.focus();

--- a/lib/utils/inlineChipActions.ts
+++ b/lib/utils/inlineChipActions.ts
@@ -3,6 +3,7 @@ import type { Node as ProsemirrorNode } from 'prosemirror-model';
 import { NodeSelection } from 'prosemirror-state';
 import type { InlineWpSize, BlockWpSize } from '../components/WorkPackage/types';
 import { moveCursorAfterBlock } from './cursor';
+import { hideSafariPhantomSelection } from './selection';
 import { PENDING_PREFIX } from '../components/InlineWorkPackage/callbacks';
 
 // Direct, position-based operations on inline work package chips.
@@ -21,12 +22,6 @@ type AnyInlineNode = InlineContentFromConfig<any, any>;
 
 const INLINE_WP_TYPE = 'openProjectWorkPackageInline';
 const BLOCK_WP_TYPE = 'openProjectWorkPackageBlock';
-
-const isSafari =
-  typeof navigator !== 'undefined' &&
-  /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-
-interface DomObserver { disconnectSelection:() => void; connectSelection:() => void; setCurSelection:() => void }
 
 export interface FoundInlineChip {
   position:number;
@@ -88,24 +83,7 @@ export function selectInlineChipAt(editor:AnyEditor, position:number):void {
   editor.transact((tr) => {
     tr.setSelection(NodeSelection.create(tr.doc, position));
   });
-  if (!isSafari) return;
-  // Safari renders a phantom selection on contenteditable=false atoms when PM syncs
-  // NodeSelection to the DOM. Collapse the native selection to hide it while keeping
-  // PM's NodeSelection intact (so Cmd+C and Delete still work).
-  // Uses PM's own disconnect→collapseToEnd→setCurSelection→connect bracket to prevent
-  // the selectionchange from being re-read as a state change. collapseToEnd not
-  // removeAllRanges — removeAllRanges blurs the editor and breaks Cmd+C in Safari.
-  // domObserver is a PM internal — missing it degrades to the visual glitch, not a crash.
-  requestAnimationFrame(() => {
-    const domObserver = (editor.prosemirrorView as unknown as { domObserver?:DomObserver }).domObserver;
-    if (!domObserver) return;
-    const nativeSel = window.getSelection();
-    if (!nativeSel || nativeSel.rangeCount === 0) return;
-    domObserver.disconnectSelection();
-    nativeSel.collapseToEnd();
-    domObserver.setCurSelection();
-    domObserver.connectSelection();
-  });
+  hideSafariPhantomSelection(editor);
 }
 
 export function removeInlineChipAt(editor:AnyEditor, position:number):void {

--- a/lib/utils/inlineChipActions.ts
+++ b/lib/utils/inlineChipActions.ts
@@ -1,6 +1,7 @@
-import type { BlockNoteEditor, InlineContentFromConfig } from '@blocknote/core';
+import type { InlineContentFromConfig } from '@blocknote/core';
 import type { Node as ProsemirrorNode } from 'prosemirror-model';
 import { NodeSelection } from 'prosemirror-state';
+import type { AnyEditor } from '../editorTypes';
 import type { InlineWpSize, BlockWpSize } from '../components/WorkPackage/types';
 import { moveCursorAfterBlock } from './cursor';
 import { hideSafariPhantomSelection } from './selection';
@@ -15,8 +16,6 @@ import { PENDING_PREFIX } from '../components/InlineWorkPackage/callbacks';
 // paste-time deduplication. A position uniquely identifies one node instance,
 // so copies are independent by construction.
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyEditor = BlockNoteEditor<any, any, any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyInlineNode = InlineContentFromConfig<any, any>;
 

--- a/lib/utils/selection.ts
+++ b/lib/utils/selection.ts
@@ -1,5 +1,5 @@
-import type { BlockNoteEditor } from '@blocknote/core';
 import type { Node as ProsemirrorNode } from 'prosemirror-model';
+import type { AnyEditor } from '../editorTypes';
 
 /**
  * Selection utilities.
@@ -8,9 +8,6 @@ import type { Node as ProsemirrorNode } from 'prosemirror-model';
  * `window.getSelection()`; it exposes a non-standard `ShadowRoot.getSelection()`
  * instead. Firefox works through `window.getSelection()`.
  */
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyEditor = BlockNoteEditor<any, any, any>;
 
 type ShadowRootWithSelection = ShadowRoot & {
   getSelection:() => Selection | null;

--- a/lib/utils/selection.ts
+++ b/lib/utils/selection.ts
@@ -1,10 +1,16 @@
+import type { BlockNoteEditor } from '@blocknote/core';
+import type { Node as ProsemirrorNode } from 'prosemirror-model';
+
 /**
- * Selection utilities for shadow DOM.
+ * Selection utilities.
  *
- * Chromium does not surface shadow-tree selections through `window.getSelection()`;
- * it exposes a non-standard `ShadowRoot.getSelection()` instead. Firefox works
- * through `window.getSelection()`.
+ * Shadow DOM: Chromium does not surface shadow-tree selections through
+ * `window.getSelection()`; it exposes a non-standard `ShadowRoot.getSelection()`
+ * instead. Firefox works through `window.getSelection()`.
  */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyEditor = BlockNoteEditor<any, any, any>;
 
 type ShadowRootWithSelection = ShadowRoot & {
   getSelection:() => Selection | null;
@@ -23,4 +29,35 @@ export function isNodeInSelection(node:Node):boolean {
   const selection = getSelectionForNode(node);
   if (!selection || selection.rangeCount === 0) return false;
   return selection.getRangeAt(0).intersectsNode(node);
+}
+
+const isSafari =
+  typeof navigator !== 'undefined' &&
+  /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+interface DomObserver { disconnectSelection:() => void; connectSelection:() => void; setCurSelection:() => void }
+
+const WORK_PACKAGE_NODE_TYPES = ['openProjectWorkPackageInline', 'openProjectWorkPackageBlock'];
+
+/** Safari paints a phantom selection over node-selected atoms; collapse it, leaving PM's NodeSelection intact. */
+export function hideSafariPhantomSelection(editor:AnyEditor):void {
+  if (!isSafari) return;
+  requestAnimationFrame(() => {
+    const view = editor.prosemirrorView;
+    if (!view) return;
+
+    const selectedNode = (view.state.selection as { node?:ProsemirrorNode }).node;
+    if (!selectedNode || !WORK_PACKAGE_NODE_TYPES.includes(selectedNode.type.name)) return;
+
+    const domObserver = (view as unknown as { domObserver?:DomObserver }).domObserver;
+    if (!domObserver) return;
+    const nativeSelection = getSelectionForNode(view.dom);
+    if (!nativeSelection || nativeSelection.rangeCount === 0) return;
+
+    domObserver.disconnectSelection();
+    // Not removeAllRanges — it blurs the editor and kills Cmd+C in Safari.
+    nativeSelection.collapseToEnd();
+    domObserver.setCurSelection();
+    domObserver.connectSelection();
+  });
 }

--- a/lib/utils/selection.ts
+++ b/lib/utils/selection.ts
@@ -28,9 +28,11 @@ export function isNodeInSelection(node:Node):boolean {
   return selection.getRangeAt(0).intersectsNode(node);
 }
 
-const isSafari =
-  typeof navigator !== 'undefined' &&
-  /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+// A function, not a module-level const, so a stubbed user agent still takes effect.
+function isSafari():boolean {
+  return typeof navigator !== 'undefined' &&
+    /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+}
 
 interface DomObserver { disconnectSelection:() => void; connectSelection:() => void; setCurSelection:() => void }
 
@@ -38,7 +40,7 @@ const WORK_PACKAGE_NODE_TYPES = ['openProjectWorkPackageInline', 'openProjectWor
 
 /** Safari paints a phantom selection over node-selected atoms; collapse it, leaving PM's NodeSelection intact. */
 export function hideSafariPhantomSelection(editor:AnyEditor):void {
-  if (!isSafari) return;
+  if (!isSafari()) return;
   requestAnimationFrame(() => {
     const view = editor.prosemirrorView;
     if (!view) return;

--- a/test/lib/components/integration/selectionHighlight.browser.test.tsx
+++ b/test/lib/components/integration/selectionHighlight.browser.test.tsx
@@ -1,7 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
+import { NodeSelection } from 'prosemirror-state';
 import { renderEditor } from '../../../helpers/renderEditor';
-import { insertBlockWorkPackageViaSlashMenu } from '../../../helpers/editorHelpers';
+import {
+  insertBlockWorkPackageViaSlashMenu,
+  insertInlineWorkPackageViaSlashMenu,
+  openInlineWorkPackagePopover,
+} from '../../../helpers/editorHelpers';
+import { hideSafariPhantomSelection } from '../../../../lib/utils/selection';
+import type { AnyEditor } from '../../../../lib/editorTypes';
 
 const blockIsSelected = () =>
   document.querySelector('[data-testid="block-wp-wrapper"][data-selected]') !== null;
@@ -36,19 +43,45 @@ describe('Block WP – blue border on focus (BNE-95)', () => {
   });
 });
 
-describe('Block WP - no text highlight on selection (BNE-125)', () => {
-  it('leaves no card text highlighted when the card is clicked', async () => {
+const SAFARI_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15';
+const CHROME_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
+
+const pretendToBeSafari = () => vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(SAFARI_USER_AGENT);
+const pretendNotToBeSafari = () => vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(CHROME_USER_AGENT);
+
+const nativeSelectionIsCollapsed = () => window.getSelection()?.isCollapsed;
+
+const afterCollapseFrame = () =>
+  new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+describe('Work package selection - no phantom text selection (BNE-125)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('collapses the phantom selection when an inline chip is clicked', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaSlashMenu();
+    pretendToBeSafari();
+
+    await openInlineWorkPackagePopover();
+
+    await expect.poll(nativeSelectionIsCollapsed).toBe(true);
+  });
+
+  it('collapses the phantom selection when the card is clicked', async () => {
     renderEditor();
     await insertBlockWorkPackageViaSlashMenu();
     await expect.element(page.getByTestId('block-wp-wrapper')).toBeVisible();
+    pretendToBeSafari();
 
     await userEvent.click(page.getByTestId('op-bn-work-package--type'));
 
     await expect.poll(blockIsSelected).toBe(true);
-    await expect.poll(() => window.getSelection()?.toString()).toBe('');
+    await expect.poll(nativeSelectionIsCollapsed).toBe(true);
   });
 
-  it('leaves no card text highlighted when a selection already spanned the card', async () => {
+  it('collapses the phantom selection when a selection already spanned the card', async () => {
     renderEditor();
     const editorEl = page.getByRole('textbox');
     await userEvent.click(editorEl);
@@ -62,10 +95,65 @@ describe('Block WP - no text highlight on selection (BNE-125)', () => {
     // The card is already part of the selection, so clicking it node-selects it
     // without the selected flag ever flipping.
     await expect.poll(blockIsSelected).toBe(true);
+    pretendToBeSafari();
 
     await userEvent.click(page.getByTestId('op-bn-work-package--type'));
 
     await expect.poll(blockIsSelected).toBe(true);
-    await expect.poll(() => window.getSelection()?.toString()).toBe('');
+    await expect.poll(nativeSelectionIsCollapsed).toBe(true);
+  });
+
+  it('leaves a text selection spanning the card alone', async () => {
+    renderEditor();
+    const editorEl = page.getByRole('textbox');
+    await userEvent.click(editorEl);
+    await userEvent.keyboard('above{Enter}');
+    await insertBlockWorkPackageViaSlashMenu();
+    await userEvent.keyboard('{Enter}below');
+    pretendToBeSafari();
+
+    await userEvent.click(page.getByText('above'));
+    await userEvent.keyboard('{Home}');
+    await userEvent.keyboard('{Shift>}{ArrowDown}{ArrowDown}{ArrowDown}{/Shift}');
+
+    await expect.poll(blockIsSelected).toBe(true);
+    await afterCollapseFrame();
+    expect(nativeSelectionIsCollapsed()).toBe(false);
+  });
+
+  it('leaves a node selection on a foreign node type alone', async () => {
+    let renderedEditor:AnyEditor | undefined;
+    renderEditor({ onEditor: (created) => { renderedEditor = created; } });
+    await insertBlockWorkPackageViaSlashMenu();
+    await expect.element(page.getByTestId('block-wp-wrapper')).toBeVisible();
+
+    const editor = renderedEditor!;
+    editor.insertBlocks([{ type: 'divider' }], editor.document[0], 'after');
+    const view = editor.prosemirrorView;
+    let dividerPosition = -1;
+    view.state.doc.descendants((node, position) => {
+      if (node.type.name === 'divider') dividerPosition = position;
+      return dividerPosition === -1;
+    });
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, dividerPosition)));
+    pretendToBeSafari();
+
+    hideSafariPhantomSelection(editor);
+
+    await afterCollapseFrame();
+    expect(nativeSelectionIsCollapsed()).toBe(false);
+  });
+
+  it('does nothing outside Safari', async () => {
+    renderEditor();
+    await insertBlockWorkPackageViaSlashMenu();
+    await expect.element(page.getByTestId('block-wp-wrapper')).toBeVisible();
+    pretendNotToBeSafari();
+
+    await userEvent.click(page.getByTestId('op-bn-work-package--type'));
+
+    await expect.poll(blockIsSelected).toBe(true);
+    await afterCollapseFrame();
+    expect(nativeSelectionIsCollapsed()).toBe(false);
   });
 });

--- a/test/lib/components/integration/selectionHighlight.browser.test.tsx
+++ b/test/lib/components/integration/selectionHighlight.browser.test.tsx
@@ -35,3 +35,37 @@ describe('Block WP – blue border on focus (BNE-95)', () => {
     await expect.poll(blockIsSelected).toBe(true);
   });
 });
+
+describe('Block WP - no text highlight on selection (BNE-125)', () => {
+  it('leaves no card text highlighted when the card is clicked', async () => {
+    renderEditor();
+    await insertBlockWorkPackageViaSlashMenu();
+    await expect.element(page.getByTestId('block-wp-wrapper')).toBeVisible();
+
+    await userEvent.click(page.getByTestId('op-bn-work-package--type'));
+
+    await expect.poll(blockIsSelected).toBe(true);
+    await expect.poll(() => window.getSelection()?.toString()).toBe('');
+  });
+
+  it('leaves no card text highlighted when a selection already spanned the card', async () => {
+    renderEditor();
+    const editorEl = page.getByRole('textbox');
+    await userEvent.click(editorEl);
+    await userEvent.keyboard('above{Enter}');
+    await insertBlockWorkPackageViaSlashMenu();
+    await userEvent.keyboard('{Enter}below');
+
+    await userEvent.click(page.getByText('above'));
+    await userEvent.keyboard('{Home}');
+    await userEvent.keyboard('{Shift>}{ArrowDown}{ArrowDown}{ArrowDown}{/Shift}');
+    // The card is already part of the selection, so clicking it node-selects it
+    // without the selected flag ever flipping.
+    await expect.poll(blockIsSelected).toBe(true);
+
+    await userEvent.click(page.getByTestId('op-bn-work-package--type'));
+
+    await expect.poll(blockIsSelected).toBe(true);
+    await expect.poll(() => window.getSelection()?.toString()).toBe('');
+  });
+});

--- a/test/lib/utils/selection.test.ts
+++ b/test/lib/utils/selection.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getSelectionForNode, isNodeInSelection } from '../../../lib/utils/selection.ts';
 
 describe('getSelectionForNode', () => {
@@ -105,5 +105,107 @@ describe('isNodeInSelection', () => {
     selection.addRange(range);
 
     expect(isNodeInSelection(outside)).toBe(false);
+  });
+});
+
+const SAFARI_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15';
+const CHROME_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
+
+async function importWithUserAgent(userAgent:string) {
+  vi.stubGlobal('navigator', { userAgent });
+  vi.resetModules();
+  return import('../../../lib/utils/selection.ts');
+}
+
+describe('hideSafariPhantomSelection', () => {
+  let observerCalls:string[];
+
+  function fakeEditor(selectedNodeType?:string) {
+    const editorDom = document.createElement('div');
+    document.body.appendChild(editorDom);
+
+    return {
+      prosemirrorView: {
+        dom: editorDom,
+        domObserver: {
+          disconnectSelection: () => observerCalls.push('disconnectSelection'),
+          setCurSelection: () => observerCalls.push('setCurSelection'),
+          connectSelection: () => observerCalls.push('connectSelection'),
+        },
+        state: {
+          selection: selectedNodeType ? { node: { type: { name: selectedNodeType } } } : {},
+        },
+      },
+    } as never;
+  }
+
+  function selectCardText():Selection {
+    const card = document.createElement('div');
+    card.textContent = 'BUG #123 Fix login bug';
+    document.body.appendChild(card);
+
+    const range = document.createRange();
+    range.selectNodeContents(card);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    return selection;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    observerCalls = [];
+    vi.stubGlobal('requestAnimationFrame', (callback:FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it.each(['openProjectWorkPackageBlock', 'openProjectWorkPackageInline'])(
+    'collapses the phantom selection on Safari when %s is node-selected',
+    async (nodeType) => {
+      const { hideSafariPhantomSelection } = await importWithUserAgent(SAFARI_USER_AGENT);
+      const selection = selectCardText();
+
+      hideSafariPhantomSelection(fakeEditor(nodeType));
+
+      expect(selection.isCollapsed).toBe(true);
+      expect(observerCalls).toEqual(['disconnectSelection', 'setCurSelection', 'connectSelection']);
+    }
+  );
+
+  it('leaves a text selection spanning the node alone', async () => {
+    const { hideSafariPhantomSelection } = await importWithUserAgent(SAFARI_USER_AGENT);
+    const selection = selectCardText();
+
+    hideSafariPhantomSelection(fakeEditor());
+
+    expect(selection.isCollapsed).toBe(false);
+    expect(observerCalls).toEqual([]);
+  });
+
+  it('leaves a node selection on a foreign node type alone', async () => {
+    const { hideSafariPhantomSelection } = await importWithUserAgent(SAFARI_USER_AGENT);
+    const selection = selectCardText();
+
+    hideSafariPhantomSelection(fakeEditor('image'));
+
+    expect(selection.isCollapsed).toBe(false);
+    expect(observerCalls).toEqual([]);
+  });
+
+  it('does nothing outside Safari', async () => {
+    const { hideSafariPhantomSelection } = await importWithUserAgent(CHROME_USER_AGENT);
+    const selection = selectCardText();
+
+    hideSafariPhantomSelection(fakeEditor('openProjectWorkPackageBlock'));
+
+    expect(selection.isCollapsed).toBe(false);
+    expect(observerCalls).toEqual([]);
   });
 });

--- a/test/lib/utils/selection.test.ts
+++ b/test/lib/utils/selection.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getSelectionForNode, isNodeInSelection } from '../../../lib/utils/selection.ts';
 
 describe('getSelectionForNode', () => {
@@ -105,107 +105,5 @@ describe('isNodeInSelection', () => {
     selection.addRange(range);
 
     expect(isNodeInSelection(outside)).toBe(false);
-  });
-});
-
-const SAFARI_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15';
-const CHROME_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
-
-async function importWithUserAgent(userAgent:string) {
-  vi.stubGlobal('navigator', { userAgent });
-  vi.resetModules();
-  return import('../../../lib/utils/selection.ts');
-}
-
-describe('hideSafariPhantomSelection', () => {
-  let observerCalls:string[];
-
-  function fakeEditor(selectedNodeType?:string) {
-    const editorDom = document.createElement('div');
-    document.body.appendChild(editorDom);
-
-    return {
-      prosemirrorView: {
-        dom: editorDom,
-        domObserver: {
-          disconnectSelection: () => observerCalls.push('disconnectSelection'),
-          setCurSelection: () => observerCalls.push('setCurSelection'),
-          connectSelection: () => observerCalls.push('connectSelection'),
-        },
-        state: {
-          selection: selectedNodeType ? { node: { type: { name: selectedNodeType } } } : {},
-        },
-      },
-    } as never;
-  }
-
-  function selectCardText():Selection {
-    const card = document.createElement('div');
-    card.textContent = 'BUG #123 Fix login bug';
-    document.body.appendChild(card);
-
-    const range = document.createRange();
-    range.selectNodeContents(card);
-    const selection = window.getSelection()!;
-    selection.removeAllRanges();
-    selection.addRange(range);
-    return selection;
-  }
-
-  beforeEach(() => {
-    document.body.innerHTML = '';
-    observerCalls = [];
-    vi.stubGlobal('requestAnimationFrame', (callback:FrameRequestCallback) => {
-      callback(0);
-      return 0;
-    });
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.resetModules();
-  });
-
-  it.each(['openProjectWorkPackageBlock', 'openProjectWorkPackageInline'])(
-    'collapses the phantom selection on Safari when %s is node-selected',
-    async (nodeType) => {
-      const { hideSafariPhantomSelection } = await importWithUserAgent(SAFARI_USER_AGENT);
-      const selection = selectCardText();
-
-      hideSafariPhantomSelection(fakeEditor(nodeType));
-
-      expect(selection.isCollapsed).toBe(true);
-      expect(observerCalls).toEqual(['disconnectSelection', 'setCurSelection', 'connectSelection']);
-    }
-  );
-
-  it('leaves a text selection spanning the node alone', async () => {
-    const { hideSafariPhantomSelection } = await importWithUserAgent(SAFARI_USER_AGENT);
-    const selection = selectCardText();
-
-    hideSafariPhantomSelection(fakeEditor());
-
-    expect(selection.isCollapsed).toBe(false);
-    expect(observerCalls).toEqual([]);
-  });
-
-  it('leaves a node selection on a foreign node type alone', async () => {
-    const { hideSafariPhantomSelection } = await importWithUserAgent(SAFARI_USER_AGENT);
-    const selection = selectCardText();
-
-    hideSafariPhantomSelection(fakeEditor('image'));
-
-    expect(selection.isCollapsed).toBe(false);
-    expect(observerCalls).toEqual([]);
-  });
-
-  it('does nothing outside Safari', async () => {
-    const { hideSafariPhantomSelection } = await importWithUserAgent(CHROME_USER_AGENT);
-    const selection = selectCardText();
-
-    hideSafariPhantomSelection(fakeEditor('openProjectWorkPackageBlock'));
-
-    expect(selection.isCollapsed).toBe(false);
-    expect(observerCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-125

# What are you trying to accomplish?

In Safari, clicking a block work package card sometimes highlighted the card's text as a text selection instead of only drawing the blue outline. This is the same defect as for inline work package, which was already fixed.

# What approach did you choose and why?

**Root cause.** ProseMirror syncs a `NodeSelection` to the DOM as a range spanning the node. WebKit paints that range as a text selection over the `contenteditable=false` atom, even though the wrapper is `user-select: none`;
Chromium and Firefox do not. It only happened *sometimes* because when the caret sat in an adjacent paragraph, ProseMirror synced a collapsed range instead.

**Solution.** As the ticket asked, the inline fix is reused rather than copied: it moved out of `selectInlineChipAt` into a shared `hideSafariPhantomSelection` helper that both call sites use. The helper now also verifies that the current
selection really is a `NodeSelection` on a work package node, so a text selection merely spanning a card keeps its legitimate highlight.

The card has no explicit "select" call site - ProseMirror owns the click - so it reacts to selection changes while it is part of the selection. Reacting only to "became selected" was not enough: clicking a card that a text selection already spans node-selects it without that flag ever flipping.

**Small refactoring on the side.** Placing the shared helper would have created an eighth copy of the `BlockNoteEditor<any, any, any>` alias, so it moved into a neutral `lib/editorTypes.ts` instead. Seven modules each redeclared it with its own `no-explicit-any` suppression, and the single exported copy sat in `components/HashMenu` - which utils and plugins cannot import from without inverting the dependency direction, which is why the copies existed. Type-only change, the published interface is unchanged.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
