### PR TITLE
[BNE-127] Documents: issues with tiny work package link preview on mobile iOS

### DIFF
--- a/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
+++ b/lib/components/BlockWorkPackage/BlockWorkPackage.tsx
@@ -16,7 +16,7 @@ import { WpOptionsPopover } from '../WorkPackage/OptionsPopover';
 import { SearchContainer, SearchLabel } from '../Search/SearchContainer';
 import { SearchDropdown } from '../Search/SearchDropdown';
 import { CreateWorkPackageModal } from '../CreateWorkPackage';
-import { defaultWpVariables } from '../WorkPackage/atoms';
+import { defaultWpVariables, nonSelectableStyles } from '../WorkPackage/atoms';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
 import { moveCursorAfterBlock } from '../../utils/cursor';
 import { hideSafariPhantomSelection } from '../../utils/selection';
@@ -26,8 +26,7 @@ import { useSuppressFormattingToolbar } from '../../hooks/useSuppressFormattingT
 const Block = styled.div.attrs({ className: 'op-bn-extensions', 'data-testid': 'block-wp-wrapper' })<{ $pending?:boolean; $selected?:boolean }>`
   ${defaultWpVariables}
   background-color: ${({ $pending }) => ($pending ? 'transparent' : 'var(--op-chip-bg)')};
-  user-select: none;
-  -webkit-touch-callout: none;
+  ${nonSelectableStyles}
   border-radius: var(--bn-border-radius);
   box-shadow: ${({ $selected }) => ($selected ? CHIP_STYLES.focusShadow : 'none')};
   ${({ $pending }) => $pending && 'position: relative;'}
@@ -186,7 +185,7 @@ export const BlockWorkPackageComponent = ({
 
   return (
     <Block ref={trackBlockElement} $pending={pendingMode !== undefined} $selected={isBlockSelected} data-selected={isBlockSelected || undefined} draggable="true" onDragStart={handleBlockDragStart}>
-      <div contentEditable={false} style={{ userSelect: 'none' }}>
+      <div contentEditable={false}>
         {pendingMode === 'create' && blockEl && (
           <CreateWorkPackageModal
             anchorEl={blockEl}

--- a/lib/components/InlineWorkPackage/chipLayouts.tsx
+++ b/lib/components/InlineWorkPackage/chipLayouts.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import styled from 'styled-components';
 import { CHIP_STYLES } from '../WorkPackage/tokens';
-import { defaultWpVariables } from '../WorkPackage/atoms';
+import { defaultWpVariables, nonSelectableStyles } from '../WorkPackage/atoms';
 
 const chipBaseStyles = css`
   display: inline;
@@ -55,8 +55,7 @@ export const InlineChip = styled.span.attrs({
   ${defaultWpVariables}
   display: inline;
   cursor: pointer;
-  user-select: none;
-  -webkit-touch-callout: none;
+  ${nonSelectableStyles}
   border-radius: ${CHIP_STYLES.radius};
   position: relative;
   line-height: 1;

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -32,6 +32,16 @@ export const defaultWpVariables = css`
   }
 `;
 
+// The -webkit- prefix is not redundant: Safari (including iOS) implements only the prefixed
+// property and styled-components v6 no longer auto-prefixes, so unprefixed alone leaves the
+// chip text selectable there. Belongs on the container only: `user-select` is not inherited,
+// but `auto` on a descendant resolves to `none` under a non-selectable parent.
+export const nonSelectableStyles = css`
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+`;
+
 export const WorkPackageId = styled.span.attrs({
   className: 'op-bn-work-package--id',
 })<{ $compact?:boolean }>`

--- a/lib/hooks/useWorkPackagePreview.ts
+++ b/lib/hooks/useWorkPackagePreview.ts
@@ -29,7 +29,9 @@ interface ChipTriggerProps {
   onPointerDown:(e:ReactPointerEvent) => void;
   onPointerUp:() => void;
   onPointerMove:(e:ReactPointerEvent) => void;
-  onPointerCancel:() => void;
+  // Deliberately no onPointerCancel: iOS fires it mid-press when it lifts the chip for a
+  // native drag, and aborting there left the preview never opening. Only the finger lifting
+  // or moving means no preview was wanted, so an armed press outlives a cancelled pointer.
   onContextMenu:((e:ReactMouseEvent) => void) | undefined;
   // Claim the touch gesture so the browser doesn't start panning and fire
   // pointercancel mid-press, which used to make the long press fire only sometimes.
@@ -128,7 +130,6 @@ export function useWorkPackagePreview({ enabled, suppressed }:UseWorkPackagePrev
         onPointerDown: handleLongPressStart,
         onPointerUp: cancelLongPress,
         onPointerMove: handleLongPressMove,
-        onPointerCancel: cancelLongPress,
         onContextMenu: canHover ? undefined : (e:ReactMouseEvent) => e.preventDefault(),
         style: { touchAction: 'none' as const },
       }

--- a/test/lib/components/InlineWorkPackage/chipLayouts.test.tsx
+++ b/test/lib/components/InlineWorkPackage/chipLayouts.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ServerStyleSheet } from 'styled-components';
+import { InlineChip } from '../../../../lib/components/InlineWorkPackage/chipLayouts';
+
+describe('Inline chip styles', () => {
+  beforeAll(() => vi.stubGlobal('matchMedia', () => ({ matches: false })));
+  afterAll(() => vi.unstubAllGlobals());
+
+  // Asserted on the emitted stylesheet, not in the browser: Chromium aliases the prefixed
+  // and unprefixed properties in both getComputedStyle and the CSSOM, so only the shipped
+  // CSS shows whether Safari gets a declaration it understands.
+  it('suppresses text selection with the prefixed properties Safari needs', () => {
+    const sheet = new ServerStyleSheet();
+    renderToStaticMarkup(sheet.collectStyles(<InlineChip />));
+    const css = sheet.getStyleTags();
+
+    expect(css).toContain('-webkit-user-select:none');
+    expect(css).toContain('-webkit-touch-callout:none');
+  });
+});

--- a/test/lib/components/integration/editor.inlineWorkPackage.browser.test.tsx
+++ b/test/lib/components/integration/editor.inlineWorkPackage.browser.test.tsx
@@ -133,3 +133,14 @@ describe('Inline chip - remove', () => {
     await expect.element(page.getByText('In Progress')).not.toBeInTheDocument();
   });
 });
+
+describe('Inline chip - selection', () => {
+  it('the chip is not text-selectable', async () => {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+
+    const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+
+    expect(getComputedStyle(chip).userSelect).toBe('none');
+  });
+});

--- a/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 import { useState } from 'react';
@@ -11,6 +11,21 @@ import {
 import { WpPreviewPopover } from '../../../../lib/components/WorkPackage/PreviewPopover';
 import { BlockCard } from '../../../../lib/components/BlockWorkPackage/BlockCard';
 import type { WorkPackage } from '../../../../lib/openProjectTypes';
+
+const wait = (ms:number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const chipElement = () => page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+
+type PointerEventType = 'pointerdown' | 'pointerup' | 'pointermove' | 'pointercancel';
+
+const dispatchPointer = (chip:Element, type:PointerEventType, init:PointerEventInit = {}) =>
+  chip.dispatchEvent(new PointerEvent(type, { bubbles: true, ...init }));
+
+const dragStartPrevented = (chip:Element) => {
+  const dragStart = new DragEvent('dragstart', { bubbles: true, cancelable: true });
+  chip.dispatchEvent(dragStart);
+  return dragStart.defaultPrevented;
+};
 
 const previewWp:WorkPackage = {
   id: 123,
@@ -99,7 +114,7 @@ describe('Inline chip - XXS hover preview', () => {
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
 
     await userEvent.hover(page.getByText('#123').first());
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await wait(600);
 
     await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
     await expect.element(page.getByTestId('popover-content')).toBeVisible();
@@ -112,15 +127,15 @@ describe('Inline chip - XXS hover preview', () => {
     await userEvent.hover(page.getByText('#123').first());
 
     // Give the open delay a chance to elapse before asserting absence
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await wait(600);
     await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
   });
 });
 
 describe('Inline chip - XXS long-press preview (touch)', () => {
-  function forceTouch() {
-    const original = window.matchMedia;
-    window.matchMedia = (query:string) => ({
+  // The chip reads (hover: hover) once per mount, so touch has to be faked before rendering.
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', (query:string) => ({
       matches: false,
       media: query,
       onchange: null,
@@ -129,103 +144,87 @@ describe('Inline chip - XXS long-press preview (touch)', () => {
       addListener: () => {},
       removeListener: () => {},
       dispatchEvent: () => false,
-    });
-    return () => { window.matchMedia = original; };
+    }));
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  async function renderChip() {
+    renderEditor();
+    await insertInlineWorkPackageViaHash('#');
+    // let the fetch settle so the chip's remount doesn't clear the long-press timer
+    await wait(600);
+    return chipElement();
   }
 
   it('opens the preview on a long press and not on a quick tap', async () => {
-    const restore = forceTouch();
-    try {
-      renderEditor();
-      await insertInlineWorkPackageViaHash('#');
-      // let the fetch settle so the chip's remount doesn't clear the long-press timer
-      await new Promise((resolve) => setTimeout(resolve, 600));
+    const chip = await renderChip();
 
-      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+    dispatchPointer(chip, 'pointerdown');
+    dispatchPointer(chip, 'pointerup');
+    await wait(600);
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
 
-      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
-      await new Promise((resolve) => setTimeout(resolve, 600));
-      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+    dispatchPointer(chip, 'pointerdown');
+    await expect.element(page.getByTestId('wp-preview'), { timeout: 2000 }).toBeVisible();
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
 
-      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-      await expect.element(page.getByTestId('wp-preview'), { timeout: 2000 }).toBeVisible();
-      await expect.element(page.getByTestId('block-card')).toBeVisible();
-
-      // stays open after the finger lifts; only an outside tap closes it on touch
-      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      await expect.element(page.getByTestId('wp-preview')).toBeVisible();
-    }
-    finally {
-      restore();
-    }
+    // stays open after the finger lifts; only an outside tap closes it on touch
+    dispatchPointer(chip, 'pointerup');
+    await wait(300);
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
   });
 
   it('closes the preview when the user taps outside', async () => {
-    const restore = forceTouch();
-    try {
-      renderEditor();
-      await insertInlineWorkPackageViaHash('#');
-      // let the fetch settle so the chip's remount doesn't clear the long-press timer
-      await new Promise((resolve) => setTimeout(resolve, 600));
+    const chip = await renderChip();
 
-      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+    dispatchPointer(chip, 'pointerdown');
+    await expect.element(page.getByTestId('wp-preview'), { timeout: 2000 }).toBeVisible();
 
-      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-      await expect.element(page.getByTestId('wp-preview'), { timeout: 2000 }).toBeVisible();
-
-      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
-      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
-    }
-    finally {
-      restore();
-    }
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
   });
 
   it('cancels the long press when the finger moves past the tolerance', async () => {
-    const restore = forceTouch();
-    try {
-      renderEditor();
-      await insertInlineWorkPackageViaHash('#');
-      // let the fetch settle so the chip's remount doesn't clear the long-press timer
-      await new Promise((resolve) => setTimeout(resolve, 600));
+    const chip = await renderChip();
 
-      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+    dispatchPointer(chip, 'pointerdown', { clientX: 100, clientY: 100 });
+    dispatchPointer(chip, 'pointermove', { clientX: 100, clientY: 140 });
+    await wait(600);
 
-      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 100, clientY: 100 }));
-      chip.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: 100, clientY: 140 }));
-      await new Promise((resolve) => setTimeout(resolve, 600));
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
+  });
 
-      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
-    }
-    finally {
-      restore();
-    }
+  // Blocking the lift would make the preview reliable too, but at the cost of dragging the
+  // chip by touch - surviving the pointercancel it fires is what keeps both.
+  it('leaves the native drag lift alone during a press', async () => {
+    const chip = await renderChip();
+
+    dispatchPointer(chip, 'pointerdown');
+
+    expect(dragStartPrevented(chip)).toBe(false);
+  });
+
+  it('still opens the preview when another gesture cancels the pointer', async () => {
+    const chip = await renderChip();
+
+    dispatchPointer(chip, 'pointerdown');
+    dispatchPointer(chip, 'pointercancel');
+
+    await expect.element(page.getByTestId('wp-preview'), { timeout: 2000 }).toBeVisible();
   });
 
   it('does not open a spurious preview after a two-finger tap', async () => {
-    const restore = forceTouch();
-    try {
-      renderEditor();
-      await insertInlineWorkPackageViaHash('#');
-      // let the fetch settle so the chip's remount doesn't clear the long-press timer
-      await new Promise((resolve) => setTimeout(resolve, 600));
+    const chip = await renderChip();
 
-      const chip = page.getByText('#123').first().element().closest('.op-bn-inline-wp')!;
+    // both fingers lift before the delay: the first timer must not be orphaned
+    dispatchPointer(chip, 'pointerdown', { pointerId: 1 });
+    dispatchPointer(chip, 'pointerdown', { pointerId: 2 });
+    dispatchPointer(chip, 'pointerup', { pointerId: 1 });
+    dispatchPointer(chip, 'pointerup', { pointerId: 2 });
+    await wait(600);
 
-      // both fingers lift before the delay: the first timer must not be orphaned
-      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
-      chip.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 2 }));
-      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
-      chip.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 2 }));
-      await new Promise((resolve) => setTimeout(resolve, 600));
-
-      await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
-    }
-    finally {
-      restore();
-    }
+    await expect.element(page.getByTestId('wp-preview')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-127

# What are you trying to accomplish?
On a long tap the preview works unreliably, sometimes it opens and sometimes it selects the text (like for copying)

The ticket's second point, the preview not being selectable and copyable, did not reproduce.
The preview card is portalled outside the chip, so it never inherits the chip's non-selectable styles and its text selects and copies normally. What most likely reads as the difference from Android is that the card's subject is a link, and iOS answers a long press on a link with its own system link preview and menu rather than the text selection loupe - copying the link works, just through that menu.

# What approach did you choose and why?
The selection fix ships the prefixed property explicitly instead of re-enabling stylis' prefixer through `StyleSheetManager`: OpenProject consumes this library without a wrapping manager, so a global switch would not reliably apply. It lives in one shared snippet, because the same declaration was needed in two places and wrong in both.

For the gesture, only `pointercancel` was dropped as a cancellation signal. Preventing the drag lift makes the preview reliable too, but it takes away dragging a chip by touch; surviving the cancelled pointer keeps both gestures. Lifting or moving the finger remain the signals that no preview was wanted.

A missing prefix cannot be caught in the browser: Chromium aliases the prefixed and unprefixed properties in both `getComputedStyle` and the CSSOM, so the guard asserts on the emitted stylesheet.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

