### PR TITLE
[BNE-126] Context menu scrolls over header on mobile

### DIFF
--- a/lib/components/CreateWorkPackage/AllowedValuesTypeahead.tsx
+++ b/lib/components/CreateWorkPackage/AllowedValuesTypeahead.tsx
@@ -28,7 +28,6 @@ interface SuggestionsProps {
   optionId:(index:number) => string;
   onFocusIndex:(index:number) => void;
   onPick:(option:AllowedValue) => void;
-  onClose:() => void;
   children:React.ReactNode;
 }
 
@@ -41,7 +40,6 @@ const Suggestions = ({
   optionId,
   onFocusIndex,
   onPick,
-  onClose,
   children,
 }:SuggestionsProps) => {
   const listRef = useRef<HTMLDivElement>(null);
@@ -51,8 +49,6 @@ const Suggestions = ({
     popoverRef: listRef,
     placement: 'below',
     offset: LIST_OFFSET,
-    onClose,
-    closeOnScroll: false,
     matchAnchorWidth: true,
     maxHeight: MAX_LIST_HEIGHT,
     resizeKey: options.length,
@@ -241,7 +237,6 @@ export const AllowedValuesTypeahead = ({
           optionId={optionId}
           onFocusIndex={setFocusedIndex}
           onPick={select}
-          onClose={() => setIsOpen(false)}
         >
           {loading ? t('createWorkPackage.loading') : t('createWorkPackage.noResults')}
         </Suggestions>

--- a/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
+++ b/lib/components/InlineWorkPackage/InlineWorkPackageChip.tsx
@@ -194,7 +194,6 @@ export const InlineWorkPackageChip = ({ inlineContent, contentRef, editor, updat
           <WpPreviewPopover
             // eslint-disable-next-line react-hooks/refs
             anchorEl={chipRef.current}
-            onClose={closePreview}
             {...cardProps}
           >
             <BlockCard workPackage={wp} size="m" linkTitle />

--- a/lib/components/InlineWorkPackage/UnavailableChip.tsx
+++ b/lib/components/InlineWorkPackage/UnavailableChip.tsx
@@ -38,7 +38,7 @@ export const UnavailableChip = ({
   optionsPopover,
 }:UnavailableChipProps) => {
   const { t } = useTranslation();
-  const { previewOpen, closePreview, triggerProps, cardProps } = preview;
+  const { previewOpen, triggerProps, cardProps } = preview;
 
   const inlineIcon = kind === 'unauthorized'
     ? <EyeClosedIcon size={12} verticalAlign="middle" />
@@ -81,7 +81,6 @@ export const UnavailableChip = ({
       {showPreview && (
         <WpPreviewPopover
           anchorEl={anchorEl}
-          onClose={closePreview}
           {...cardProps}
         >
           <UnavailableCard

--- a/lib/components/Search/SearchContainer.tsx
+++ b/lib/components/Search/SearchContainer.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { defaultWpVariables } from '../WorkPackage/atoms';
+import { FLOATING_Z_INDEX } from '../WorkPackage/tokens';
 
 export const SEARCH_INPUT_ID = 'op-bn-wp-search-input';
 
@@ -15,7 +16,7 @@ export const SearchContainer = styled.div.attrs({
 })<{ $floating?:boolean }>`
   ${defaultWpVariables}
   position: ${({ $floating }) => ($floating ? 'absolute' : 'relative')};
-  z-index: ${({ $floating }) => ($floating ? 9999 : 'auto')};
+  z-index: ${({ $floating }) => ($floating ? FLOATING_Z_INDEX.search : 'auto')};
   top: ${({ $floating }) => ($floating ? '1.6em' : 'auto')};
   left: ${({ $floating }) => ($floating ? 0 : 'auto')};
   overflow: ${({ $floating }) => ($floating ? 'hidden' : 'visible')};

--- a/lib/components/Search/SearchContainer.tsx
+++ b/lib/components/Search/SearchContainer.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { defaultWpVariables } from '../WorkPackage/atoms';
-import { FLOATING_Z_INDEX } from '../WorkPackage/tokens';
+import { FLOATING_Z_INDEX } from '../../utils/zIndex';
 
 export const SEARCH_INPUT_ID = 'op-bn-wp-search-input';
 

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -6,13 +6,13 @@ import type { InlineWpSize, BlockWpSize } from './types';
 import styled from 'styled-components';
 import { defaultWpVariables } from './atoms';
 import { useAnchoredPopover, PopoverPortal } from './anchoredPopover';
+import { FLOATING_Z_INDEX } from './tokens';
 import {
   LinkExternalIcon,
   TrashIcon,
   ChevronDownIcon,
 } from '@primer/octicons-react';
 import {formatWorkPackageId} from '../../utils/id';
-import { supportsHover } from '../../utils/device';
 
 export interface WpOptionsProps {
   wp?:WorkPackage;
@@ -37,7 +37,7 @@ const Popover = styled.div.attrs({
 })`
   ${defaultWpVariables}
   position: absolute;
-  z-index: 9999;
+  z-index: ${FLOATING_Z_INDEX.options};
   background-color: var(--bn-colors-menu-background, #fff);
   box-shadow: var(--bn-shadow-medium);
   border-radius: var(--bn-border-radius-large);
@@ -93,7 +93,7 @@ const SizeMenu = styled.div.attrs<{
   position: absolute;
   top: calc(100% + var(--spacer-s));
   left: 0;
-  z-index: 10000;
+  z-index: 1;
   background: var(--bn-colors-menu-background, #fff);
   box-shadow: var(--bn-shadow-medium);
   border-radius: var(--bn-border-radius-large);
@@ -164,13 +164,7 @@ export const WpOptionsPopover = ({
   const [showSizes, setShowSizes] = useState(false);
 
   const popoverRef = useRef<HTMLDivElement | null>(null);
-  useAnchoredPopover({
-    anchorEl,
-    popoverRef,
-    placement: 'above',
-    onClose,
-    closeOnScroll: supportsHover(),
-  });
+  useAnchoredPopover({ anchorEl, popoverRef, placement: 'above' });
 
   const isBlock = currentSize === undefined;
 

--- a/lib/components/WorkPackage/OptionsPopover.tsx
+++ b/lib/components/WorkPackage/OptionsPopover.tsx
@@ -6,7 +6,7 @@ import type { InlineWpSize, BlockWpSize } from './types';
 import styled from 'styled-components';
 import { defaultWpVariables } from './atoms';
 import { useAnchoredPopover, PopoverPortal } from './anchoredPopover';
-import { FLOATING_Z_INDEX } from './tokens';
+import { FLOATING_Z_INDEX } from '../../utils/zIndex';
 import {
   LinkExternalIcon,
   TrashIcon,

--- a/lib/components/WorkPackage/PreviewPopover.tsx
+++ b/lib/components/WorkPackage/PreviewPopover.tsx
@@ -2,6 +2,7 @@ import { useRef, type ReactNode } from 'react';
 import styled from 'styled-components';
 import { defaultWpVariables } from './atoms';
 import { useAnchoredPopover, PopoverPortal } from './anchoredPopover';
+import { FLOATING_Z_INDEX } from './tokens';
 
 const PreviewContainer = styled.div.attrs({
   className: 'op-bn-wp-preview',
@@ -9,7 +10,7 @@ const PreviewContainer = styled.div.attrs({
 })`
   ${defaultWpVariables}
   position: absolute;
-  z-index: 9999;
+  z-index: ${FLOATING_Z_INDEX.preview};
   top: calc(100% + 6px);
   left: 0;
   width: max-content;
@@ -23,7 +24,6 @@ const PreviewContainer = styled.div.attrs({
 
 export interface WpPreviewPopoverProps {
   anchorEl?:HTMLElement | null;
-  onClose:() => void;
   onMouseEnter?:() => void;
   onMouseLeave?:() => void;
   children:ReactNode;
@@ -32,18 +32,12 @@ export interface WpPreviewPopoverProps {
 // Hover/long-press preview for tiny (xxs) inline chips.
 export const WpPreviewPopover = ({
   anchorEl,
-  onClose,
   onMouseEnter,
   onMouseLeave,
   children,
 }:WpPreviewPopoverProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  useAnchoredPopover({
-    anchorEl,
-    popoverRef: containerRef,
-    placement: 'below',
-    onClose,
-  });
+  useAnchoredPopover({ anchorEl, popoverRef: containerRef, placement: 'below' });
 
   return (
     <PopoverPortal anchorEl={anchorEl}>

--- a/lib/components/WorkPackage/PreviewPopover.tsx
+++ b/lib/components/WorkPackage/PreviewPopover.tsx
@@ -2,7 +2,7 @@ import { useRef, type ReactNode } from 'react';
 import styled from 'styled-components';
 import { defaultWpVariables } from './atoms';
 import { useAnchoredPopover, PopoverPortal } from './anchoredPopover';
-import { FLOATING_Z_INDEX } from './tokens';
+import { FLOATING_Z_INDEX } from '../../utils/zIndex';
 
 const PreviewContainer = styled.div.attrs({
   className: 'op-bn-wp-preview',

--- a/lib/components/WorkPackage/anchoredPopover.tsx
+++ b/lib/components/WorkPackage/anchoredPopover.tsx
@@ -163,13 +163,20 @@ export const useAnchoredPopover = ({
       frame = requestAnimationFrame(() => { frame = 0; update(); });
     };
 
+    const handleScroll = () => {
+      const popover = popoverRef.current;
+      if (popover && getComputedStyle(popover).position === 'fixed') scheduleUpdate();
+    };
+
     update();
+    window.addEventListener('scroll', handleScroll, true);
     window.addEventListener('resize', scheduleUpdate);
     return () => {
       if (frame) cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', handleScroll, true);
       window.removeEventListener('resize', scheduleUpdate);
     };
-  }, [anchorEl]);
+  }, [anchorEl, popoverRef]);
 
   // Position before paint so the popover never flashes at its CSS fallback spot.
   useLayoutEffect(() => {

--- a/lib/components/WorkPackage/anchoredPopover.tsx
+++ b/lib/components/WorkPackage/anchoredPopover.tsx
@@ -8,8 +8,20 @@ import {
 import { createPortal } from 'react-dom';
 
 const DEFAULT_ANCHOR_OFFSET = 6;
-const VIEWPORT_MARGIN = 8;
+const CLIP_MARGIN = 8;
 const MIN_POPOVER_HEIGHT = 80;
+
+type Side = 'above' | 'below';
+
+interface VisibleRect {
+  top:number;
+  left:number;
+  right:number;
+  bottom:number;
+}
+
+const clamp = (value:number, min:number, max:number):number =>
+  Math.max(min, Math.min(value, max));
 
 // For a chip wrapped across lines, getBoundingClientRect() returns the union of
 // its line fragments (left edge = start of line). The first fragment is where
@@ -17,14 +29,105 @@ const MIN_POPOVER_HEIGHT = 80;
 const getAnchorRect = (el:HTMLElement):DOMRect =>
   el.getClientRects()[0] ?? el.getBoundingClientRect();
 
+const isSameRect = (a:DOMRect, b:DOMRect):boolean =>
+  a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height;
+
+const getParentElement = (element:Element):Element | null => {
+  if (element.parentElement) return element.parentElement;
+  const root = element.getRootNode();
+  return root instanceof ShadowRoot ? root.host : null;
+};
+
+// A fixed popover is taken out of the flow, so only the viewport clips it; an
+// absolute one is also clipped by every scrolling ancestor above it.
+const getVisibleRect = (element:HTMLElement):VisibleRect => {
+  const visible:VisibleRect = {
+    top: 0,
+    left: 0,
+    right: window.innerWidth,
+    bottom: window.innerHeight,
+  };
+
+  if (getComputedStyle(element).position === 'fixed') return visible;
+
+  for (let parent = getParentElement(element); parent; parent = getParentElement(parent)) {
+    const { overflowX, overflowY } = getComputedStyle(parent);
+    if (overflowX === 'visible' && overflowY === 'visible') continue;
+
+    const rect = parent.getBoundingClientRect();
+    visible.top = Math.max(visible.top, rect.top);
+    visible.left = Math.max(visible.left, rect.left);
+    visible.right = Math.min(visible.right, rect.right);
+    visible.bottom = Math.min(visible.bottom, rect.bottom);
+  }
+
+  return visible;
+};
+
+const getSpaces = (
+  anchorRect:DOMRect,
+  visible:VisibleRect,
+  offset:number,
+):Record<Side, number> => ({
+  above: anchorRect.top - visible.top - offset - CLIP_MARGIN,
+  below: visible.bottom - anchorRect.bottom - offset - CLIP_MARGIN,
+});
+
+const resolveSide = (preferred:Side, height:number, spaces:Record<Side, number>):Side => {
+  if (height <= spaces[preferred]) return preferred;
+
+  return spaces.above >= spaces.below ? 'above' : 'below';
+};
+
+// Where the popover lands with no offsets applied, so the styles below can be
+// expressed in viewport coordinates whatever the containing block is.
+const getOrigin = (popover:HTMLElement):DOMRect => {
+  popover.style.bottom = 'auto';
+  popover.style.left = '0px';
+  popover.style.top = '0px';
+
+  return popover.getBoundingClientRect();
+};
+
+const positionPopover = (
+  popover:HTMLElement,
+  anchorRect:DOMRect,
+  placement:Side,
+  offset:number,
+  maxHeight?:number,
+) => {
+  // Undo an earlier run's cap first - the side is chosen from the natural height.
+  if (maxHeight !== undefined) popover.style.maxHeight = `${maxHeight}px`;
+
+  const origin = getOrigin(popover);
+  const visible = getVisibleRect(popover);
+  const spaces = getSpaces(anchorRect, visible, offset);
+  const side = resolveSide(placement, popover.offsetHeight, spaces);
+
+  if (maxHeight !== undefined) {
+    popover.style.maxHeight = `${Math.min(maxHeight, Math.max(MIN_POPOVER_HEIGHT, spaces[side]))}px`;
+  }
+
+  // Read after the cap, or a shortened popover would be placed by its full height.
+  const { offsetWidth: width, offsetHeight: height } = popover;
+
+  const anchoredTop = side === 'above'
+    ? anchorRect.top - offset - height
+    : anchorRect.bottom + offset;
+
+  // Clamping keeps every button reachable where the popover would still cross an edge.
+  const left = clamp(anchorRect.left, visible.left + CLIP_MARGIN, visible.right - width - CLIP_MARGIN);
+  const top = clamp(anchoredTop, visible.top + CLIP_MARGIN, visible.bottom - height - CLIP_MARGIN);
+
+  popover.style.left = `${left - origin.left}px`;
+  popover.style.top = `${top - origin.top}px`;
+};
+
 export interface AnchoredPopoverOptions {
   anchorEl?:HTMLElement | null;
   popoverRef:RefObject<HTMLElement | null>;
   placement:'above' | 'below';
   offset?:number;
-  onClose:() => void;
-  // When false, a scroll repositions the popover instead of closing it.
-  closeOnScroll?:boolean;
   matchAnchorWidth?:boolean;
   maxHeight?:number;
   // Any value that changes when the content changes size.
@@ -36,8 +139,6 @@ export const useAnchoredPopover = ({
   popoverRef,
   placement,
   offset = DEFAULT_ANCHOR_OFFSET,
-  onClose,
-  closeOnScroll = true,
   matchAnchorWidth = false,
   maxHeight,
   resizeKey,
@@ -48,25 +149,27 @@ export const useAnchoredPopover = ({
 
   useEffect(() => {
     if (!anchorEl) return;
-    const update = () => setAnchorRect(getAnchorRect(anchorEl));
+    // The chip rerenders on every editor transaction, and a fresh DOMRect would
+    // reposition the popover on each of them.
+    const update = () => setAnchorRect((previous) => {
+      const next = getAnchorRect(anchorEl);
+      return previous && isSameRect(previous, next) ? previous : next;
+    });
 
-    // Coalesce reposition work to one run per frame - scroll fires far faster.
+    // Coalesce reposition work to one run per frame - resize fires far faster.
     let frame = 0;
     const scheduleUpdate = () => {
       if (frame) return;
       frame = requestAnimationFrame(() => { frame = 0; update(); });
     };
-    const handleScroll = () => (closeOnScroll ? onClose() : scheduleUpdate());
 
     update();
-    window.addEventListener('scroll', handleScroll, true);
     window.addEventListener('resize', scheduleUpdate);
     return () => {
       if (frame) cancelAnimationFrame(frame);
-      window.removeEventListener('scroll', handleScroll, true);
       window.removeEventListener('resize', scheduleUpdate);
     };
-  }, [anchorEl, onClose, closeOnScroll]);
+  }, [anchorEl]);
 
   // Position before paint so the popover never flashes at its CSS fallback spot.
   useLayoutEffect(() => {
@@ -74,34 +177,8 @@ export const useAnchoredPopover = ({
     if (!anchorRect || !popover) return;
 
     if (matchAnchorWidth) popover.style.width = `${anchorRect.width}px`;
-    if (maxHeight !== undefined) popover.style.maxHeight = `${maxHeight}px`;
 
-    const { offsetWidth: width, offsetHeight: height } = popover;
-    const spaceAbove = anchorRect.top - offset - VIEWPORT_MARGIN;
-    const spaceBelow = window.innerHeight - anchorRect.bottom - offset - VIEWPORT_MARGIN;
-    const fitsPreferred = height <= (placement === 'above' ? spaceAbove : spaceBelow);
-    const resolved = fitsPreferred
-      ? placement
-      : (spaceAbove >= spaceBelow ? 'above' : 'below');
-
-    const left = Math.max(
-      VIEWPORT_MARGIN,
-      Math.min(anchorRect.left, window.innerWidth - width - VIEWPORT_MARGIN)
-    );
-
-    popover.style.position = 'fixed';
-    popover.style.left = `${left}px`;
-    if (maxHeight !== undefined) {
-      const space = resolved === 'above' ? spaceAbove : spaceBelow;
-      popover.style.maxHeight = `${Math.min(maxHeight, Math.max(MIN_POPOVER_HEIGHT, space))}px`;
-    }
-    if (resolved === 'above') {
-      popover.style.bottom = `${window.innerHeight - anchorRect.top + offset}px`;
-      popover.style.top = 'auto';
-    } else {
-      popover.style.top = `${anchorRect.bottom + offset}px`;
-      popover.style.bottom = 'auto';
-    }
+    positionPopover(popover, anchorRect, placement, offset, maxHeight);
   }, [anchorRect, placement, offset, popoverRef, matchAnchorWidth, maxHeight, resizeKey]);
 };
 

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -1,12 +1,3 @@
-// BlockNote layers its own floating UI at `--bn-ui-base-z-index` + 10..90 (formatting
-// toolbar 40, link toolbar 50); staying on that scale keeps ours inside the editor's
-// layer instead of above the host app's header and tabs.
-export const FLOATING_Z_INDEX = {
-  preview: 'calc(var(--bn-ui-base-z-index, 0) + 40)',
-  search: 'calc(var(--bn-ui-base-z-index, 0) + 50)',
-  options: 'calc(var(--bn-ui-base-z-index, 0) + 50)',
-} as const;
-
 export const CHIP_STYLES = {
   bg: 'var(--op-chip-bg)',
   radius: 'var(--bn-border-radius)',

--- a/lib/components/WorkPackage/tokens.ts
+++ b/lib/components/WorkPackage/tokens.ts
@@ -1,3 +1,12 @@
+// BlockNote layers its own floating UI at `--bn-ui-base-z-index` + 10..90 (formatting
+// toolbar 40, link toolbar 50); staying on that scale keeps ours inside the editor's
+// layer instead of above the host app's header and tabs.
+export const FLOATING_Z_INDEX = {
+  preview: 'calc(var(--bn-ui-base-z-index, 0) + 40)',
+  search: 'calc(var(--bn-ui-base-z-index, 0) + 50)',
+  options: 'calc(var(--bn-ui-base-z-index, 0) + 50)',
+} as const;
+
 export const CHIP_STYLES = {
   bg: 'var(--op-chip-bg)',
   radius: 'var(--bn-border-radius)',

--- a/lib/hooks/useWorkPackagePreview.ts
+++ b/lib/hooks/useWorkPackagePreview.ts
@@ -73,8 +73,8 @@ export function useWorkPackagePreview({ enabled, suppressed }:UseWorkPackagePrev
     [clearTimers]
   );
 
-  // Stable identity: the popover's positioning effect subscribes scroll/resize
-  // listeners keyed on onClose, so it must not change every render.
+  // Stable identity: the chip closes the preview from an effect keyed on it, so
+  // it must not change every render.
   const closePreview = useCallback(() => {
     clearTimers();
     setPreviewOpen(false);

--- a/lib/utils/zIndex.ts
+++ b/lib/utils/zIndex.ts
@@ -1,0 +1,8 @@
+// BlockNote layers its own floating UI at `--bn-ui-base-z-index` + 10..90 (formatting
+// toolbar 40, link toolbar 50); staying on that scale keeps ours inside the editor's
+// layer instead of above the host app's header and tabs.
+export const FLOATING_Z_INDEX = {
+  preview: 'calc(var(--bn-ui-base-z-index, 0) + 40)',
+  search: 'calc(var(--bn-ui-base-z-index, 0) + 50)',
+  options: 'calc(var(--bn-ui-base-z-index, 0) + 50)',
+} as const;

--- a/test/lib/components/integration/createWorkPackageEdgeCases.browser.test.tsx
+++ b/test/lib/components/integration/createWorkPackageEdgeCases.browser.test.tsx
@@ -7,6 +7,9 @@ import { worker } from '../../../mocks/browser';
 
 afterEach(() => worker.resetHandlers());
 
+const SCROLL_STEP = 40;
+const MAX_LIST_GAP = 4;
+
 describe('Create work package - form and editor boundaries', () => {
   it('loads the form once and puts the cursor into the subject', async () => {
     let formRequests = 0;
@@ -62,6 +65,44 @@ describe('Create work package - form and editor boundaries', () => {
     expect(list.getBoundingClientRect().top).toBeGreaterThanOrEqual(input.getBoundingClientRect().bottom);
     expect(Math.round(list.getBoundingClientRect().width))
       .toBe(Math.round(input.getBoundingClientRect().width));
+  });
+
+  it('keeps the suggestions on their field while the form scrolls beneath them', async () => {
+    await page.viewport(390, 420);
+
+    try {
+      renderEditor();
+      await openCreateModal();
+
+      // A filled form is what brings in enough fields to make the body scroll.
+      await fillRequiredFields('Fix the header alignment');
+      const body = page.getByTestId('create-wp-modal').element().querySelector('form > div')!;
+
+      await userEvent.click(page.getByLabelText('Supervisor *'));
+      await expect.element(page.getByRole('option', { name: 'Anna Kovalenko' })).toBeVisible();
+
+      const input = page.getByLabelText('Supervisor *').element();
+      const list = page.getByRole('listbox', { name: 'Supervisor' }).element();
+      // Distance to whichever side of the field the list sits on.
+      const gapToField = () => {
+        const field = input.getBoundingClientRect();
+        const suggestions = list.getBoundingClientRect();
+        return Math.round(Math.min(
+          Math.abs(suggestions.top - field.bottom),
+          Math.abs(field.top - suggestions.bottom),
+        ));
+      };
+
+      expect(getComputedStyle(list).position).toBe('fixed');
+      expect(gapToField()).toBeLessThanOrEqual(MAX_LIST_GAP);
+
+      expect(body.scrollHeight).toBeGreaterThan(body.clientHeight + SCROLL_STEP);
+      body.scrollTop += body.scrollTop >= SCROLL_STEP ? -SCROLL_STEP : SCROLL_STEP;
+
+      await expect.poll(gapToField).toBeLessThanOrEqual(MAX_LIST_GAP);
+    } finally {
+      await page.viewport(800, 600);
+    }
   });
 
   it('keeps a filled form when the overlay is clicked, and drops an untouched one', async () => {

--- a/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
@@ -38,7 +38,7 @@ function FlipHarness({ anchorTop }:{ anchorTop:number }) {
         #123
       </span>
       {anchor && (
-        <WpPreviewPopover anchorEl={anchor} onClose={() => {}}>
+        <WpPreviewPopover anchorEl={anchor}>
           <BlockCard workPackage={previewWp} size="m" linkTitle />
         </WpPreviewPopover>
       )}

--- a/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
+++ b/test/lib/components/integration/wpOptionsPopover.browser.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { InlineWorkPackageChip } from '../../../../lib/components/InlineWorkPackage/InlineWorkPackageChip';
+import { ShadowDomWrapper } from '../../../../lib/components/ShadowDomWrapper';
 import { renderEditor } from '../../../helpers/renderEditor';
 import {
   insertInlineWorkPackageViaSlashMenu,
@@ -48,6 +50,12 @@ async function openPopover() {
   await userEvent.click(page.getByText('#123'));
   await expect.element(page.getByTestId('popover-content')).toBeVisible();
 }
+
+const getPopover = (root:ParentNode = document):Element =>
+  root.querySelector('[data-testid="popover-content"]')!;
+
+const getScrollerRect = ():DOMRect =>
+  page.getByTestId('scroller').element().getBoundingClientRect();
 
 async function openSizeMenu() {
   await openPopover();
@@ -203,6 +211,128 @@ describe('Options popover positioning', () => {
   });
 });
 
+// Mirrors the OpenProject mobile layout: a page header above the container the
+// document scrolls in.
+function PageWithScroller({ height = 240, children }:{ height?:number; children:ReactNode }) {
+  return (
+    <div>
+      <div data-testid="page-header" style={{ height: '60px', background: '#eee' }}>
+        Header
+      </div>
+      <div data-testid="scroller" style={{ height: `${height}px`, overflowY: 'auto' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function EditorContent({ chipOffset }:{ chipOffset:number }) {
+  return (
+    <div className="bn-container" style={{ position: 'relative' }}>
+      <div style={{ paddingTop: `${chipOffset}px`, height: '900px' }}>
+        <InlineWorkPackageChip
+          inlineContent={{ props: { wpid: '123', size: 's', displayId: '123' } }}
+          contentRef={vi.fn()}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ScrollHarness({ chipOffset = 150, height = 240 }:{ chipOffset?:number; height?:number }) {
+  return (
+    <PageWithScroller height={height}>
+      <EditorContent chipOffset={chipOffset} />
+    </PageWithScroller>
+  );
+}
+
+describe('Options popover while the document scrolls', () => {
+  it('scrolls under the page header instead of hovering above it', async () => {
+    render(<ScrollHarness />);
+    await waitForResolvedChip();
+    await openPopover();
+
+    const scroller = page.getByTestId('scroller').element();
+    const popover = getPopover();
+    const scrollerTop = scroller.getBoundingClientRect().top;
+    const popoverTopBefore = popover.getBoundingClientRect().top;
+    expect(popoverTopBefore).toBeGreaterThan(scrollerTop);
+
+    // Scroll just far enough that the popover reaches into the header's row.
+    const delta = Math.round(popoverTopBefore - scrollerTop + 10);
+    scroller.scrollTop = delta;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const popoverRect = popover.getBoundingClientRect();
+    expect(popoverRect.top).toBeCloseTo(popoverTopBefore - delta, 0);
+    expect(popoverRect.top).toBeLessThan(scrollerTop);
+
+    // The part reaching into the header row is clipped, not painted over it.
+    const hitInHeaderRow = document.elementFromPoint(popoverRect.left + 4, scrollerTop - 4);
+    expect(popover.contains(hitInHeaderRow)).toBe(false);
+  });
+});
+
+// Same layout with the editor in a shadow root, as OpenProject mounts it.
+function ShadowScrollHarness({ chipOffset }:{ chipOffset:number }) {
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+  const attachHost = (host:HTMLDivElement | null) => {
+    if (host && !host.shadowRoot) setShadowRoot(host.attachShadow({ mode: 'open' }));
+  };
+
+  return (
+    <PageWithScroller>
+      <div ref={attachHost} data-testid="editor-host" />
+      {shadowRoot && createPortal(
+        <ShadowDomWrapper target={shadowRoot}>
+          <EditorContent chipOffset={chipOffset} />
+        </ShadowDomWrapper>,
+        shadowRoot,
+      )}
+    </PageWithScroller>
+  );
+}
+
+describe('Options popover on the first row', () => {
+  it('stops at the page header edge instead of opening half hidden behind it', async () => {
+    render(<ScrollHarness chipOffset={2} />);
+    await waitForResolvedChip();
+    await openPopover();
+
+    const scrollerRect = getScrollerRect();
+    const popoverRect = getPopover().getBoundingClientRect();
+
+    expect(popoverRect.top).toBeGreaterThanOrEqual(scrollerRect.top);
+    expect(popoverRect.bottom).toBeLessThanOrEqual(scrollerRect.bottom);
+  });
+
+  it('is parked inside the visible area when neither side of the chip has room', async () => {
+    render(<ScrollHarness chipOffset={16} height={60} />);
+    await waitForResolvedChip();
+    await openPopover();
+
+    const scrollerRect = getScrollerRect();
+    const popoverRect = getPopover().getBoundingClientRect();
+
+    expect(popoverRect.top).toBeGreaterThanOrEqual(scrollerRect.top);
+    expect(popoverRect.bottom).toBeLessThanOrEqual(scrollerRect.bottom);
+  });
+
+  it('stays inside the scroll container when the editor is in a shadow root', async () => {
+    render(<ShadowScrollHarness chipOffset={2} />);
+    await waitForResolvedChip();
+    await openPopover();
+
+    const shadowRoot = page.getByTestId('editor-host').element().shadowRoot!;
+    const scrollerRect = getScrollerRect();
+    const popoverRect = getPopover(shadowRoot).getBoundingClientRect();
+
+    expect(popoverRect.top).toBeGreaterThanOrEqual(scrollerRect.top);
+    expect(popoverRect.bottom).toBeLessThanOrEqual(scrollerRect.bottom);
+  });
+});
+
 describe('Inline chip popover UX', () => {
   it('popover is not visible before clicking the chip', async () => {
     render(<ChipWrapper initialSize="s" />);
@@ -327,14 +457,22 @@ describe('Options popover coexists with the editor', () => {
     expect(formattingToolbarVisible()).toBe(false);
   });
 
-  it('inline chip: a scroll closes the popover on desktop', async () => {
+  it('inline chip: a scroll keeps the popover anchored to the chip', async () => {
     renderEditor();
     await insertInlineWorkPackageViaSlashMenu();
     await openInlineWorkPackagePopover();
 
-    window.dispatchEvent(new Event('scroll'));
+    const chip = document.querySelector('.op-bn-inline-wp')!;
+    const popover = document.querySelector('[data-testid="popover-content"]')!;
+    const distance = () =>
+      chip.getBoundingClientRect().top - popover.getBoundingClientRect().top;
+    const distanceBefore = distance();
 
-    await expect.element(page.getByTestId('popover-content')).not.toBeInTheDocument();
+    window.dispatchEvent(new Event('scroll'));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    await expect.element(page.getByTestId('popover-content')).toBeVisible();
+    expect(distance()).toBeCloseTo(distanceBefore, 0);
   });
 
   it('block card: opening the popover summons no formatting toolbar', async () => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-126

# What are you trying to accomplish?

On Android, the context menu of a work package link stayed pinned over the document header while the page scrolled, instead of scrolling away underneath it like the rest of the editor content. iOS was not affected. Opening the menu on a link in the first editor row left it cut off at the header edge as well.

# What approach did you choose and why?

**Root cause.** The menu was placed with `position: fixed` and `z-index: 9999` - a leftover workaround from it being clipped in the first editor row. A fixed-positioned descendant of a scroll container is pinned to the viewport in Chrome and is not clipped by that container, so the menu floated above the page header on Android. WebKit clips
such elements, which is why iOS never showed the bug, and on desktop it was masked by closing the menu on any scroll.

**Solution.** The menu is now positioned absolutely inside the editor container it is already portaled into, so it lives in the editor's coordinate space: it travels with its anchor and is clipped by the same scroll container as the rest of the editor content, on every engine. Its z-index moved onto BlockNote's own scale (`--bn-ui-base-z-index` + 40/50)
so our floating UI stays in the editor's layer rather than above the application chrome. The side is chosen against the area that is actually visible - the viewport narrowed by every clipping ancestor, crossing the shadow root the editor is mounted in - so a link in the first row opens its menu downwards, and a final clamp keeps the menu inside that area instead of half hidden behind the header.

**Behaviour change worth noting:** scrolling no longer closes the menu on desktop. That close only existed because a fixed menu drifted away from its link; the menu now stays anchored, which also matches BlockNote's own toolbars. On touch it already stayed open.

**Alternatives discarded.** BlockNote's `GenericPopover` - its `useBlockNoteEditor()` throws outside an editor context, so every standalone chip test would have to be rebuilt around a full editor. `@floating-ui/dom` - a natural fit for the geometry, but its `autoUpdate` repositions on scroll even with `ancestorScroll: false`, which would park the
menu at the header edge instead of letting it scroll away. Tradeoff accepted: the positioning geometry is our own, kept in one file behind a four-field hook API, so swapping it for a library later touches nothing else.
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
