### PR TITLE
[COMMS-870] Paragraph in Firefox document is infinite in width

### DIFF
--- a/lib/components/ShadowDomWrapper.tsx
+++ b/lib/components/ShadowDomWrapper.tsx
@@ -1,12 +1,21 @@
 import type { PropsWithChildren } from 'react';
-import { StyleSheetManager } from 'styled-components';
+import { createGlobalStyle, StyleSheetManager } from 'styled-components';
 
 interface ShadowDomWrapperProps {
   target:ShadowRoot | HTMLElement;
 }
 
+const ProseMirrorBaseStyles = createGlobalStyle`
+  .ProseMirror {
+    overflow-wrap: break-word;
+  }
+`;
+
 export const ShadowDomWrapper = ({ children, target }:PropsWithChildren<ShadowDomWrapperProps>) => (
   <StyleSheetManager target={target}>
-    {children}
+    <>
+      <ProseMirrorBaseStyles />
+      {children}
+    </>
   </StyleSheetManager>
 );

--- a/test/helpers/renderEditor.tsx
+++ b/test/helpers/renderEditor.tsx
@@ -3,16 +3,20 @@ import { BlockNoteView } from '@blocknote/mantine';
 import { useCreateBlockNote, SuggestionMenuController, getDefaultReactSlashMenuItems } from '@blocknote/react';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
 import { useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { onTestFinished } from 'vitest';
 import { render } from 'vitest-browser-react';
 import {
   openProjectWorkPackageBlockSpec,
   openProjectWorkPackageInlineSpec,
   getOpenProjectSlashMenuItems,
   useHashWpMenu,
+  ShadowDomWrapper,
 } from '../../lib';
 
 import '@blocknote/core/fonts/inter.css';
 import '@blocknote/mantine/style.css';
+import mantineStylesUrl from '@blocknote/mantine/style.css?url';
 
 const defaultSchema = BlockNoteSchema.create().extend({
   blockSpecs: {
@@ -57,4 +61,34 @@ function Editor({ onEditor, schema }:{ onEditor?:(editor:any) => void; schema?:a
 
 export function renderEditor(opts?:{ onEditor?:(editor:any) => void; schema?:any }) {
   return render(<Editor onEditor={opts?.onEditor} schema={opts?.schema} />);
+}
+
+export async function renderEditorInShadowDom(opts?:{ onEditor?:(editor:any) => void; schema?:any }) {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  onTestFinished(() => host.remove());
+
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const mount = document.createElement('div');
+  shadowRoot.appendChild(mount);
+
+  await new Promise<void>((resolve, reject) => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = mantineStylesUrl;
+    link.onload = () => resolve();
+    link.onerror = () => reject(new Error('Failed to load BlockNote styles into the shadow root'));
+    shadowRoot.appendChild(link);
+  });
+
+  const renderResult = await render(
+    createPortal(
+      <ShadowDomWrapper target={mount}>
+        <Editor onEditor={opts?.onEditor} schema={opts?.schema} />
+      </ShadowDomWrapper>,
+      mount
+    )
+  );
+
+  return { renderResult, shadowRoot };
 }

--- a/test/lib/components/integration/shadowDomTextWrap.browser.test.tsx
+++ b/test/lib/components/integration/shadowDomTextWrap.browser.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderEditorInShadowDom } from '../../../helpers/renderEditor';
+
+const unbreakableWord = 'q'.repeat(300);
+
+const proseMirrorWrapRules = (shadowRoot:ShadowRoot) => Array.from(shadowRoot.styleSheets)
+  .flatMap((styleSheet) => Array.from(styleSheet.cssRules))
+  .filter((rule):rule is CSSStyleRule => rule instanceof CSSStyleRule)
+  .filter((rule) => rule.selectorText === '.ProseMirror');
+
+describe('paragraph text wrapping inside a shadow root', () => {
+  it('wraps an unbreakable word instead of growing the paragraph past the editor', async () => {
+    let editor:any;
+    const { shadowRoot } = await renderEditorInShadowDom({ onEditor: (createdEditor) => { editor = createdEditor; } });
+
+    const editorLocator = page.getByRole('textbox');
+    await expect.element(editorLocator).toBeVisible();
+
+    editor.replaceBlocks(editor.document, [{ type: 'paragraph', content: unbreakableWord }]);
+    await expect.element(page.getByText(unbreakableWord)).toBeVisible();
+
+    const paragraph = shadowRoot.querySelector('.bn-inline-content')!;
+
+    expect(paragraph.scrollWidth).toBeLessThanOrEqual(paragraph.clientWidth);
+  });
+
+  it('puts the ProseMirror wrap rule into the shadow root', async () => {
+    const { shadowRoot } = await renderEditorInShadowDom();
+
+    await expect.element(page.getByRole('textbox')).toBeVisible();
+
+    expect(proseMirrorWrapRules(shadowRoot).some((rule) => rule.style.overflowWrap === 'break-word')).toBe(true);
+  });
+});


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/COMMS-870

# What are you trying to accomplish?
Text in a document paragraph never wrapped in Firefox: a long word kept running past the editor width instead of breaking onto the next line. Chrome and Safari were unaffected.

Root cause: tiptap ships the ProseMirror base styles at runtime, and its `createStyleTag` appends them to `document.head` unconditionally. Our editor renders inside the `<op-block-note>` shadow root, which document styles never reach, so `.ProseMirror { word-wrap: break-word }` never applied to it. Chromium and WebKit hide this, because they compute `overflow-wrap: break-word` on a `contenteditable` from their UA stylesheet even with no author rule; Firefox computes `normal`, so an unbreakable word has nowhere to break.

The paragraph box itself stays at editor width - it is the text line inside it that overflows (measured in Firefox: `scrollWidth` 2810 vs `clientWidth` 306).

## Screenshots

# What approach did you choose and why?
Restated the one missing declaration under tiptap's own selector and injected it into the shadow root through `createGlobalStyle` inside the `StyleSheetManager` that `ShadowDomWrapper` already sets up, so it lands in the same target as the rest of our styles. No timing assumptions, no browser sniffing.

Alternatives considered:

- Mirroring tiptap's own `<style>` nodes into the shadow root. Restores everything the shadow root is missing, not just the wrap rule, but it depends on the undocumented `data-tiptap-style` attribute and needs a `MutationObserver`: tiptap only injects when an editor is constructed, which here happens after the loading skeleton, i.e. after this wrapper's mount effects. Too much machinery for one rule.
- The same one-liner in OpenProject's own sass, since `styles.css` is linked into the shadow root. Equivalent visually, but it would only fix OpenProject, and our Chrome-only CI could never guard it.

Putting it in op-blocknote-extensions fixes every `ShadowDomWrapper` consumer and is testable.

I consider this a sound temporary fix rather than a workaround we will have to untangle: it is an upstream rule restated under the upstream selector, so once tiptap injects into the editor's root node (or BlockNote ships the base CSS in its own bundle), this simply becomes a harmless duplicate.

**If that reasoning is OK with you, I will open an issue in tiptap.** The existing request (ueberdosis/tiptap#2066) was closed by the stale bot and then withdrawn by its author, because contenteditable inside a shadow root was not reliably supported at the time - which no longer holds.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
