### PR TITLE
[BNE-104] Documents: two wps highlighted at once in wp dropdown

### DIFF
--- a/lib/components/HashMenu/HashWpMenu.tsx
+++ b/lib/components/HashMenu/HashWpMenu.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react';
 import type { FC, RefObject } from 'react';
 import type { SuggestionMenuProps } from '@blocknote/react';
 import styled from 'styled-components';
@@ -5,6 +6,7 @@ import { BlockCard } from '../BlockWorkPackage/BlockCard';
 import { defaultWpVariables } from '../WorkPackage/atoms';
 import { SearchMessage } from '../Search/SearchContainer';
 import { Spinner } from '../Spinner';
+import { supportsHover } from '../../utils/device';
 import type { HashMenuItem, HashSearchState } from './types';
 import { useTranslation } from 'react-i18next';
 
@@ -34,16 +36,12 @@ const Menu = styled.div.attrs({ className: 'op-bn-hash-menu' })`
   min-height: 0;
 `;
 
-const MenuItem = styled.div<{ $selected:boolean }>`
+const MenuItem = styled.div.attrs({ className: 'op-bn-hash-menu-item' })<{ $highlighted:boolean }>`
   border-radius: var(--bn-border-radius-small);
-  background: ${({ $selected }) =>
-    $selected ? 'var(--op-item-hover-bg)' : 'transparent'};
+  background: ${({ $highlighted }) =>
+    $highlighted ? 'var(--op-item-hover-bg)' : 'transparent'};
   cursor: pointer;
   padding: 0 var(--spacer-s);
-
-  &:hover {
-    background: var(--op-item-hover-bg);
-  }
 `;
 
 const MAX_RESULTS = 5;
@@ -60,6 +58,15 @@ export function createHashWpMenuComponent(
     const { t } = useTranslation();
     const { query, results, error } = searchStateRef.current;
     const visibleResults = results.slice(0, MAX_RESULTS);
+
+    const canHover = useMemo(() => supportsHover(), []);
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+    useEffect(() => {
+      setHoveredIndex(null);
+    }, [selectedIndex, items]);
+
+    const highlightedIndex = hoveredIndex ?? selectedIndex;
 
     if (loadingState !== 'loaded') {
       return (
@@ -89,15 +96,15 @@ export function createHashWpMenuComponent(
     }
 
     return (
-      <Menu>
+      <Menu onMouseLeave={canHover ? () => setHoveredIndex(null) : undefined}>
         {visibleResults.map((wp, index) => (
           <MenuItem
             key={wp.id}
-            $selected={selectedIndex === index}
-            // Mouse path: e.preventDefault() prevents the editor from losing focus.
-            // This allows us to safely insert the chip without needing TipTap to restore the cursor.
-            onMouseDown={(e) => {
-              e.preventDefault();
+            $highlighted={highlightedIndex === index}
+            onMouseMove={canHover ? () => setHoveredIndex(index) : undefined}
+            role="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
               if (items[index]) onItemClick?.(items[index]);
             }}
           >

--- a/test/lib/components/integration/hashMenuHighlight.browser.test.tsx
+++ b/test/lib/components/integration/hashMenuHighlight.browser.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { renderEditor } from '../../../helpers/renderEditor';
+import { openEditorAndType } from '../../../helpers/editorHelpers';
+
+const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+async function openHashMenu() {
+  renderEditor();
+  await openEditorAndType('#Fix');
+  await expect.element(page.getByText('Add dark mode')).toBeVisible();
+  return Array.from(document.querySelectorAll('.op-bn-hash-menu-item'));
+}
+
+function highlightedRows(rows:Element[]) {
+  return rows
+    .map((row, index) => ({ index, background: getComputedStyle(row).backgroundColor }))
+    .filter(({ background }) => background !== TRANSPARENT)
+    .map(({ index }) => index);
+}
+
+describe('Hash menu - row highlighting', () => {
+  it('highlights the first row while nothing else has been pointed at', async () => {
+    const rows = await openHashMenu();
+
+    expect(highlightedRows(rows)).toEqual([0]);
+  });
+
+  it('hands the single highlight to the row under the pointer', async () => {
+    const rows = await openHashMenu();
+
+    await userEvent.hover(page.getByText('Semantic ID work package'));
+
+    expect(highlightedRows(rows)).toEqual([2]);
+  });
+
+  it('gives the highlight back to the keyboard selection', async () => {
+    const rows = await openHashMenu();
+    await userEvent.hover(page.getByText('Semantic ID work package'));
+    expect(highlightedRows(rows)).toEqual([2]);
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(highlightedRows(rows)).toEqual([1]);
+  });
+
+  it('inserts the work package the pointer is on from the click alone', async () => {
+    const rows = await openHashMenu();
+
+    rows[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await expect.element(page.getByText('#456')).toBeVisible();
+  });
+});
+
+describe('Hash menu - row highlighting without a hovering pointer', () => {
+  const realMatchMedia = window.matchMedia.bind(window);
+
+  afterEach(() => {
+    window.matchMedia = realMatchMedia;
+  });
+
+  function reportTouchScreen() {
+    window.matchMedia = (query:string) => (
+      query.includes('hover')
+        ? { ...realMatchMedia(query), matches: query.includes('hover: none') }
+        : realMatchMedia(query)
+    );
+  }
+
+  it('keeps the highlight on the selected row when the pointer cannot hover', async () => {
+    reportTouchScreen();
+    const rows = await openHashMenu();
+
+    await userEvent.hover(page.getByText('Semantic ID work package'));
+
+    expect(highlightedRows(rows)).toEqual([0]);
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/BNE-104
# What are you trying to accomplish?
The `#` work package menu highlighted two rows at once: the row BlockNote had selected and the row the pointer was on. The ticket reports it on iOS, but it happens on the desktop just as much - a hovered row and the selected row were painted identically, so a mouse user saw two highlights too.

On a touch screen the same hover rule also cost a second tap: iOS withholds the click of a tap that only changed hover styling, so the first tap did nothing but leave the hover stuck on the tapped row.

Now a single row is highlighted at any time, and one tap inserts the work package.

# What approach did you choose and why?
The highlight has one source now - the pointer or BlockNote's keyboard selection, whichever was used last - and the `:hover` rule is gone.

Keeping `:hover` and hiding the selected row while the menu is hovered (`:has`) would have been smaller, but the highlight would then lie about what Enter does: BlockNote owns `selectedIndex` and exposes no setter, so a pointer resting on the menu while typing would highlight a row Enter does not insert. Driving the highlight from state lets it reset on every keyboard move and every new result set, which keeps it honest.

Gating `:hover` behind `@media (hover: hover)` was the other option, but it only covers the touch half of the report.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
