### PR TITLE
[COMMS-953] "No results" feedback in the hash menu is unreachable for longer queries

### DIFF
--- a/lib/components/HashMenu/editorUtils.ts
+++ b/lib/components/HashMenu/editorUtils.ts
@@ -66,6 +66,12 @@ export function insertWpChip(editor:AnyEditor, wp:WorkPackage, size:InlineWpSize
   editor.focus();
 }
 
+export function restoreHashQuery(editor:AnyEditor, query:string):void {
+  (editor.insertInlineContent as (content:unknown[]) => void)([
+    { type: 'text', text: `#${query}`, styles: {} },
+  ]);
+}
+
 /**
  * Removes the leftover trigger hashes (`#`/`##`) that BlockNote's suggestion menu
  * leaves directly before the chip for `##`/`###` triggers.

--- a/lib/components/HashMenu/useHashWpMenu.ts
+++ b/lib/components/HashMenu/useHashWpMenu.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef } from 'react';
 import { useWorkPackageSearch } from '../../hooks/useWorkPackageSearch';
 import { createHashWpMenuComponent } from './HashWpMenu';
 import { isHashWpQuery } from './types';
-import { getSizeFromCurrentBlock, insertWpChip } from './editorUtils';
+import { getSizeFromCurrentBlock, insertWpChip, restoreHashQuery } from './editorUtils';
 import type { HashMenuItem, HashSearchState } from './types';
 import type { AnyEditor } from './editorUtils';
 import { cacheColors } from '../../services/colors';
@@ -12,13 +12,23 @@ export function useHashWpMenu(editor:AnyEditor) {
   const searchStateRef = useRef<HashSearchState>({ query: '', results: [], error: null });
   const latestQueryRef = useRef('');
 
+  const placeholderItems = useCallback(
+    (query:string):HashMenuItem[] => [{
+      title: query,
+      onItemClick: () => {
+        restoreHashQuery(editor, query);
+      },
+    }],
+    [editor]
+  );
+
   const getHashItems = useCallback(
     async (query:string):Promise<HashMenuItem[]> => {
       latestQueryRef.current = query;
 
       if (!isHashWpQuery(query)) {
         searchStateRef.current = { query, results: [], error: null };
-        return [];
+        return placeholderItems(query);
       }
 
       await cacheColors();
@@ -28,6 +38,8 @@ export function useHashWpMenu(editor:AnyEditor) {
 
         if (latestQueryRef.current !== query) return [];
         searchStateRef.current = { query, results, error: null };
+
+        if (results.length === 0) return placeholderItems(query);
 
         const size = getSizeFromCurrentBlock(editor);
         return results.map((wp) => ({
@@ -45,10 +57,10 @@ export function useHashWpMenu(editor:AnyEditor) {
             error: error instanceof Error ? error.message : 'Unknown error',
           };
         }
-        return [];
+        return placeholderItems(query);
       }
     },
-    [editor, search]
+    [editor, search, placeholderItems]
   );
 
   /* eslint-disable react-hooks/refs */

--- a/test/lib/components/integration/hashMenuFeedback.browser.test.tsx
+++ b/test/lib/components/integration/hashMenuFeedback.browser.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { http, HttpResponse, delay } from 'msw';
 import { renderEditor } from '../../../helpers/renderEditor';
 import { openEditorAndType } from '../../../helpers/editorHelpers';
@@ -7,6 +7,8 @@ import { mockWorkPackage } from '../../../mocks/handlers';
 import { worker } from '../../../mocks/browser';
 
 const WORK_PACKAGES_ENDPOINT = 'http://localhost:3000/api/v3/work_packages';
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 500));
 
 describe('Hash menu - search feedback', () => {
   afterEach(() => {
@@ -43,6 +45,38 @@ describe('Hash menu - search feedback', () => {
     await openEditorAndType('#zzz');
 
     await expect.element(page.getByText('No results')).toBeVisible();
+  });
+
+  it('keeps showing "No results" for a six character query', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, () =>
+        HttpResponse.json({ _embedded: { elements: [] } })
+      )
+    );
+
+    renderEditor();
+    await openEditorAndType('#zzzzzz');
+
+    await expect.element(page.getByText('No results')).toBeVisible();
+    await settle();
+    await expect.element(page.getByText('No results')).toBeVisible();
+  });
+
+  it('keeps the typed query when the menu is dismissed with Enter', async () => {
+    worker.use(
+      http.get(WORK_PACKAGES_ENDPOINT, () =>
+        HttpResponse.json({ _embedded: { elements: [] } })
+      )
+    );
+
+    renderEditor();
+    await openEditorAndType('#zzz');
+
+    await expect.element(page.getByText('No results')).toBeVisible();
+    await userEvent.keyboard('{Enter}');
+
+    await expect.element(page.getByText('No results')).not.toBeInTheDocument();
+    await expect.element(page.getByRole('textbox')).toHaveTextContent('#zzz');
   });
 
   it('shows an error message when the search request fails', async () => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-953

# What approach did you choose and why?
Root cause is in BlockNote, not in our code. `SuggestionMenuWrapper` calls `useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu)` and closes the menu as soon as a query returns no items and is more than three characters
longer than the last query that did return some. The threshold is a default argument that `SuggestionMenuController` does not expose - not in our 0.51.3 and not in the current 0.53.0 either. The exact character count where the menu
dies is not fixed, because the comparison is against the last query that found something.

The only lever the public API leaves is the items array: any non-empty result keeps the menu alive. So every state that renders a message instead of results now returns a single placeholder item. Nothing about the rendered menu changes - it already draws itself from the search state, not from the items.

The alternatives were worse. Reimplementing the controller means copying roughly 150 lines of BlockNote's popover and floating-ui plumbing into this repo and re-checking it on every version bump; patching the package means
editing third-party code to change a default argument. Both trade one quiet risk for a permanent maintenance cost. The proper fix is upstream exposing the threshold as a prop, at which point this workaround comes out in one line.

Code from node_modules/@blocknote/react/src/components/SuggestionMenu/hooks/useCloseSuggestionMenuNoItems.ts
```ts
import { useEffect, useRef } from "react";

// Hook which closes the suggestion after a certain number of consecutive
// invalid queries are made. An invalid query is one which returns no items, and
// each invalid query must be longer than the previous one to close the menu
export function useCloseSuggestionMenuNoItems<Item>(
  items: Item[],
  usedQuery: string | undefined,
  closeMenu: () => void,
  invalidQueries = 3,
) {
  const lastUsefulQueryLength = useRef(0);

  useEffect(() => {
    if (usedQuery === undefined) {
      return;
    }

    if (items.length > 0) {
      lastUsefulQueryLength.current = usedQuery.length;
    } else if (
      usedQuery.length - lastUsefulQueryLength.current >
      invalidQueries
    ) {
      closeMenu();
    }
  }, [closeMenu, invalidQueries, items.length, usedQuery]);
}
```

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
