### PR TITLE
[BNE-124] Documents: overflow in the work package preview when the wp type is long

### DIFF
--- a/lib/components/BlockWorkPackage/BlockCards.tsx
+++ b/lib/components/BlockWorkPackage/BlockCards.tsx
@@ -8,6 +8,7 @@ import {
   WorkPackageStatus,
   WorkPackageTitle,
   WorkPackageTitleLink,
+  WRAP_OPPORTUNITY,
 } from '../WorkPackage/atoms';
 import {
   typeColor,
@@ -19,6 +20,9 @@ import {
 import { formatWorkPackageId } from '../../utils/id';
 
 const DESCRIPTION_MAX_CHARS = 300;
+
+/* keeps the ↑ / ◈ marker on the same line as the label it marks  */
+const MARKER_GAP = '\u00A0';
 
 export interface BlockCardSharedProps {
   workPackage:WorkPackage;
@@ -61,11 +65,13 @@ const CardBase = styled.div<{ $inDropdown:boolean }>`
 const CardDetails = styled.div.attrs({
   className: 'op-bn-work-package--details',
 })`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0 10px;
   width: 100%;
   font-size: 0.86em;
+  line-height: 1.5;
+
+  & > *:not(:last-child) {
+    margin-right: 10px;
+  }
 `;
 
 const CardDetailsSpaced = styled(CardDetails)`
@@ -90,6 +96,40 @@ const DescriptionSnippet = styled.p`
   -webkit-box-orient: vertical;
 `;
 
+const CardMeta = ({
+  workPackage,
+  withRelations = false,
+}:{ workPackage:WorkPackage; withRelations?:boolean }) => (
+  <>
+    <WorkPackageType $color={typeColor(workPackage)}>
+      {workPackage._links?.type?.title}
+    </WorkPackageType>
+    {WRAP_OPPORTUNITY}
+    <WorkPackageId>{formatWorkPackageId(workPackage.displayId)}</WorkPackageId>
+    {WRAP_OPPORTUNITY}
+    <WorkPackageStatus
+      $baseColor={statusColor(workPackage)}
+      $borderColor={statusBorderColor()}
+      $textColor={statusTextColor()}
+      $bgColor={statusBackgroundColor()}
+    >
+      {workPackage._links?.status?.title}
+    </WorkPackageStatus>
+    {withRelations && workPackage._links?.parent?.title && (
+      <>
+        {WRAP_OPPORTUNITY}
+        <MetaItem>↑{MARKER_GAP}{workPackage._links.parent.title}</MetaItem>
+      </>
+    )}
+    {withRelations && workPackage._links?.project?.title && (
+      <>
+        {WRAP_OPPORTUNITY}
+        <MetaItem>◈{MARKER_GAP}{workPackage._links.project.title}</MetaItem>
+      </>
+    )}
+  </>
+);
+
 // M — Compact card: Type, ID, Status + Subject
 export const BlockCardM = ({
   workPackage,
@@ -111,18 +151,7 @@ export const BlockCardM = ({
     style={onClick ? { cursor: 'pointer' } : undefined}
   >
     <CardDetails>
-      <WorkPackageType $color={typeColor(workPackage)}>
-        {workPackage._links?.type?.title}
-      </WorkPackageType>
-      <WorkPackageId>{formatWorkPackageId(workPackage.displayId)}</WorkPackageId>
-      <WorkPackageStatus
-        $baseColor={statusColor(workPackage)}
-        $borderColor={statusBorderColor()}
-        $textColor={statusTextColor()}
-        $bgColor={statusBackgroundColor()}
-      >
-        {workPackage._links?.status?.title}
-      </WorkPackageStatus>
+      <CardMeta workPackage={workPackage} />
     </CardDetails>
     <WorkPackageTitle>{buildTitle(workPackage, linkTitle)}</WorkPackageTitle>
   </CardBase>
@@ -147,24 +176,7 @@ export const BlockCardL = ({
     style={onClick ? { cursor: 'pointer' } : undefined}
   >
     <CardDetailsSpaced>
-      <WorkPackageType $color={typeColor(workPackage)}>
-        {workPackage._links?.type?.title}
-      </WorkPackageType>
-      <WorkPackageId>{formatWorkPackageId(workPackage.displayId)}</WorkPackageId>
-      <WorkPackageStatus
-        $baseColor={statusColor(workPackage)}
-        $borderColor={statusBorderColor()}
-        $textColor={statusTextColor()}
-        $bgColor={statusBackgroundColor()}
-      >
-        {workPackage._links?.status?.title}
-      </WorkPackageStatus>
-      {workPackage._links?.parent?.title && (
-        <MetaItem>↑ {workPackage._links.parent.title}</MetaItem>
-      )}
-      {workPackage._links?.project?.title && (
-        <MetaItem>◈ {workPackage._links.project.title}</MetaItem>
-      )}
+      <CardMeta workPackage={workPackage} withRelations />
     </CardDetailsSpaced>
     <WorkPackageTitle>{buildTitle(workPackage, linkTitle)}</WorkPackageTitle>
   </CardBase>
@@ -197,24 +209,7 @@ export const BlockCardXL = ({
       style={onClick ? { cursor: 'pointer' } : undefined}
     >
       <CardDetailsSpaced>
-        <WorkPackageType $color={typeColor(workPackage)}>
-          {workPackage._links?.type?.title}
-        </WorkPackageType>
-        <WorkPackageId>{formatWorkPackageId(workPackage.displayId)}</WorkPackageId>
-        <WorkPackageStatus
-          $baseColor={statusColor(workPackage)}
-          $borderColor={statusBorderColor()}
-          $textColor={statusTextColor()}
-          $bgColor={statusBackgroundColor()}
-        >
-          {workPackage._links?.status?.title}
-        </WorkPackageStatus>
-        {workPackage._links?.parent?.title && (
-          <MetaItem>↑ {workPackage._links.parent.title}</MetaItem>
-        )}
-        {workPackage._links?.project?.title && (
-          <MetaItem>◈ {workPackage._links.project.title}</MetaItem>
-        )}
+        <CardMeta workPackage={workPackage} withRelations />
       </CardDetailsSpaced>
       <WorkPackageTitle>{buildTitle(workPackage, linkTitle)}</WorkPackageTitle>
       {snippetText && (

--- a/lib/components/InlineWorkPackage/InlineChips.tsx
+++ b/lib/components/InlineWorkPackage/InlineChips.tsx
@@ -13,11 +13,11 @@ import {
   WorkPackageStatus,
   WorkPackageTitleLink,
   workPackageLinkProps,
+  WRAP_OPPORTUNITY,
 } from '../WorkPackage/atoms';
 import { formatWorkPackageId } from '../../utils/id';
 
 const resolvedDisplayId = (wp:WorkPackage) => wp.displayId ?? String(wp.id);
-const WRAP_OPPORTUNITY = '\u200B'; /*zero-width space*/
 
 const titleLinkProps = (wp:WorkPackage) => ({
   as: 'a' as const,

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -64,12 +64,13 @@ export const WorkPackageType = styled.span.attrs({
   font-weight: ${({ $compact }) => ($compact ? 600 : 500)};
   text-transform: uppercase;
   color: ${typeTextColor} !important;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 
   ${({ $compact }) =>
     $compact &&
     css`
       font-size: 12px;
+      white-space: nowrap;
     `}
 `;
 

--- a/lib/components/WorkPackage/atoms.tsx
+++ b/lib/components/WorkPackage/atoms.tsx
@@ -7,6 +7,9 @@ import {
 } from '../../services/colors';
 import { linkToWorkPackage } from '../../services/openProjectApi';
 
+/* lets a line break between two meta parts that are each kept unbroken  */
+export const WRAP_OPPORTUNITY = '\u200B';
+
 export const defaultWpVariables = css`
   --spacer-s: 4px;
   --spacer-m: 8px;
@@ -70,7 +73,6 @@ export const WorkPackageType = styled.span.attrs({
     $compact &&
     css`
       font-size: 12px;
-      white-space: nowrap;
     `}
 `;
 

--- a/test/lib/components/integration/blockCardMetaLine.browser.test.tsx
+++ b/test/lib/components/integration/blockCardMetaLine.browser.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page } from 'vitest/browser';
+import type { WorkPackage } from '../../../../lib/openProjectTypes';
+import { BlockCardL } from '../../../../lib/components/BlockWorkPackage/BlockCards';
+
+const cardWp:WorkPackage = {
+  id: 81,
+  displayId: '81',
+  subject: 'Fix login bug',
+  _links: {
+    self: { href: '/api/v3/work_packages/81' },
+    type: { title: 'BUG', href: '/api/v3/types/1' },
+    status: { title: 'In progress', href: '/api/v3/statuses/1' },
+    assignee: null,
+    parent: { title: 'Parent WP', href: '/api/v3/work_packages/1' },
+    project: { title: 'A project with a name long enough to need a line of its own', href: '/api/v3/projects/1' },
+  },
+};
+
+function renderCard(workPackage:WorkPackage = cardWp) {
+  render(
+    <div data-testid="card-host" style={{ width: 260 }}>
+      <BlockCardL workPackage={workPackage} linkTitle />
+    </div>,
+  );
+}
+
+describe('Block card - meta line', () => {
+  it('keeps the relation marker on the line of the label it marks', async () => {
+    renderCard();
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    const metaItems = page.getByTestId('block-card').element().querySelectorAll('.op-bn-work-package--details > span:not([class*="op-bn-work-package--"])');
+    const [parent, project] = Array.from(metaItems).slice(-2);
+
+    expect(parent.textContent).toBe('↑\u00A0Parent WP');
+    expect(project.textContent).toBe(`◈\u00A0${cardWp._links!.project!.title}`);
+  });
+
+  it('wraps a long relation title instead of overflowing the card', async () => {
+    renderCard();
+
+    await expect.element(page.getByTestId('block-card')).toBeVisible();
+
+    const card = page.getByTestId('block-card').element();
+    const details = card.querySelector('.op-bn-work-package--details')!;
+
+    expect(details.scrollWidth).toBeLessThanOrEqual(details.clientWidth);
+    expect(card.getBoundingClientRect().right)
+      .toBeLessThanOrEqual(page.getByTestId('card-host').element().getBoundingClientRect().right);
+  });
+});

--- a/test/lib/components/integration/inlineWorkPackageMetaWrap.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageMetaWrap.browser.test.tsx
@@ -5,11 +5,11 @@ import { WpChipXS, WpChipS } from '../../../../lib/components/InlineWorkPackage/
 import { mockWorkPackage } from '../../../mocks/handlers';
 
 // Container narrow enough that the meta cluster (#ID TYPE [STATUS]) cannot sit on a single
-// line, but wide enough for the widest single part. Each part is `white-space: nowrap`, so the
-// only way to avoid horizontal overflow is to wrap *between* parts. Before the fix the parts
-// had no soft-wrap opportunity between them and the cluster overflowed; now a zero-width space
-// between parts lets it wrap. The S chip has the extra (wide) status pill, so it needs more
-// room for its widest single part than the XS chip does.
+// line, but wide enough for the widest single part. The ID and the status pill are
+// `white-space: nowrap`, so the only way to avoid horizontal overflow is to wrap *between*
+// parts. Before the fix the parts had no soft-wrap opportunity between them and the cluster
+// overflowed; now a zero-width space between parts lets it wrap. The S chip has the extra
+// (wide) status pill, so it needs more room for its widest single part than the XS chip does.
 const S_NARROW_WIDTH = '110px';
 const XS_NARROW_WIDTH = '80px';
 
@@ -48,5 +48,42 @@ describe('InlineChips - wrap between meta parts', () => {
 
     const wrapperElement = await wrapperLocator.element();
     expect(wrapperElement.scrollWidth).toBeLessThanOrEqual(wrapperElement.clientWidth);
+  });
+
+  const renderWithType = (typeTitle:string) => {
+    const wp = {
+      ...mockWorkPackage,
+      _links: { ...mockWorkPackage._links, type: { ...mockWorkPackage._links.type, title: typeTitle } },
+    };
+
+    render(
+      <div data-testid="narrow-wrapper" style={{ width: '320px' }}>
+        <WpChipS wp={wp} />
+      </div>
+    );
+    return page.getByTestId('narrow-wrapper');
+  };
+
+  it('WpChipS wraps a type that is wider than the container', async () => {
+    const typeTitle = 'TYPE WITH EXCEPTIONALLY LONG NAME TO MATCH WHAT CECILE HAS ON THE QA INSTANCE';
+    const wrapperLocator = renderWithType(typeTitle);
+
+    await expect.element(wrapperLocator).toBeVisible();
+    await expect.element(page.getByText(typeTitle)).toBeVisible();
+
+    const wrapperElement = await wrapperLocator.element();
+    expect(wrapperElement.scrollWidth).toBeLessThanOrEqual(wrapperElement.clientWidth);
+  });
+
+  it('WpChipS breaks a type that is a single word wider than the container', async () => {
+    const typeTitle = 'VERYVERYVERYVERYVERYVERYVERYVERYVERYVERYVERYVERYLONGTYPE';
+    const wrapperLocator = renderWithType(typeTitle);
+
+    await expect.element(wrapperLocator).toBeVisible();
+    await expect.element(page.getByText(typeTitle)).toBeVisible();
+
+    const wrapperElement = await wrapperLocator.element();
+    const chipPadding = 2 * 6;
+    expect(wrapperElement.scrollWidth - wrapperElement.clientWidth).toBeLessThanOrEqual(chipPadding);
   });
 });

--- a/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
@@ -39,9 +39,9 @@ const previewWp:WorkPackage = {
   },
 };
 
-// Renders the preview against a fixed anchor so the flip behaviour can be
-// asserted for anchors near the viewport edges.
-function FlipHarness({ anchorTop }:{ anchorTop:number }) {
+// Renders the preview against a fixed anchor so placement and layout can be
+// asserted without going through the editor.
+function PreviewHarness({ anchorTop, workPackage = previewWp }:{ anchorTop:number; workPackage?:WorkPackage }) {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   return (
     <div>
@@ -54,7 +54,7 @@ function FlipHarness({ anchorTop }:{ anchorTop:number }) {
       </span>
       {anchor && (
         <WpPreviewPopover anchorEl={anchor}>
-          <BlockCard workPackage={previewWp} size="m" linkTitle />
+          <BlockCard workPackage={workPackage} size="m" linkTitle />
         </WpPreviewPopover>
       )}
     </div>
@@ -230,7 +230,7 @@ describe('Inline chip - XXS long-press preview (touch)', () => {
 
 describe('Preview popover - placement', () => {
   it('opens below the anchor when there is space', async () => {
-    render(<FlipHarness anchorTop={50} />);
+    render(<PreviewHarness anchorTop={50} />);
 
     await expect.element(page.getByTestId('wp-preview')).toBeVisible();
 
@@ -240,7 +240,7 @@ describe('Preview popover - placement', () => {
   });
 
   it('flips above the anchor near the bottom of the viewport', async () => {
-    render(<FlipHarness anchorTop={window.innerHeight - 30} />);
+    render(<PreviewHarness anchorTop={window.innerHeight - 30} />);
 
     await expect.element(page.getByTestId('wp-preview')).toBeVisible();
 
@@ -248,5 +248,27 @@ describe('Preview popover - placement', () => {
     const previewRect = page.getByTestId('wp-preview').element().getBoundingClientRect();
     expect(previewRect.bottom).toBeLessThanOrEqual(anchorRect.top);
     expect(previewRect.top).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('Preview popover - long work package type', () => {
+  const longType = 'CECILE CONFIGURATION FORM TEST TYPE AND SOME MORE WORDS SO THE TYPE GETS LONG';
+  const longTypeWp:WorkPackage = {
+    ...previewWp,
+    _links: { ...previewWp._links, type: { title: longType, href: '/api/v3/types/1' } },
+  };
+
+  it('wraps a long type instead of overflowing the preview', async () => {
+    render(<PreviewHarness anchorTop={50} workPackage={longTypeWp} />);
+
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+    // Shown in full: the type wraps onto more lines, it is never truncated.
+    await expect.element(page.getByText(longType)).toBeVisible();
+
+    const previewElement = page.getByTestId('wp-preview').element();
+    const typeRect = page.getByTestId('op-bn-work-package--type').element().getBoundingClientRect();
+    expect(typeRect.right).toBeLessThanOrEqual(previewElement.getBoundingClientRect().right);
+    // scrollWidth > clientWidth means content sticks out to the right of the preview.
+    expect(previewElement.scrollWidth).toBeLessThanOrEqual(previewElement.clientWidth);
   });
 });

--- a/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackagePreview.browser.test.tsx
@@ -255,7 +255,7 @@ describe('Preview popover - long work package type', () => {
   const longType = 'CECILE CONFIGURATION FORM TEST TYPE AND SOME MORE WORDS SO THE TYPE GETS LONG';
   const longTypeWp:WorkPackage = {
     ...previewWp,
-    _links: { ...previewWp._links, type: { title: longType, href: '/api/v3/types/1' } },
+    _links: { ...previewWp._links!, type: { title: longType, href: '/api/v3/types/1' } },
   };
 
   it('wraps a long type instead of overflowing the preview', async () => {
@@ -270,5 +270,18 @@ describe('Preview popover - long work package type', () => {
     expect(typeRect.right).toBeLessThanOrEqual(previewElement.getBoundingClientRect().right);
     // scrollWidth > clientWidth means content sticks out to the right of the preview.
     expect(previewElement.scrollWidth).toBeLessThanOrEqual(previewElement.clientWidth);
+  });
+
+  it('continues the meta line after a wrapped type instead of breaking to a new one', async () => {
+    render(<PreviewHarness anchorTop={50} workPackage={longTypeWp} />);
+
+    await expect.element(page.getByTestId('wp-preview')).toBeVisible();
+
+    const previewElement = page.getByTestId('wp-preview').element();
+    const typeRect = page.getByTestId('op-bn-work-package--type').element().getBoundingClientRect();
+    const idRect = previewElement.querySelector('.op-bn-work-package--id')!.getBoundingClientRect();
+
+    expect(idRect.top).toBeLessThan(typeRect.bottom);
+    expect(idRect.left).toBeGreaterThan(typeRect.left);
   });
 });

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -8,6 +8,7 @@ export const mockWorkPackage = {
     self:   { href: '/api/v3/work_packages/123' },
     type:   { title: 'Bug',         href: '/api/v3/types/1'    },
     status: { title: 'In Progress', href: '/api/v3/statuses/1' },
+    assignee: null,
   },
 };
 
@@ -19,6 +20,7 @@ export const mockWorkPackage2 = {
     self:   { href: '/api/v3/work_packages/456' },
     type:   { title: 'Feature', href: '/api/v3/types/2' },
     status: { title: 'Open',    href: '/api/v3/statuses/2' },
+    assignee: null,
   },
 };
 
@@ -30,6 +32,7 @@ export const mockWorkPackageWithSemanticId = {
     self:   { href: '/api/v3/work_packages/789' },
     type:   { title: 'Feature', href: '/api/v3/types/2' },
     status: { title: 'Open',    href: '/api/v3/statuses/2' },
+    assignee: null,
   },
 };
 
@@ -41,6 +44,7 @@ export const mockCreatedWorkPackage = {
     self:   { href: '/api/v3/work_packages/999' },
     type:   { title: 'Task', href: '/api/v3/types/1'    },
     status: { title: 'New',  href: '/api/v3/statuses/1' },
+    assignee: null,
   },
 };
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-124

# What are you trying to accomplish?
A work package with a long type name overflowed the hover preview: the type ran past the right edge of the popover instead of staying inside it.

## Screenshots
<img width="631" height="359" alt="image" src="https://github.com/user-attachments/assets/133cb125-9009-4a19-b17a-9a45a15884ce" />

# What approach did you choose and why?
`nowrap` now applies only to the compact (inline chip) variant, which is the context that actually needs it: there the meta parts are kept unbroken and the chip wraps *between* them via the zero-width spaces introduced earlier. The card variant - the only other consumer, used by the preview, the search dropdown and the block cards - instead gets `overflow-wrap: anywhere`, so a long type wraps onto another line and stays fully readable.

Considered truncating with an ellipsis instead, but the type is one of the three identifying attributes of the card; hiding part of it to save a line is a worse trade than wrapping, and the ticket asks for no overflow rather than for a fixed height.

`overflow-wrap: anywhere` is no new browser-support baseline here: `WorkPackageTitle` and `WorkPackageTitleLink` already rely on it for long subjects.

Not addressed on purpose: `WorkPackageStatus` has the same unconditional `nowrap` and can overflow the same way with a very long status name. Wrapping a rounded pill across two lines looks broken, so that needs a design decision of its own rather than being quietly folded into this fix.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
