### PR TITLE
[BNE-124] Address review follow-up for #221

### DIFF
--- a/test/lib/components/integration/blockCardMetaLine.browser.test.tsx
+++ b/test/lib/components/integration/blockCardMetaLine.browser.test.tsx
@@ -1,10 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page } from 'vitest/browser';
-import type { WorkPackage } from '../../../../lib/openProjectTypes';
 import { BlockCardL } from '../../../../lib/components/BlockWorkPackage/BlockCards';
 
-const cardWp:WorkPackage = {
+const cardWp = {
   id: 81,
   displayId: '81',
   subject: 'Fix login bug',
@@ -12,16 +11,15 @@ const cardWp:WorkPackage = {
     self: { href: '/api/v3/work_packages/81' },
     type: { title: 'BUG', href: '/api/v3/types/1' },
     status: { title: 'In progress', href: '/api/v3/statuses/1' },
-    assignee: null,
     parent: { title: 'Parent WP', href: '/api/v3/work_packages/1' },
     project: { title: 'A project with a name long enough to need a line of its own', href: '/api/v3/projects/1' },
   },
 };
 
-function renderCard(workPackage:WorkPackage = cardWp) {
+function renderCard() {
   render(
     <div data-testid="card-host" style={{ width: 260 }}>
-      <BlockCardL workPackage={workPackage} linkTitle />
+      <BlockCardL workPackage={cardWp} linkTitle />
     </div>,
   );
 }
@@ -36,7 +34,7 @@ describe('Block card - meta line', () => {
     const [parent, project] = Array.from(metaItems).slice(-2);
 
     expect(parent.textContent).toBe('↑\u00A0Parent WP');
-    expect(project.textContent).toBe(`◈\u00A0${cardWp._links!.project!.title}`);
+    expect(project.textContent).toBe(`◈\u00A0${cardWp._links.project.title}`);
   });
 
   it('wraps a long relation title instead of overflowing the card', async () => {

--- a/test/lib/components/integration/inlineWorkPackageMetaWrap.browser.test.tsx
+++ b/test/lib/components/integration/inlineWorkPackageMetaWrap.browser.test.tsx
@@ -6,9 +6,8 @@ import { mockWorkPackage } from '../../../mocks/handlers';
 
 // Container narrow enough that the meta cluster (#ID TYPE [STATUS]) cannot sit on a single
 // line, but wide enough for the widest single part. The ID and the status pill are
-// `white-space: nowrap`, so the only way to avoid horizontal overflow is to wrap *between*
-// parts. Before the fix the parts had no soft-wrap opportunity between them and the cluster
-// overflowed; now a zero-width space between parts lets it wrap. The S chip has the extra
+// `white-space: nowrap`, so the cluster can only stay inside the container by wrapping
+// *between* parts, at the zero-width space that separates them. The S chip has the extra
 // (wide) status pill, so it needs more room for its widest single part than the XS chip does.
 const S_NARROW_WIDTH = '110px';
 const XS_NARROW_WIDTH = '80px';

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -8,7 +8,6 @@ export const mockWorkPackage = {
     self:   { href: '/api/v3/work_packages/123' },
     type:   { title: 'Bug',         href: '/api/v3/types/1'    },
     status: { title: 'In Progress', href: '/api/v3/statuses/1' },
-    assignee: null,
   },
 };
 
@@ -20,7 +19,6 @@ export const mockWorkPackage2 = {
     self:   { href: '/api/v3/work_packages/456' },
     type:   { title: 'Feature', href: '/api/v3/types/2' },
     status: { title: 'Open',    href: '/api/v3/statuses/2' },
-    assignee: null,
   },
 };
 
@@ -32,7 +30,6 @@ export const mockWorkPackageWithSemanticId = {
     self:   { href: '/api/v3/work_packages/789' },
     type:   { title: 'Feature', href: '/api/v3/types/2' },
     status: { title: 'Open',    href: '/api/v3/statuses/2' },
-    assignee: null,
   },
 };
 
@@ -44,7 +41,6 @@ export const mockCreatedWorkPackage = {
     self:   { href: '/api/v3/work_packages/999' },
     type:   { title: 'Task', href: '/api/v3/types/1'    },
     status: { title: 'New',  href: '/api/v3/statuses/1' },
-    assignee: null,
   },
 };
 


### PR DESCRIPTION
Judith's review remarks on #221 arrived after that PR had already been merged, so they come separately instead of as another commit on the merged branch.

Two remarks, both in the tests: the `assignee` link was only added to silence pre-existing TypeScript errors in the fixtures and has nothing to do with this change, and the wrap comment described a before / after state instead of the
current one.
