### PR TITLE
[BNE-124] Add the assignee link to the work package test fixtures

### DIFF
--- a/test/lib/components/integration/blockCardMetaLine.browser.test.tsx
+++ b/test/lib/components/integration/blockCardMetaLine.browser.test.tsx
@@ -11,6 +11,7 @@ const cardWp = {
     self: { href: '/api/v3/work_packages/81' },
     type: { title: 'BUG', href: '/api/v3/types/1' },
     status: { title: 'In progress', href: '/api/v3/statuses/1' },
+    assignee: null,
     parent: { title: 'Parent WP', href: '/api/v3/work_packages/1' },
     project: { title: 'A project with a name long enough to need a line of its own', href: '/api/v3/projects/1' },
   },

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -8,6 +8,7 @@ export const mockWorkPackage = {
     self:   { href: '/api/v3/work_packages/123' },
     type:   { title: 'Bug',         href: '/api/v3/types/1'    },
     status: { title: 'In Progress', href: '/api/v3/statuses/1' },
+    assignee: null,
   },
 };
 
@@ -19,6 +20,7 @@ export const mockWorkPackage2 = {
     self:   { href: '/api/v3/work_packages/456' },
     type:   { title: 'Feature', href: '/api/v3/types/2' },
     status: { title: 'Open',    href: '/api/v3/statuses/2' },
+    assignee: null,
   },
 };
 
@@ -30,6 +32,7 @@ export const mockWorkPackageWithSemanticId = {
     self:   { href: '/api/v3/work_packages/789' },
     type:   { title: 'Feature', href: '/api/v3/types/2' },
     status: { title: 'Open',    href: '/api/v3/statuses/2' },
+    assignee: null,
   },
 };
 
@@ -41,6 +44,7 @@ export const mockCreatedWorkPackage = {
     self:   { href: '/api/v3/work_packages/999' },
     type:   { title: 'Task', href: '/api/v3/types/1'    },
     status: { title: 'New',  href: '/api/v3/statuses/1' },
+    assignee: null,
   },
 };
 


### PR DESCRIPTION
Follow-up to the review discussion in #221: `_links.assignee` is required in `openProjectTypes.ts` while `parent` and `project` are optional, so every test fixture built from these mocks shows up as a type error in the IDE.