### PR TITLE
[BNE-133] Show type colors in Type select

### DIFF
--- a/lib/components/CreateWorkPackage/CreateWorkPackageModal.tsx
+++ b/lib/components/CreateWorkPackage/CreateWorkPackageModal.tsx
@@ -4,6 +4,7 @@ import { StyleSheetManager } from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { AlertIcon, SyncIcon, XIcon } from '@primer/octicons-react';
 import type { WorkPackage } from '../../openProjectTypes';
+import { useColors } from '../../services/colors';
 import { linkToNewWorkPackage } from '../../services/openProjectApi';
 import { projectIdFromHref } from '../../utils/id';
 import { dependencyOf } from './formSchema';
@@ -119,6 +120,7 @@ export const CreateWorkPackageModal = ({ anchorEl, onCreated, onCancel }:CreateW
   const { t } = useTranslation();
   const panelRef = useRef<HTMLDivElement>(null);
   usePageScrollLock();
+  useColors();
   const {
     primaryFields,
     extraFields,

--- a/lib/components/CreateWorkPackage/FormFieldControl.tsx
+++ b/lib/components/CreateWorkPackage/FormFieldControl.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlertIcon } from '@primer/octicons-react';
+import { colorOfType } from '../../services/colors';
 import type { FieldValue, FormField, ValueProblem } from './formSchema';
 import { AllowedValuesTypeahead } from './AllowedValuesTypeahead';
 import { PickerArrows } from './PickerArrows';
@@ -15,6 +16,7 @@ import {
   SelectWrapper,
   TextAreaControl,
   TextControl,
+  TypeColorDot,
 } from './atoms';
 
 interface FormFieldControlProps {
@@ -50,6 +52,9 @@ export const FormFieldControl = ({ field, value, onChange, autoFocus, error, pro
   const textValue = typeof value === 'string' ? value : '';
   const ownPlaceholder = PLACEHOLDERS[field.key];
   const placeholder = field.placeholder ?? (ownPlaceholder ? t(ownPlaceholder) : undefined);
+  const colorDot = field.key === 'type' && textValue
+    ? <TypeColorDot $color={colorOfType(textValue)} />
+    : null;
 
   const withError = (children:ReactNode) => (
     <FieldRow $invalid={Boolean(message)}>
@@ -90,7 +95,7 @@ export const FormFieldControl = ({ field, value, onChange, autoFocus, error, pro
   switch (field.kind) {
     case 'select':
       control = (
-        <SelectWrapper>
+        <SelectWrapper $withColorDot={Boolean(colorDot)}>
           <SelectControl
             id={id}
             value={textValue}
@@ -104,6 +109,7 @@ export const FormFieldControl = ({ field, value, onChange, autoFocus, error, pro
               <option key={allowed.href} value={allowed.href}>{allowed.label}</option>
             ))}
           </SelectControl>
+          {colorDot}
           <PickerArrows />
         </SelectWrapper>
       );

--- a/lib/components/CreateWorkPackage/atoms.ts
+++ b/lib/components/CreateWorkPackage/atoms.ts
@@ -1,5 +1,6 @@
 import styled, { css, keyframes } from 'styled-components';
 import { defaultWpVariables } from '../WorkPackage/atoms';
+import { defaultColorStyles, typeTextColor } from '../../services/colors';
 
 const surfaceColor = 'var(--op-create-wp-surface)';
 const textColor = 'var(--op-create-wp-text)';
@@ -8,6 +9,8 @@ const controlBorderColor = 'var(--op-create-wp-control-border)';
 const radius = '6px';
 const radiusLarge = '12px';
 const arrowsWidth = '32px';
+const colorDotSize = '12px';
+const colorDotWidth = `calc(var(--spacer-l) + ${colorDotSize} + var(--spacer-m))`;
 
 const MODAL_WIDTH = '460px';
 
@@ -307,10 +310,30 @@ export const SelectControl = styled.select`
   }
 `;
 
-export const SelectWrapper = styled.div`
+export const SelectWrapper = styled.div<{ $withColorDot?:boolean }>`
   position: relative;
   display: flex;
   align-items: center;
+
+  ${({ $withColorDot }) => $withColorDot && css`
+    && select {
+      padding-left: ${colorDotWidth};
+    }
+  `}
+`;
+
+export const TypeColorDot = styled.span.attrs({
+  className: 'op-bn-create-wp-type-color',
+  'data-testid': 'create-wp-type-color',
+})<{ $color:string }>`
+  ${({ $color }) => defaultColorStyles($color)}
+  position: absolute;
+  left: var(--spacer-l);
+  width: ${colorDotSize};
+  height: ${colorDotSize};
+  border-radius: 50%;
+  background: ${typeTextColor};
+  pointer-events: none;
 `;
 
 export const CheckboxRow = styled.label`

--- a/lib/services/colors.ts
+++ b/lib/services/colors.ts
@@ -65,12 +65,13 @@ export function cacheColors():Promise<void> {
   return colorsPromise;
 }
 
+export function colorOfType(typeHref:string | undefined) {
+  const typeId = typeHref ? idFromHref(typeHref) : undefined;
+  return typeColors[typeId ?? ''] || FALLBACK_TYPE_COLOR;
+}
+
 export function typeColor(workPackage:WorkPackage) {
-  if (!workPackage._links?.type) {
-    return FALLBACK_TYPE_COLOR;
-  }
-  const typeId = idFromHref(workPackage._links.type.href) ?? '';
-  return typeColors[typeId] || FALLBACK_TYPE_COLOR;
+  return colorOfType(workPackage._links?.type?.href);
 }
 
 export function statusColor(workPackage:WorkPackage) {

--- a/test/lib/components/integration/createWorkPackage.browser.test.tsx
+++ b/test/lib/components/integration/createWorkPackage.browser.test.tsx
@@ -8,6 +8,11 @@ import { mockCreatedWorkPackage } from '../../../mocks/handlers';
 
 afterEach(() => worker.resetHandlers());
 
+function colorChannelsOf(element:Element):string[] {
+  const styles = getComputedStyle(element);
+  return ['--color-r', '--color-g', '--color-b'].map((channel) => styles.getPropertyValue(channel).trim());
+}
+
 describe('Create work package', () => {
   it('creates a card when invoked on an empty line', async () => {
     renderEditor();
@@ -122,6 +127,26 @@ describe('Create work package', () => {
 
     await expect.element(page.getByLabelText('Supervisor *')).not.toHaveAttribute('aria-invalid');
     await expect.element(page.getByLabelText('Subject *')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('shows the color of the chosen type', async () => {
+    renderEditor();
+    await openCreateModal();
+    await pickProject();
+
+    await expect.element(page.getByLabelText('Type *')).toBeVisible();
+    await expect.element(page.getByTestId('create-wp-type-color')).not.toBeInTheDocument();
+
+    await selectOptionNamed('Type *', 'Task');
+    const dot = page.getByTestId('create-wp-type-color');
+    await expect.element(dot).toBeVisible();
+    await expect.poll(() => colorChannelsOf(dot.element())).toEqual(['211', '84', '0']);
+
+    const { width, height } = getComputedStyle(dot.element());
+    expect([width, height]).toEqual(['12px', '12px']);
+
+    await selectOptionNamed('Type *', 'Bug');
+    await expect.poll(() => colorChannelsOf(dot.element())).toEqual(['39', '174', '96']);
   });
 
   it('narrows the project typeahead through the API', async () => {

--- a/test/lib/services/colors.test.ts
+++ b/test/lib/services/colors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cacheColors, colorOfType } from '../../../lib/services/colors';
+
+vi.mock('../../../lib/services/openProjectApi', () => ({
+  fetchTypes: () => Promise.resolve({
+    _embedded: { elements: [{ id: '1', color: '#D35400' }, { id: '2' }] },
+  }),
+  fetchStatuses: () => Promise.resolve({ _embedded: { elements: [] } }),
+}));
+
+describe('colorOfType', () => {
+  it('answers with the cached color of the type the href names', async () => {
+    await cacheColors();
+
+    expect(colorOfType('/api/v3/types/1')).toBe('#D35400');
+  });
+
+  it('falls back for a type left without a color, an unknown one, and none at all', async () => {
+    await cacheColors();
+    const fallback = colorOfType('/api/v3/types/404');
+
+    expect(fallback).not.toBe('#D35400');
+    expect(colorOfType('/api/v3/types/2')).toBe(fallback);
+    expect(colorOfType(undefined)).toBe(fallback);
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-133

# What are you trying to accomplish?
The Type field of the create form was the one place where a work package type showed up without its color, while the same types are colored everywhere else in OpenProject. The chosen type is now marked by a dot in its color, so the field reads the way the mockup asks for.

## Screenshots
<img width="541" height="513" alt="image" src="https://github.com/user-attachments/assets/8b5cbe6f-26fb-4844-aa60-6f9da6521400" />
<img width="555" height="619" alt="image" src="https://github.com/user-attachments/assets/f92e82b1-3547-429b-bc0d-c059850bdb62" />
<img width="555" height="619" alt="image" src="https://github.com/user-attachments/assets/0adf3e45-fa24-43ec-91a9-60c0838839c4" />


# What approach did you choose and why?
The colors come from the cache the work package chips already fill, so the form costs no extra request, and they are toned through the same helpers those chips use - the dot follows the color scheme and the contrast settings without any rules of its own.

The dot marks the closed select only. A native `<option>` takes no markup, and per-option colors are ignored by Safari and by the native popups on macOS, so painting the open list would have looked different per browser rather than like the mockup. The ticket allows for this ("if it's not doable don't do it"), and OpenProject's own type autocompleters leave their options plain as well.

One visible side effect: the room the dot needs is left padding on the select, and Chromium hands that padding to the rows of the native popup too, so the option list is now indented along with the value. I left it that way because the list then lines up with the text of the closed field instead of jumping to the left. If we would rather have the list flush as it was, the value can be shifted with `text-indent` instead of padding.

The alternative was to drop the native select for the custom listbox this form already uses for Project and Assignee, which would allow dots in the open list too. I discarded it for this ticket: it means owning the keyboard handling and the ARIA wiring a native select gives for free, and deciding whether every select of the form follows or Type becomes the exception. Worth its own ticket if design wants the open list colored.

One tradeoff kept as it is: a type configured without a color gets the same gray fallback the cards use, so it reads as a gray type rather than as no color.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
